### PR TITLE
Support for additional S3 providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ S3_UPLOAD_BUCKET=name-of-s3-bucket
 S3_UPLOAD_REGION=us-east-1
 ```
 
+You can also use other S3 providers by providing a custom endpoint:
+
+```.env
+S3_UPLOAD_ENDPOINT=http://localhost:9000
+```
+
 ## License
 
 MIT, see [LICENSE](./LICENSE).

--- a/next.config.js
+++ b/next.config.js
@@ -1,14 +1,27 @@
+/** 
+ * Undefined entries are not supported. Push optional patterns to this array only if defined.
+ * @type {import('next/dist/shared/lib/image-config').RemotePattern}
+ */
+const remotePatterns = []
+
+// S3 Storage
+if (process.env.S3_UPLOAD_ENDPOINT) {
+  // custom endpoint for providers other than AWS
+  const url = new URL(process.env.S3_UPLOAD_ENDPOINT);
+  remotePatterns.push({
+    hostname: url.hostname,
+  })
+} else if (process.env.S3_UPLOAD_BUCKET && process.env.S3_UPLOAD_REGION) {
+  // default provider
+  remotePatterns.push({
+    hostname: `${process.env.S3_UPLOAD_BUCKET}.s3.${process.env.S3_UPLOAD_REGION}.amazonaws.com`,
+  })
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    remotePatterns:
-      process.env.S3_UPLOAD_BUCKET && process.env.S3_UPLOAD_REGION
-        ? [
-            {
-              hostname: `${process.env.S3_UPLOAD_BUCKET}.s3.${process.env.S3_UPLOAD_REGION}.amazonaws.com`,
-            },
-          ]
-        : [],
+    remotePatterns
   },
 }
 

--- a/src/app/api/s3-upload/route.ts
+++ b/src/app/api/s3-upload/route.ts
@@ -1,11 +1,12 @@
 import { sanitizeKey } from 'next-s3-upload'
 import { POST as route } from 'next-s3-upload/route'
+import { env } from '@/lib/env'
 
 export const POST = route.configure({
   key(req, filename) {
     return sanitizeKey(filename).toLowerCase()
   },
-  endpoint: process.env.S3_UPLOAD_ENDPOINT,
+  endpoint: env.S3_UPLOAD_ENDPOINT,
   // forcing path style is only necessary for providers other than AWS
-  forcePathStyle: !!process.env.S3_UPLOAD_ENDPOINT,
+  forcePathStyle: !!env.S3_UPLOAD_ENDPOINT,
 })

--- a/src/app/api/s3-upload/route.ts
+++ b/src/app/api/s3-upload/route.ts
@@ -5,4 +5,11 @@ export const POST = route.configure({
   key(req, filename) {
     return sanitizeKey(filename).toLowerCase()
   },
+  accessKeyId: process.env.S3_UPLOAD_KEY,
+  secretAccessKey: process.env.S3_UPLOAD_SECRET,
+  bucket: process.env.S3_UPLOAD_BUCKET,
+  region: process.env.S3_UPLOAD_REGION,
+  endpoint: process.env.S3_UPLOAD_ENDPOINT,
+  // forcing path style is only necessary for providers other than AWS
+  forcePathStyle: !!process.env.S3_UPLOAD_ENDPOINT,
 })

--- a/src/app/api/s3-upload/route.ts
+++ b/src/app/api/s3-upload/route.ts
@@ -1,6 +1,6 @@
 import { randomId } from '@/lib/api'
-import { POST as route } from 'next-s3-upload/route'
 import { env } from '@/lib/env'
+import { POST as route } from 'next-s3-upload/route'
 
 export const POST = route.configure({
   key(req, filename) {

--- a/src/app/api/s3-upload/route.ts
+++ b/src/app/api/s3-upload/route.ts
@@ -5,10 +5,6 @@ export const POST = route.configure({
   key(req, filename) {
     return sanitizeKey(filename).toLowerCase()
   },
-  accessKeyId: process.env.S3_UPLOAD_KEY,
-  secretAccessKey: process.env.S3_UPLOAD_SECRET,
-  bucket: process.env.S3_UPLOAD_BUCKET,
-  region: process.env.S3_UPLOAD_REGION,
   endpoint: process.env.S3_UPLOAD_ENDPOINT,
   // forcing path style is only necessary for providers other than AWS
   forcePathStyle: !!process.env.S3_UPLOAD_ENDPOINT,

--- a/src/components/expense-documents-input.tsx
+++ b/src/components/expense-documents-input.tsx
@@ -18,7 +18,7 @@ import { useToast } from '@/components/ui/use-toast'
 import { randomId } from '@/lib/api'
 import { ExpenseFormValues } from '@/lib/schemas'
 import { Loader2, Plus, Trash, X } from 'lucide-react'
-import { getImageData, useS3Upload } from 'next-s3-upload'
+import { getImageData, usePresignedUpload } from 'next-s3-upload'
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
 
@@ -29,7 +29,7 @@ type Props = {
 
 export function ExpenseDocumentsInput({ documents, updateDocuments }: Props) {
   const [pending, setPending] = useState(false)
-  const { FileInput, openFileDialog, uploadToS3 } = useS3Upload()
+  const { FileInput, openFileDialog, uploadToS3 } = usePresignedUpload() // use presigned uploads to addtionally support providers other than AWS
   const { toast } = useToast()
 
   const handleFileChange = async (file: File) => {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -17,10 +17,12 @@ const envSchema = z
     S3_UPLOAD_SECRET: z.string().optional(),
     S3_UPLOAD_BUCKET: z.string().optional(),
     S3_UPLOAD_REGION: z.string().optional(),
+    S3_UPLOAD_ENDPOINT: z.string().optional(),
   })
   .superRefine((env, ctx) => {
     if (
       env.NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS &&
+      // S3_UPLOAD_ENDPOINT is fully optional as it will only be used for providers other than AWS
       (!env.S3_UPLOAD_BUCKET ||
         !env.S3_UPLOAD_KEY ||
         !env.S3_UPLOAD_REGION ||


### PR DESCRIPTION
Adding support for additional S3 providers to avoid vendor lock-in and for a better self-hosting experience. See #65 

I successfully tested integration with a local instance of Minio. I have not tested these changes with a standard AWS S3 setup.