### PR TITLE
Update start_url to /groups page

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -6,7 +6,7 @@ export default function manifest(): MetadataRoute.Manifest {
     short_name: 'Spliit',
     description:
       'A minimalist web application to share expenses with friends and family. No ads, no account, no problem.',
-    start_url: '/',
+    start_url: '/groups',
     display: 'standalone',
     background_color: '#fff',
     theme_color: '#047857',


### PR DESCRIPTION
This way when you install the PWA it will open to the groups page each time you open it instead of the home page.

Thanks for all the hard work on this project!