### PR TITLE
Format currency with thousand separators

### DIFF
--- a/src/app/groups/[groupId]/balances-list.tsx
+++ b/src/app/groups/[groupId]/balances-list.tsx
@@ -1,5 +1,5 @@
 import { Balances } from '@/lib/balances'
-import { cn } from '@/lib/utils'
+import { cn, formatCurrency } from '@/lib/utils'
 import { Participant } from '@prisma/client'
 
 type Props = {
@@ -28,7 +28,7 @@ export function BalancesList({ balances, participants, currency }: Props) {
             </div>
             <div className={cn('w-1/2 relative', isLeft || 'text-right')}>
               <div className="absolute inset-0 p-2 z-20">
-                {currency} {(balance / 100).toFixed(2)}
+                {formatCurrency(currency, balance)}
               </div>
               {balance !== 0 && (
                 <div

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
@@ -26,7 +26,7 @@ import {
 import { ToastAction } from '@/components/ui/toast'
 import { useToast } from '@/components/ui/use-toast'
 import { useMediaQuery } from '@/lib/hooks'
-import { formatExpenseDate } from '@/lib/utils'
+import { formatCurrency, formatExpenseDate } from '@/lib/utils'
 import { Category } from '@prisma/client'
 import { ChevronRight, FileQuestion, Loader2, Receipt } from 'lucide-react'
 import { getImageData, useS3Upload } from 'next-s3-upload'
@@ -185,9 +185,7 @@ export function CreateFromReceiptButton({
               <div>
                 {receiptInfo ? (
                   receiptInfo.amount ? (
-                    <>
-                      {groupCurrency} {receiptInfo.amount.toFixed(2)}
-                    </>
+                    <>{formatCurrency(groupCurrency, receiptInfo.amount)}</>
                   ) : (
                     <Unknown />
                   )

--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -3,7 +3,7 @@ import { CategoryIcon } from '@/app/groups/[groupId]/expenses/category-icon'
 import { Button } from '@/components/ui/button'
 import { SearchBar } from '@/components/ui/search-bar'
 import { getGroupExpenses } from '@/lib/api'
-import { cn, formatExpenseDate } from '@/lib/utils'
+import { cn, formatCurrency, formatExpenseDate } from '@/lib/utils'
 import { Expense, Participant } from '@prisma/client'
 import dayjs, { type Dayjs } from 'dayjs'
 import { ChevronRight } from 'lucide-react'
@@ -156,7 +156,7 @@ export function ExpenseList({
                       expense.isReimbursement ? 'italic' : 'font-bold',
                     )}
                   >
-                    {currency} {(expense.amount / 100).toFixed(2)}
+                    {formatCurrency(currency, expense.amount)}
                   </div>
                   <div className="text-xs text-muted-foreground">
                     {formatExpenseDate(expense.expenseDate)}

--- a/src/app/groups/[groupId]/reimbursement-list.tsx
+++ b/src/app/groups/[groupId]/reimbursement-list.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { Reimbursement } from '@/lib/balances'
+import { formatCurrency } from '@/lib/utils'
 import { Participant } from '@prisma/client'
 import Link from 'next/link'
 
@@ -42,9 +43,7 @@ export function ReimbursementList({
               </Link>
             </Button>
           </div>
-          <div>
-            {currency} {(reimbursement.amount / 100).toFixed(2)}
-          </div>
+          <div>{formatCurrency(currency, reimbursement.amount)}</div>
         </div>
       ))}
     </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,3 +15,12 @@ export function formatExpenseDate(date: Date) {
     timeZone: 'UTC',
   })
 }
+
+export function formatCurrency(currency: string, amount: number) {
+  const format = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+  const formattedAmount = format.format(amount / 100)
+  return `${currency} ${formattedAmount}`
+}


### PR DESCRIPTION
Added a formatting function for currency strings, in order to be able to use (and change) the format everywhere at once, and alos to add thousand separators to the formats.

I chose to do this by using the `en-US` locale (which is also used for dates), and left it hard coded for now. But since I've seen issues about translations etc, I thought perhaps a group-wide locale setting would be implemented at some point, and this makes it somewhat easy to build upon.

This makes it easier to parse larger numbers especially in the list, but also in the balances overview. This is less needed for currencies like USD and EUR, but makes more sense for other currencies like (my use case) SEK, or something like JPY.