### PR TITLE
Fix decimal point issue in expense form schema `amount` field

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -51,7 +51,8 @@ export const expenseFormSchema = z
         [
           z.number(),
           z.string().transform((value, ctx) => {
-            const valueAsNumber = Number(value)
+            const normalizedValue = value.replace(/,/g, '.')
+            const valueAsNumber = Number(normalizedValue)
             if (Number.isNaN(valueAsNumber))
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,
@@ -75,7 +76,8 @@ export const expenseFormSchema = z
           shares: z.union([
             z.number(),
             z.string().transform((value, ctx) => {
-              const valueAsNumber = Number(value)
+              const normalizedValue = value.replace(/,/g, '.')
+              const valueAsNumber = Number(normalizedValue)
               if (Number.isNaN(valueAsNumber))
                 ctx.addIssue({
                   code: z.ZodIssueCode.custom,


### PR DESCRIPTION
### Problem

The `amount` input field in the "add expense" view uses the `decimal` inputMode. This renders a numbers-only keyboard that on some locales only allows the user to input a comma as the decimal point. However, the zod schema does not permit a comma as the decimal point, since `Number(value)` will return `NaN` for such numbers.

E.g. `Number("1.23") === 1.23`, but `Number("1,23") === NaN`.

### Solution

Replace commas with dots in the user-inputted amount value before casting it to a JS number. The rest of the schema validation will proceed as normal.

Fixes #78