### PR TITLE
Add onClick-event to select all to amount input

### DIFF
--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -222,6 +222,7 @@ export function ExpenseForm({
                         inputMode="decimal"
                         step={0.01}
                         placeholder="0.00"
+                        onFocus={(e) => e.currentTarget.select()}
                         {...field}
                       />
                     </FormControl>

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -222,7 +222,7 @@ export function ExpenseForm({
                         inputMode="decimal"
                         step={0.01}
                         placeholder="0.00"
-                        onFocus={(e) => e.currentTarget.select()}
+                        onClick={(e) => e.currentTarget.select()}
                         {...field}
                       />
                     </FormControl>


### PR DESCRIPTION
When you add a new expense you always have to start by removing the placeholder 0 value that is already there.

I added an onFocus event to select the entire value so that you can just start writing the amount immediately