### PR TITLE
Add a prettier script for ease of use (npm run prettier)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "check-types": "tsc --noEmit",
     "check-formatting": "prettier -c src",
+    "prettier": "prettier -w src",
     "postinstall": "prisma migrate deploy && prisma generate",
     "build-image": "./scripts/build-image.sh",
     "start-container": "docker compose --env-file container.env up"


### PR DESCRIPTION
I'm not sure if I have things installed incorrectly or something on my machine, but I can't seem to run prettier normally, so I added a script for it locally so that I can just run `npm run prettier` in order to fix formatting.

I thought I'd share, but feel free to shoot down this PR if this isn't something you want in the repo.