### PR TITLE
Add "x" button to cancel search in search bar

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -90,7 +90,7 @@ export function ExpenseList({
   const groupedExpensesByDate = getGroupedExpensesByDate(expenses)
   return expenses.length > 0 ? (
     <>
-      <SearchBar onChange={(e) => setSearchText(e.target.value)} />
+      <SearchBar onValueChange={(value) => setSearchText(value)} />
       {Object.values(EXPENSE_GROUPS).map((expenseGroup: string) => {
         let groupExpenses = groupedExpensesByDate[expenseGroup]
         if (!groupExpenses) return null

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -1,33 +1,49 @@
-import * as React from "react"
+import * as React from 'react'
 
-import {Input} from "@/components/ui/input";
-import {cn} from "@/lib/utils";
-import {
-  Search
-} from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import { Search, XCircle } from 'lucide-react'
 
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  onValueChange?: (value: string) => void
+}
 
 const SearchBar = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, onValueChange, ...props }, ref) => {
+    const [value, _setValue] = React.useState('')
+
+    const setValue = (v: string) => {
+      _setValue(v)
+      onValueChange && onValueChange(v)
+    }
+
     return (
       <div className="mx-4 sm:mx-6 flex relative">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
         <Input
           type={type}
           className={cn(
-            "pl-10 text-sm focus:text-base bg-muted border-none text-muted-foreground",
-            className
+            'pl-10 text-sm focus:text-base bg-muted border-none text-muted-foreground',
+            className,
           )}
           ref={ref}
           placeholder="Search for an expense…"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
           {...props}
+        />
+        <XCircle
+          className={cn(
+            'absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 cursor-pointer',
+            !value && 'hidden',
+          )}
+          onClick={() => setValue('')}
         />
       </div>
     )
-  }
+  },
 )
-SearchBar.displayName = "SearchBar"
+SearchBar.displayName = 'SearchBar'
 
 export { SearchBar }


### PR DESCRIPTION
Simply adds an "x" button to the search bar that will show when text has been entered.
As expected, clicking on "x" will clear the search.

Motivation for this PR: I have a long list. Having to click backspace multiple times to remove the search is time consuming, since every keystroke (backspace too) triggers a new search.