### PR TITLE
Fix decimal separator issue in numeric form fields

### DIFF
--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -435,7 +435,7 @@ export function ExpenseForm({
                                               ),
                                             )}
                                             className="text-base w-[80px] -my-2"
-                                            type="number"
+                                            type="text"
                                             disabled={
                                               !field.value?.some(
                                                 ({ participant }) =>
@@ -448,19 +448,23 @@ export function ExpenseForm({
                                                   participant === id,
                                               )?.shares
                                             }
-                                            onChange={(event) =>
-                                              field.onChange(
+                                            onChange={(event) => {
+                                              const value = event.target.value
+                                              const fixedValue = typeof value === "string"
+                                                ? value.replace(/,/g, '.')
+                                                : value
+
+                                              return field.onChange(
                                                 field.value.map((p) =>
                                                   p.participant === id
                                                     ? {
                                                         participant: id,
-                                                        shares:
-                                                          event.target.value,
+                                                        shares: fixedValue,
                                                       }
                                                     : p,
                                                 ),
                                               )
-                                            }
+                                            }}
                                             inputMode={
                                               form.getValues().splitMode ===
                                               'BY_AMOUNT'

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -217,12 +217,20 @@ export function ExpenseForm({
                     <span>{group.currency}</span>
                     <FormControl>
                       <Input
+                        {...field}
                         className="text-base max-w-[120px]"
-                        type="number"
+                        type="text"
                         inputMode="decimal"
                         step={0.01}
                         placeholder="0.00"
-                        {...field}
+                        onChange={(event) => {
+                          const value = event.target.value
+                          const fixedValue = typeof value === "string"
+                            ? value.replace(/,/g, '.')
+                            : value
+
+                          return field.onChange(fixedValue)
+                        }}
                       />
                     </FormControl>
                   </div>

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -56,6 +56,18 @@ export type Props = {
   runtimeFeatureFlags: RuntimeFeatureFlags
 }
 
+const enforceCurrencyPattern = (
+  onChange: (value: string) => void,
+  value: string,
+) =>
+  onChange(
+    value
+      // replace commas with dots
+      .replace(/,/g, '.')
+      // remove all non-numeric and non-dot characters
+      .replace(/[^\d.]/g, ''),
+  )
+
 export function ExpenseForm({
   group,
   expense,
@@ -223,15 +235,12 @@ export function ExpenseForm({
                         inputMode="decimal"
                         step={0.01}
                         placeholder="0.00"
-                        onChange={(event) => {
-                          const value = event.target.value
-                          const fixedValue =
-                            typeof value === 'string'
-                              ? value.replace(/,/g, '.')
-                              : value
-
-                          return field.onChange(fixedValue)
-                        }}
+                        onChange={(event) =>
+                          enforceCurrencyPattern(
+                            field.onChange,
+                            event.target.value,
+                          )
+                        }
                       />
                     </FormControl>
                   </div>
@@ -449,24 +458,13 @@ export function ExpenseForm({
                                                   participant === id,
                                               )?.shares
                                             }
-                                            onChange={(event) => {
-                                              const value = event.target.value
-                                              const fixedValue =
-                                                typeof value === 'string'
-                                                  ? value.replace(/,/g, '.')
-                                                  : value
-
-                                              return field.onChange(
-                                                field.value.map((p) =>
-                                                  p.participant === id
-                                                    ? {
-                                                        participant: id,
-                                                        shares: fixedValue,
-                                                      }
-                                                    : p,
-                                                ),
+                                            pattern="[0-9]+([,\.][0-9]+)?"
+                                            onChange={(event) =>
+                                              enforceCurrencyPattern(
+                                                field.onChange,
+                                                event.target.value,
                                               )
-                                            }}
+                                            }
                                             inputMode={
                                               form.getValues().splitMode ===
                                               'BY_AMOUNT'

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -225,9 +225,10 @@ export function ExpenseForm({
                         placeholder="0.00"
                         onChange={(event) => {
                           const value = event.target.value
-                          const fixedValue = typeof value === "string"
-                            ? value.replace(/,/g, '.')
-                            : value
+                          const fixedValue =
+                            typeof value === 'string'
+                              ? value.replace(/,/g, '.')
+                              : value
 
                           return field.onChange(fixedValue)
                         }}
@@ -450,9 +451,10 @@ export function ExpenseForm({
                                             }
                                             onChange={(event) => {
                                               const value = event.target.value
-                                              const fixedValue = typeof value === "string"
-                                                ? value.replace(/,/g, '.')
-                                                : value
+                                              const fixedValue =
+                                                typeof value === 'string'
+                                                  ? value.replace(/,/g, '.')
+                                                  : value
 
                                               return field.onChange(
                                                 field.value.map((p) =>

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -221,7 +221,7 @@ export function ExpenseForm({
             <FormField
               control={form.control}
               name="amount"
-              render={({ field }) => (
+              render={({ field: { onChange, ...field } }) => (
                 <FormItem className="sm:order-3">
                   <FormLabel>Amount</FormLabel>
                   <div className="flex items-baseline gap-2">
@@ -235,9 +235,7 @@ export function ExpenseForm({
                         step={0.01}
                         placeholder="0.00"
                         onChange={(event) =>
-                          field.onChange(
-                            enforceCurrencyPattern(event.target.value),
-                          )
+                          onChange(enforceCurrencyPattern(event.target.value))
                         }
                         onClick={(e) => e.currentTarget.select()}
                         {...field}

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -56,17 +56,16 @@ export type Props = {
   runtimeFeatureFlags: RuntimeFeatureFlags
 }
 
-const enforceCurrencyPattern = (
-  onChange: (value: string) => void,
-  value: string,
-) =>
-  onChange(
-    value
-      // replace commas with dots
-      .replace(/,/g, '.')
-      // remove all non-numeric and non-dot characters
-      .replace(/[^\d.]/g, ''),
-  )
+const enforceCurrencyPattern = (value: string) =>
+  value
+    // replace first comma with #
+    .replace(/[.,]/, '#')
+    // remove all other commas
+    .replace(/[.,]/g, '')
+    // change back # to dot
+    .replace(/#/, '.')
+    // remove all non-numeric and non-dot characters
+    .replace(/[^\d.]/g, '')
 
 export function ExpenseForm({
   group,
@@ -236,9 +235,8 @@ export function ExpenseForm({
                         step={0.01}
                         placeholder="0.00"
                         onChange={(event) =>
-                          enforceCurrencyPattern(
-                            field.onChange,
-                            event.target.value,
+                          field.onChange(
+                            enforceCurrencyPattern(event.target.value),
                           )
                         }
                       />
@@ -458,11 +456,19 @@ export function ExpenseForm({
                                                   participant === id,
                                               )?.shares
                                             }
-                                            pattern="[0-9]+([,\.][0-9]+)?"
                                             onChange={(event) =>
-                                              enforceCurrencyPattern(
-                                                field.onChange,
-                                                event.target.value,
+                                              field.onChange(
+                                                field.value.map((p) =>
+                                                  p.participant === id
+                                                    ? {
+                                                        participant: id,
+                                                        shares:
+                                                          enforceCurrencyPattern(
+                                                            event.target.value,
+                                                          ),
+                                                      }
+                                                    : p,
+                                                ),
                                               )
                                             }
                                             inputMode={

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -51,8 +51,7 @@ export const expenseFormSchema = z
         [
           z.number(),
           z.string().transform((value, ctx) => {
-            const normalizedValue = value.replace(/,/g, '.')
-            const valueAsNumber = Number(normalizedValue)
+            const valueAsNumber = Number(value)
             if (Number.isNaN(valueAsNumber))
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,


### PR DESCRIPTION
Related:
- Previous PR: https://github.com/spliit-app/spliit/pull/90
- Issue: https://github.com/spliit-app/spliit/issues/78

## Problem

I previously made a fix that converted commas to dots in the "amount" field during Zod validation. Turns out, on some browsers, the problem remained, and these numbers that used a comma as the decimal separator were not accepted as valid numbers.

The reason was that when using inputs with `type="number"`, browsers have different behaviour regarding validation. For example, iOS Safari rejects numbers with commas in them. This happens _before_ the number can reach the Zod validation and be subsequently fixed with the previous fix.

I first attempted to replace commas with dots in an `onChange` handler, but it turns out that the "erroneous" numeric value is not accessible to JS in that context when browser validation has deemed it invalid (I.e. `event.target.value` is empty or not in sync with the inputted value). The browser validation needs to be disabled first.

## Fix

- Make the inputs `type="text"` to circumvent the aggressive validation, while retaining the same input experience with `inputMode="decimal"`
- Replace commas with dots in an `onChange` handler.

This also fixes the same issue in the `paidFor` field inputs.

## Issues with this fix

- With `input="text"`, desktop browsers will no longer show an "up-down" widget that nudges the value up or down. I don't think this is a big problem since not many use that anyway.