### PR TITLE
Minor: reorder Dockerfile layers for better cache use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,12 @@ COPY ./package.json \
      ./postcss.config.js ./
 COPY ./scripts ./scripts
 COPY ./prisma ./prisma
-COPY ./src ./src
 
 RUN apk add --no-cache openssl && \
     npm ci --ignore-scripts && \
     npx prisma generate
+
+COPY ./src ./src
 
 ENV NEXT_TELEMETRY_DISABLED=1
 


### PR DESCRIPTION
Move package installs and prisma client generation to before copying the `src` directory into the image. Regular source code changes in `src` do not warrant rerunning those steps.