### PR TITLE
Add "save as default splitting options" feature

### DIFF
--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -73,7 +73,7 @@ const enforceCurrencyPattern = (value: string) =>
 
 const getDefaultSplittingOptions = (
   group: Props['group'],
-): SplittingOptions => {
+) => {
   const defaultValue = {
     splitMode: 'EVENLY' as const,
     paidFor: group.participants.map(({ id }) => ({

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -36,7 +36,11 @@ import {
 } from '@/components/ui/select'
 import { getCategories, getExpense, getGroup, randomId } from '@/lib/api'
 import { RuntimeFeatureFlags } from '@/lib/featureFlags'
-import { ExpenseFormValues, expenseFormSchema } from '@/lib/schemas'
+import {
+  ExpenseFormValues,
+  SplittingOptions,
+  expenseFormSchema,
+} from '@/lib/schemas'
 import { cn } from '@/lib/utils'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Save, Trash2 } from 'lucide-react'
@@ -67,6 +71,82 @@ const enforceCurrencyPattern = (value: string) =>
     // remove all non-numeric and non-dot characters
     .replace(/[^\d.]/g, '')
 
+const getDefaultSplittingOptions = (
+  group: Props['group'],
+): SplittingOptions => {
+  const defaultValue = {
+    splitMode: 'EVENLY' as const,
+    paidFor: group.participants.map(({ id }) => ({
+      participant: id,
+      shares: '1' as unknown as number,
+    })),
+  }
+
+  if (typeof localStorage === 'undefined') return defaultValue
+  const defaultSplitMode = localStorage.getItem(
+    `${group.id}-defaultSplittingOptions`,
+  )
+  if (defaultSplitMode === null) return defaultValue
+  const parsedDefaultSplitMode = JSON.parse(
+    defaultSplitMode,
+  ) as SplittingOptions
+
+  if (parsedDefaultSplitMode.paidFor === null) {
+    parsedDefaultSplitMode.paidFor = defaultValue.paidFor
+  }
+
+  // if there is a participant in the default options that does not exist anymore,
+  // remove the stale default splitting options
+  for (const parsedPaidFor of parsedDefaultSplitMode.paidFor) {
+    if (
+      !group.participants.some(({ id }) => id === parsedPaidFor.participant)
+    ) {
+      localStorage.removeItem(`${group.id}-defaultSplittingOptions`)
+      return defaultValue
+    }
+  }
+
+  return {
+    splitMode: parsedDefaultSplitMode.splitMode,
+    paidFor: parsedDefaultSplitMode.paidFor.map((paidFor) => ({
+      participant: paidFor.participant,
+      shares: String(paidFor.shares / 100) as unknown as number,
+    })),
+  }
+}
+
+async function persistDefaultSplittingOptions(
+  groupId: string,
+  expenseFormValues: ExpenseFormValues,
+) {
+  if (localStorage && expenseFormValues.saveDefaultSplittingOptions) {
+    const computePaidFor = (): SplittingOptions["paidFor"] => {
+      if (expenseFormValues.splitMode === 'EVENLY') {
+        return expenseFormValues.paidFor.map(({ participant }) => ({
+          participant,
+          shares: '100' as unknown as number,
+        }))
+      }
+      else if (expenseFormValues.splitMode === 'BY_AMOUNT' ) {
+        return null;
+      }
+      else {
+        return expenseFormValues.paidFor
+      }
+    }
+
+    const splittingOptions = {
+      splitMode: expenseFormValues.splitMode,
+      paidFor: computePaidFor(),
+    } satisfies SplittingOptions
+
+    localStorage.setItem(
+      `${groupId}-defaultSplittingOptions`,
+      JSON.stringify(splittingOptions),
+    )
+  }
+}
+
 export function ExpenseForm({
   group,
   expense,
@@ -86,6 +166,7 @@ export function ExpenseForm({
     }
     return field?.value
   }
+  const defaultSplittingOptions = getDefaultSplittingOptions(group)
   const form = useForm<ExpenseFormValues>({
     resolver: zodResolver(expenseFormSchema),
     defaultValues: expense
@@ -100,6 +181,7 @@ export function ExpenseForm({
             shares: String(shares / 100) as unknown as number,
           })),
           splitMode: expense.splitMode,
+          saveDefaultSplittingOptions: false,
           isReimbursement: expense.isReimbursement,
           documents: expense.documents,
         }
@@ -121,7 +203,8 @@ export function ExpenseForm({
               : undefined,
           ],
           isReimbursement: true,
-          splitMode: 'EVENLY',
+          splitMode: defaultSplittingOptions.splitMode,
+          saveDefaultSplittingOptions: false,
           documents: [],
         }
       : {
@@ -134,13 +217,11 @@ export function ExpenseForm({
             ? Number(searchParams.get('categoryId'))
             : 0, // category with Id 0 is General
           // paid for all, split evenly
-          paidFor: group.participants.map(({ id }) => ({
-            participant: id,
-            shares: '1' as unknown as number,
-          })),
+          paidFor: defaultSplittingOptions.paidFor,
           paidBy: getSelectedPayer(),
           isReimbursement: false,
-          splitMode: 'EVENLY',
+          splitMode: defaultSplittingOptions.splitMode,
+          saveDefaultSplittingOptions: false,
           documents: searchParams.get('imageUrl')
             ? [
                 {
@@ -155,9 +236,14 @@ export function ExpenseForm({
   })
   const [isCategoryLoading, setCategoryLoading] = useState(false)
 
+  const submit = async (values: ExpenseFormValues) => {
+    await persistDefaultSplittingOptions(group.id, values)
+    return onSubmit(values)
+  }
+
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit((values) => onSubmit(values))}>
+      <form onSubmit={form.handleSubmit(submit)}>
         <Card>
           <CardHeader>
             <CardTitle>
@@ -511,7 +597,10 @@ export function ExpenseForm({
               )}
             />
 
-            <Collapsible className="mt-5">
+            <Collapsible
+              className="mt-5"
+              defaultOpen={form.getValues().splitMode !== 'EVENLY'}
+            >
               <CollapsibleTrigger asChild>
                 <Button variant="link" className="-mx-4">
                   Advanced splitting options…
@@ -523,7 +612,7 @@ export function ExpenseForm({
                     control={form.control}
                     name="splitMode"
                     render={({ field }) => (
-                      <FormItem className="sm:order-2">
+                      <FormItem>
                         <FormLabel>Split mode</FormLabel>
                         <FormControl>
                           <Select
@@ -556,6 +645,25 @@ export function ExpenseForm({
                         <FormDescription>
                           Select how to split the expense.
                         </FormDescription>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="saveDefaultSplittingOptions"
+                    render={({ field }) => (
+                      <FormItem className="flex flex-row gap-2 items-center space-y-0 pt-2">
+                        <FormControl>
+                          <Checkbox
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </FormControl>
+                        <div>
+                          <FormLabel>
+                            Save as default splitting options
+                          </FormLabel>
+                        </div>
                       </FormItem>
                     )}
                   />

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -71,9 +71,7 @@ const enforceCurrencyPattern = (value: string) =>
     // remove all non-numeric and non-dot characters
     .replace(/[^\d.]/g, '')
 
-const getDefaultSplittingOptions = (
-  group: Props['group'],
-) => {
+const getDefaultSplittingOptions = (group: Props['group']) => {
   const defaultValue = {
     splitMode: 'EVENLY' as const,
     paidFor: group.participants.map(({ id }) => ({
@@ -120,17 +118,15 @@ async function persistDefaultSplittingOptions(
   expenseFormValues: ExpenseFormValues,
 ) {
   if (localStorage && expenseFormValues.saveDefaultSplittingOptions) {
-    const computePaidFor = (): SplittingOptions["paidFor"] => {
+    const computePaidFor = (): SplittingOptions['paidFor'] => {
       if (expenseFormValues.splitMode === 'EVENLY') {
         return expenseFormValues.paidFor.map(({ participant }) => ({
           participant,
           shares: '100' as unknown as number,
         }))
-      }
-      else if (expenseFormValues.splitMode === 'BY_AMOUNT' ) {
-        return null;
-      }
-      else {
+      } else if (expenseFormValues.splitMode === 'BY_AMOUNT') {
+        return null
+      } else {
         return expenseFormValues.paidFor
       }
     }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -105,6 +105,7 @@ export const expenseFormSchema = z
         Object.values(SplitMode) as any,
       )
       .default('EVENLY'),
+    saveDefaultSplittingOptions: z.boolean(),
     isReimbursement: z.boolean(),
     documents: z
       .array(
@@ -160,3 +161,9 @@ export const expenseFormSchema = z
   })
 
 export type ExpenseFormValues = z.infer<typeof expenseFormSchema>
+
+export type SplittingOptions = {
+  // Used for saving default splitting options in localStorage
+  splitMode: SplitMode
+  paidFor: ExpenseFormValues['paidFor'] | null
+}


### PR DESCRIPTION
Related issue: #98

See issue for problem statement.

## Implementation

- Add a checkbox form field `saveDefaultSplittingOptions`
- On form submit, if `saveDefaultSplittingOptions` is set, serialize the splitting options, i.e. `paidFor` and `splitMode`, to JSON and store it with a group ID -based key in local storage. Supports all split modes. Note: `BY_AMOUNT` has special behaviour where the serialized paidFor object is set to `null`. This is because storing absolute currency values do not make much sense since expenses have different total amounts. 
- On form load, if there is no data from an existing `expense` object, try to deserialize the splitting options from local storage and use them as defaults. If that fails (missing local storage key or stale data), or `paidFor = null` as with `BY_AMOUNT`, fallback to the simple default (`splitMode = "EVENLY"`).

## Challenges

I did not completely understand the behaviour where the paidFor shares are sometimes multiplied and sometimes divided by 100, so I just tried to match that behaviour in this feature. There seems to be space for improvement there. Everything seems to work as it should though in my manual testing. 
