### PR TITLE
Expense list: add section for planned purchases

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -19,7 +19,7 @@ type Props = {
 }
 
 const EXPENSE_GROUPS = {
-  PLANNED_PURCHASES: 'Planned purchases',
+  UPCOMING: 'Upcoming',
   THIS_WEEK: 'This week',
   EARLIER_THIS_MONTH: 'Earlier this month',
   LAST_MONTH: 'Last month',
@@ -30,7 +30,7 @@ const EXPENSE_GROUPS = {
 
 function getExpenseGroup(date: Dayjs, today: Dayjs) {
   if (today.isBefore(date)) {
-    return EXPENSE_GROUPS.PLANNED_PURCHASES
+    return EXPENSE_GROUPS.UPCOMING
   } else if (today.isSame(date, 'week')) {
     return EXPENSE_GROUPS.THIS_WEEK
   } else if (today.isSame(date, 'month')) {

--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -19,6 +19,7 @@ type Props = {
 }
 
 const EXPENSE_GROUPS = {
+  PLANNED_PURCHASES: 'Planned purchases',
   THIS_WEEK: 'This week',
   EARLIER_THIS_MONTH: 'Earlier this month',
   LAST_MONTH: 'Last month',
@@ -28,7 +29,9 @@ const EXPENSE_GROUPS = {
 }
 
 function getExpenseGroup(date: Dayjs, today: Dayjs) {
-  if (today.isSame(date, 'week')) {
+  if (today.isBefore(date)) {
+    return EXPENSE_GROUPS.PLANNED_PURCHASES
+  } else if (today.isSame(date, 'week')) {
     return EXPENSE_GROUPS.THIS_WEEK
   } else if (today.isSame(date, 'month')) {
     return EXPENSE_GROUPS.EARLIER_THIS_MONTH


### PR DESCRIPTION
I have a pending purchase that I made for an upcoming trip and went ahead and added it to Spliit in preparation for it hitting my account. I noticed that it shows up in the "Earlier this year" section of the expense groups and would like it marked as a future purchase until that date arrives. I've attached before and after screenshots of my proposed changes.

Before: <img width="875" alt="Screenshot 2024-03-03 at 6 56 34 PM" src="https://github.com/spliit-app/spliit/assets/9884444/51afec47-baa9-43b5-a026-880de891bb1f">

After: <img width="852" alt="Screenshot 2024-03-03 at 6 58 01 PM" src="https://github.com/spliit-app/spliit/assets/9884444/a0809234-1181-4a59-8cf7-1aa5b178fa2c">
