### PR TITLE
Bug: Fixed wrong paid by Name in Reimbursement

### DIFF
--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -156,7 +156,7 @@ export function ExpenseForm({
   const getSelectedPayer = (field?: { value: string }) => {
     if (isCreate && typeof window !== 'undefined') {
       const activeUser = localStorage.getItem(`${group.id}-activeUser`)
-      if (activeUser && activeUser !== 'None') {
+      if (activeUser && activeUser !== 'None' && field?.value === undefined) {
         return activeUser
       }
     }


### PR DESCRIPTION
Related issue #133 

Default selected user was getting updated in paid-by field, even by user select a normal reimbursement transaction.

Working Demo
https://www.loom.com/share/20b999695b23402a8a313350084cf2ca?sid=eedd3056-e1df-4c83-81ec-ddca16257ccd