### PR TITLE
change onClick to onFocus, with a slight delay for safari

### DIFF
--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -327,13 +327,9 @@ export function ExpenseForm({
                           onChange(enforceCurrencyPattern(event.target.value))
                         }
                         onFocus={(e) => {
-                          {
-                            // we're adding a small delay to get around safaris issue with onMouseUp deselecting things again
-                            let target = e.currentTarget
-                            setTimeout(function () {
-                              target.select()
-                            }, 1)
-                          }
+                          // we're adding a small delay to get around safaris issue with onMouseUp deselecting things again
+                          const target = e.currentTarget
+                          setTimeout(() => target.select(), 1)
                         }}
                         {...field}
                       />

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -326,7 +326,15 @@ export function ExpenseForm({
                         onChange={(event) =>
                           onChange(enforceCurrencyPattern(event.target.value))
                         }
-                        onClick={(e) => e.currentTarget.select()}
+                        onFocus={(e) => {
+                          {
+                            // we're adding a small delay to get around safaris issue with onMouseUp deselcting things again
+                            let evt = e.currentTarget
+                            setTimeout(function () {
+                              evt.select()
+                            }, 1)
+                          }
+                        }}
                         {...field}
                       />
                     </FormControl>

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -329,9 +329,9 @@ export function ExpenseForm({
                         onFocus={(e) => {
                           {
                             // we're adding a small delay to get around safaris issue with onMouseUp deselecting things again
-                            let evt = e.currentTarget
+                            let target = e.currentTarget
                             setTimeout(function () {
-                              evt.select()
+                              target.select()
                             }, 1)
                           }
                         }}

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -328,7 +328,7 @@ export function ExpenseForm({
                         }
                         onFocus={(e) => {
                           {
-                            // we're adding a small delay to get around safaris issue with onMouseUp deselcting things again
+                            // we're adding a small delay to get around safaris issue with onMouseUp deselecting things again
                             let evt = e.currentTarget
                             setTimeout(function () {
                               evt.select()


### PR DESCRIPTION
## Background
I originally wanted to make the amount field select `onFocus`, as I wanted it to be possible to choose parts of the amount.
It was then pointed out that `onFocus` does not work for Safari, since the way onMouseUp works there deselects the text again after initially selecting it.
Therefore the choice was made to go with `onClick` instead, which seemed to work out for everyone involved, and you could still move around using the arrow keys for example if you just wanted to do edits.

Along came https://github.com/spliit-app/spliit/issues/136!
So I decided to look into getting it to work better, and more in line with the original thought.

## Solution
After scouring the net I found that there is a rather simple solution for allowing this to work on Safari as well, which is to add a small delay to the selection of the input, since then the `mouseup` event will have come and gone.
I'm not sure if there are other concerns regarding the solution, but I am open to feedback on it.

### Tested on
* Safari 16.5.1
* Chrome 123.0.6312.86
* Mobile Safari iOS 17.4.1

## Issues
Closes https://github.com/spliit-app/spliit/issues/136 on merge