### PR TITLE
copy the next.config.js in order to get custom domains working (for alternative s3 providers) again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN rm -r .next/cache
 FROM node:21-alpine as runtime-deps
 
 WORKDIR /usr/app
-COPY --from=base /usr/app/package.json /usr/app/package-lock.json ./
+COPY --from=base /usr/app/package.json /usr/app/package-lock.json /usr/app/next.config.js ./
 COPY --from=base /usr/app/prisma ./prisma
 
 RUN npm ci --omit=dev --omit=optional --ignore-scripts && \
@@ -38,7 +38,7 @@ FROM node:21-alpine as runner
 EXPOSE 3000/tcp
 WORKDIR /usr/app
 
-COPY --from=base /usr/app/package.json /usr/app/package-lock.json ./
+COPY --from=base /usr/app/package.json /usr/app/package-lock.json /usr/app/next.config.js ./
 COPY --from=runtime-deps /usr/app/node_modules ./node_modules
 COPY ./public ./public
 COPY ./scripts ./scripts


### PR DESCRIPTION
## Background
The custom s3 domains have stopped working for me, as the domain never gets added to the runtime next config. Next complains about the url not being whitelisted for loading images (but not in a clear way…)

This seems to have been the case since https://github.com/spliit-app/spliit/pull/91 which removed files (among other fixes) in order to make the the Docker image smaller.

## Fix
The easy fix is just adding back the `next.config.js` to the runtime environment, since this fix was already added in https://github.com/spliit-app/spliit/pull/71 in order to get the custom domains working in the first case.