### PR TITLE
Use placeholder for new participant input

### DIFF
--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -173,7 +173,7 @@ export function GroupForm({
                         </FormLabel>
                         <FormControl>
                           <div className="flex gap-2">
-                            <Input className="text-base" {...field} />
+                            <Input className="text-base" {...field} placeholder="New"/>
                             {item.id &&
                             protectedParticipantIds.includes(item.id) ? (
                               <HoverCard>
@@ -221,7 +221,7 @@ export function GroupForm({
             <Button
               variant="secondary"
               onClick={() => {
-                append({ name: 'New' })
+                append({ name: '' })
               }}
               type="button"
             >


### PR DESCRIPTION
Instead of creating the new input with "New" as its value, set a placeholder on the input. This makes it so that when you add a participant, you still see "New" but you can immediately start typing instead of having to select/delete the initial value.

Before:
![spliit before](https://github.com/spliit-app/spliit/assets/161132/d4d985dc-f405-43b1-b107-7dfa5fd4affc)

After:
![spliit after](https://github.com/spliit-app/spliit/assets/161132/b9302525-35c3-4120-a4ba-878a92b93eef)
