### PR TITLE
Fix relative path docker db script

### DIFF
--- a/scripts/start-local-db.sh
+++ b/scripts/start-local-db.sh
@@ -6,6 +6,6 @@ else
     echo "postgres is not running, starting it"
     docker rm postgres --force
     mkdir -p postgres-data
-    docker run --name postgres -d -p 5432:5432 -e POSTGRES_PASSWORD=1234 -v ./postgres-data:/var/lib/postgresql/data postgres
+    docker run --name postgres -d -p 5432:5432 -e POSTGRES_PASSWORD=1234 -v "/$(pwd)/postgres-data:/var/lib/postgresql/data" postgres
     sleep 5 # Wait for postgres to start
 fi


### PR DESCRIPTION
Without this, docker complained:
```
docker: Error response from daemon: create ./postgres-data: "./postgres-data" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
```

Followed recommendation from https://stackoverflow.com/questions/46526165/docker-invalid-characters-for-volume-when-using-relative-paths