### PR TITLE
Add support for group income (= negative expenses)

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -136,8 +136,10 @@ export function ExpenseList({
                     {expense.title}
                   </div>
                   <div className="text-xs text-muted-foreground">
-                    Paid by{' '}
-                    <strong>{getParticipant(expense.paidById)?.name}</strong>{' '}
+                    {expense.amount > 0 ? 'Paid by ' : 'Received by '}
+                    <strong>
+                      {getParticipant(expense.paidById)?.name}
+                    </strong>{' '}
                     for{' '}
                     {expense.paidFor.map((paidFor: any, index: number) => (
                       <Fragment key={index}>

--- a/src/app/groups/[groupId]/stats/totals-group-spending.tsx
+++ b/src/app/groups/[groupId]/stats/totals-group-spending.tsx
@@ -6,11 +6,12 @@ type Props = {
 }
 
 export function TotalsGroupSpending({ totalGroupSpendings, currency }: Props) {
+  const balance = totalGroupSpendings < 0 ? 'earnings' : 'spendings'
   return (
     <div>
-      <div className="text-muted-foreground">Total group spendings</div>
+      <div className="text-muted-foreground">Total group {balance}</div>
       <div className="text-lg">
-        {formatCurrency(currency, totalGroupSpendings)}
+        {formatCurrency(currency, Math.abs(totalGroupSpendings))}
       </div>
     </div>
   )

--- a/src/app/groups/[groupId]/stats/totals-your-share.tsx
+++ b/src/app/groups/[groupId]/stats/totals-your-share.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { getGroup, getGroupExpenses } from '@/lib/api'
 import { getTotalActiveUserShare } from '@/lib/totals'
-import { formatCurrency } from '@/lib/utils'
+import { cn, formatCurrency } from '@/lib/utils'
 import { useEffect, useState } from 'react'
 
 type Props = {
@@ -26,8 +26,13 @@ export function TotalsYourShare({ group, expenses }: Props) {
   return (
     <div>
       <div className="text-muted-foreground">Your total share</div>
-      <div className="text-lg">
-        {formatCurrency(currency, totalActiveUserShare)}
+      <div
+        className={cn(
+          'text-lg',
+          totalActiveUserShare < 0 ? 'text-green-600' : 'text-red-600',
+        )}
+      >
+        {formatCurrency(currency, Math.abs(totalActiveUserShare))}
       </div>
     </div>
   )

--- a/src/app/groups/[groupId]/stats/totals-your-spending.tsx
+++ b/src/app/groups/[groupId]/stats/totals-your-spending.tsx
@@ -2,7 +2,7 @@
 import { getGroup, getGroupExpenses } from '@/lib/api'
 import { useActiveUser } from '@/lib/hooks'
 import { getTotalActiveUserPaidFor } from '@/lib/totals'
-import { formatCurrency } from '@/lib/utils'
+import { cn, formatCurrency } from '@/lib/utils'
 
 type Props = {
   group: NonNullable<Awaited<ReturnType<typeof getGroup>>>
@@ -17,13 +17,19 @@ export function TotalsYourSpendings({ group, expenses }: Props) {
       ? 0
       : getTotalActiveUserPaidFor(activeUser, expenses)
   const currency = group.currency
+  const balance = totalYourSpendings < 0 ? 'earnings' : 'spendings'
 
   return (
     <div>
-      <div className="text-muted-foreground">Total you paid for</div>
+      <div className="text-muted-foreground">Your total {balance}</div>
 
-      <div className="text-lg">
-        {formatCurrency(currency, totalYourSpendings)}
+      <div
+        className={cn(
+          'text-lg',
+          totalYourSpendings < 0 ? 'text-green-600' : 'text-red-600',
+        )}
+      >
+        {formatCurrency(currency, Math.abs(totalYourSpendings))}
       </div>
     </div>
   )

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -70,6 +70,9 @@ const enforceCurrencyPattern = (value: string) =>
     .replace(/#/, '.') // change back # to dot
     .replace(/[^-\d.]/g, '') // remove all non-numeric characters
 
+const capitalize = (value: string) =>
+  value.charAt(0).toUpperCase() + value.slice(1)
+
 const getDefaultSplittingOptions = (group: Props['group']) => {
   const defaultValue = {
     splitMode: 'EVENLY' as const,
@@ -240,15 +243,15 @@ export function ExpenseForm({
   }
 
   const [isIncome, setIsIncome] = useState(Number(form.getValues().amount) < 0)
+  const sExpense = isIncome ? 'income' : 'expense'
+  const sPaid = isIncome ? 'received' : 'payed'
 
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(submit)}>
         <Card>
           <CardHeader>
-            <CardTitle>
-              {isCreate ? <>Create expense</> : <>Edit expense</>}
-            </CardTitle>
+            <CardTitle>{(isCreate ? 'Create ' : 'Edit ') + sExpense}</CardTitle>
           </CardHeader>
           <CardContent className="grid sm:grid-cols-2 gap-6">
             <FormField
@@ -256,7 +259,7 @@ export function ExpenseForm({
               name="title"
               render={({ field }) => (
                 <FormItem className="">
-                  <FormLabel>Expense title</FormLabel>
+                  <FormLabel>{capitalize(sExpense)} title</FormLabel>
                   <FormControl>
                     <Input
                       placeholder="Monday evening restaurant"
@@ -276,7 +279,7 @@ export function ExpenseForm({
                     />
                   </FormControl>
                   <FormDescription>
-                    Enter a description for the expense.
+                    Enter a description for the {sExpense}.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -288,7 +291,7 @@ export function ExpenseForm({
               name="expenseDate"
               render={({ field }) => (
                 <FormItem className="sm:order-1">
-                  <FormLabel>Expense date</FormLabel>
+                  <FormLabel>{capitalize(sExpense)} date</FormLabel>
                   <FormControl>
                     <Input
                       className="date-base"
@@ -300,7 +303,7 @@ export function ExpenseForm({
                     />
                   </FormControl>
                   <FormDescription>
-                    Enter the date the expense was made.
+                    Enter the date the {sExpense} was {sPaid}.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -373,7 +376,7 @@ export function ExpenseForm({
                     isLoading={isCategoryLoading}
                   />
                   <FormDescription>
-                    Select the expense category.
+                    Select the {sExpense} category.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -385,7 +388,7 @@ export function ExpenseForm({
               name="paidBy"
               render={({ field }) => (
                 <FormItem className="sm:order-5">
-                  <FormLabel>Paid by</FormLabel>
+                  <FormLabel>{capitalize(sPaid)} by</FormLabel>
                   <Select
                     onValueChange={field.onChange}
                     defaultValue={getSelectedPayer(field)}
@@ -402,7 +405,7 @@ export function ExpenseForm({
                     </SelectContent>
                   </Select>
                   <FormDescription>
-                    Select the participant who paid the expense.
+                    Select the participant who {sPaid} the {sExpense}.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -426,7 +429,7 @@ export function ExpenseForm({
         <Card className="mt-4">
           <CardHeader>
             <CardTitle className="flex justify-between">
-              <span>Paid for</span>
+              <span>{capitalize(sPaid)} for</span>
               <Button
                 variant="link"
                 type="button"
@@ -459,7 +462,7 @@ export function ExpenseForm({
               </Button>
             </CardTitle>
             <CardDescription>
-              Select who the expense was paid for.
+              Select who the {sExpense} was {sPaid} for.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -659,7 +662,7 @@ export function ExpenseForm({
                           </Select>
                         </FormControl>
                         <FormDescription>
-                          Select how to split the expense.
+                          Select how to split the {sExpense}.
                         </FormDescription>
                       </FormItem>
                     )}
@@ -696,7 +699,7 @@ export function ExpenseForm({
                 <span>Attach documents</span>
               </CardTitle>
               <CardDescription>
-                See and attach receipts to the expense.
+                See and attach receipts to the {sExpense}.
               </CardDescription>
             </CardHeader>
             <CardContent>

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -239,6 +239,8 @@ export function ExpenseForm({
     return onSubmit(values)
   }
 
+  const [isIncome, setIsIncome] = useState(Number(form.getValues().amount) < 0)
+
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(submit)}>
@@ -315,15 +317,17 @@ export function ExpenseForm({
                     <span>{group.currency}</span>
                     <FormControl>
                       <Input
-                        {...field}
                         className="text-base max-w-[120px]"
                         type="text"
                         inputMode="decimal"
-                        step={0.01}
                         placeholder="0.00"
-                        onChange={(event) =>
-                          onChange(enforceCurrencyPattern(event.target.value))
-                        }
+                        onChange={(event) => {
+                          const v = enforceCurrencyPattern(event.target.value)
+                          const income = Number(v) < 0
+                          setIsIncome(income)
+                          if (income) form.setValue('isReimbursement', false)
+                          onChange(v)
+                        }}
                         onClick={(e) => e.currentTarget.select()}
                         {...field}
                       />
@@ -331,23 +335,25 @@ export function ExpenseForm({
                   </div>
                   <FormMessage />
 
-                  <FormField
-                    control={form.control}
-                    name="isReimbursement"
-                    render={({ field }) => (
-                      <FormItem className="flex flex-row gap-2 items-center space-y-0 pt-2">
-                        <FormControl>
-                          <Checkbox
-                            checked={field.value}
-                            onCheckedChange={field.onChange}
-                          />
-                        </FormControl>
-                        <div>
-                          <FormLabel>This is a reimbursement</FormLabel>
-                        </div>
-                      </FormItem>
-                    )}
-                  />
+                  {!isIncome && (
+                    <FormField
+                      control={form.control}
+                      name="isReimbursement"
+                      render={({ field }) => (
+                        <FormItem className="flex flex-row gap-2 items-center space-y-0 pt-2">
+                          <FormControl>
+                            <Checkbox
+                              checked={field.value}
+                              onCheckedChange={field.onChange}
+                            />
+                          </FormControl>
+                          <div>
+                            <FormLabel>This is a reimbursement</FormLabel>
+                          </div>
+                        </FormItem>
+                      )}
+                    />
+                  )}
                 </FormItem>
               )}
             />

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -63,14 +63,12 @@ export type Props = {
 
 const enforceCurrencyPattern = (value: string) =>
   value
-    // replace first comma with #
-    .replace(/[.,]/, '#')
-    // remove all other commas
-    .replace(/[.,]/g, '')
-    // change back # to dot
-    .replace(/#/, '.')
-    // remove all non-numeric and non-dot characters
-    .replace(/[^\d.]/g, '')
+    .replace(/^\s*-/, '_') // replace leading minus with _
+    .replace(/[.,]/, '#') // replace first comma with #
+    .replace(/[-.,]/g, '') // remove other minus and commas characters
+    .replace(/_/, '-') // change back _ to minus
+    .replace(/#/, '.') // change back # to dot
+    .replace(/[^-\d.]/g, '') // remove all non-numeric characters
 
 const getDefaultSplittingOptions = (group: Props['group']) => {
   const defaultValue = {

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -244,7 +244,7 @@ export function ExpenseForm({
 
   const [isIncome, setIsIncome] = useState(Number(form.getValues().amount) < 0)
   const sExpense = isIncome ? 'income' : 'expense'
-  const sPaid = isIncome ? 'received' : 'payed'
+  const sPaid = isIncome ? 'received' : 'paid'
 
   return (
     <Form {...form}>

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -62,7 +62,7 @@ export const expenseFormSchema = z
         ],
         { required_error: 'You must enter an amount.' },
       )
-      .refine((amount) => amount >= 1, 'The amount must be higher than 0.01.')
+      .refine((amount) => amount != 1, 'The amount must not be zero.')
       .refine(
         (amount) => amount <= 10_000_000_00,
         'The amount must be lower than 10,000,000.',


### PR DESCRIPTION
A feature which I don't need very often, but dearly miss when I need it, is to **enter a group income**.

Imagine a flight you paid for your trip with Jane and Jack gets cancelled. You are receiving $90 refund from the booking agency on behalf of the group. How would you enter that?

- What I did was to enter 2 reimbursements with $30 each: "Jane --> yourself" and "Jack --> yourself". This is not only ugly and weird (calculate splits and record cash flows in the opposite direction) but also wrong: The total group balance is not reduced by $90 as ist should be.

- Another option would be to remove the original expense completely. But this is also wrong because it messes with the transaction history.

Adding a proper income is actually very simple. It's just an **expense with a negative amount**!

In this PR I am adding it as a hidden feature, because it might confuse people or someone might not like it. To enter an income just write a negative value into the amount field. The UI clearly reflects this by replacing "expense" with "income" and "paid" with "received":

<img width="773" alt="Screenshot 2024-05-29 at 15 51 15" src="https://github.com/spliit-app/spliit/assets/22676812/7e6fb2b2-a9d5-45ba-a446-eebeed99a23b">

An Income in the expenses list has a negative value and the description starts with "Received by ...":

<img width="773" alt="Screenshot 2024-05-29 at 15 50 50" src="https://github.com/spliit-app/spliit/assets/22676812/9c711c32-4e36-4a10-9f0d-05b8063ab9c7">

All splits and balance calculations remain unaffected.
