### PR TITLE
categorisation via locally hosted llm service such as ollama

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "next-s3-upload": "^0.3.4",
         "next-themes": "^0.2.1",
         "next13-progressbar": "^1.1.1",
+        "node-fetch": "^2.6.7",
         "openai": "^4.25.0",
         "pg": "^8.11.3",
         "prisma": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "next-s3-upload": "^0.3.4",
     "next-themes": "^0.2.1",
     "next13-progressbar": "^1.1.1",
+    "node-fetch": "^2.6.7",
     "openai": "^4.25.0",
     "pg": "^8.11.3",
     "prisma": "^5.7.0",

--- a/src/components/expense-form-actions.tsx
+++ b/src/components/expense-form-actions.tsx
@@ -2,26 +2,28 @@
 import { getCategories } from '@/lib/api'
 import { env } from '@/lib/env'
 import { formatCategoryForAIPrompt } from '@/lib/utils'
+import fetch from 'node-fetch'
 import OpenAI from 'openai'
 import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/index.mjs'
 
-const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY })
+const openai = env.OPENAI_API_KEY
+  ? new OpenAI({ apiKey: env.OPENAI_API_KEY })
+  : null
 
 /** Limit of characters to be evaluated. May help avoiding abuse when using AI. */
 const limit = 40 // ~10 tokens
 
-/**
- * Attempt extraction of category from expense title
- * @param description Expense title or description. Only the first characters as defined in {@link limit} will be used.
- */
-export async function extractCategoryFromTitle(description: string) {
-  'use server'
-  const categories = await getCategories()
-
-  const body: ChatCompletionCreateParamsNonStreaming = {
-    model: 'gpt-3.5-turbo',
-    temperature: 0.1, // try to be highly deterministic so that each distinct title may lead to the same category every time
-    max_tokens: 1, // category ids are unlikely to go beyond ~4 digits so limit possible abuse
+function getChatCompletionParams(
+  categories: NonNullable<Awaited<ReturnType<typeof getCategories>>>,
+  description: string,
+  model: string,
+  temperature: number,
+  max_tokens: number,
+): ChatCompletionCreateParamsNonStreaming {
+  return {
+    model: model,
+    temperature: temperature,
+    max_tokens: max_tokens,
     messages: [
       {
         role: 'system',
@@ -42,11 +44,51 @@ export async function extractCategoryFromTitle(description: string) {
       },
     ],
   }
-  const completion = await openai.chat.completions.create(body)
-  const messageContent = completion.choices.at(0)?.message.content
+}
+
+/**
+ * Attempt extraction of category from expense title
+ * @param description Expense title or description. Only the first characters as defined in {@link limit} will be used.
+ */
+export async function extractCategoryFromTitle(description: string) {
+  'use server'
+  const categories = await getCategories()
+
+  const model = env.OPENAI_API_KEY ? 'gpt-3.5-turbo' : env.LOCAL_AI_MODEL ?? ''
+  const temperature = 0.1 // try to be highly deterministic so that each distinct title may lead to the same category every time
+  const max_tokens = 1 // category ids are unlikely to go beyond ~4 digits so limit possible abuse
+
+  const body: ChatCompletionCreateParamsNonStreaming = getChatCompletionParams(
+    categories,
+    description,
+    model,
+    temperature,
+    max_tokens,
+  )
+
+  let categoryId = 0
+
+  if (env.OPENAI_API_KEY) {
+    const completion = await openai!.chat.completions.create(body)
+    categoryId = Number(completion.choices.at(0)?.message.content)
+  } else if (env.LOCAL_AI_URL) {
+    // We're using the local URL
+    const response = await fetch(env.LOCAL_AI_URL!, {
+      method: 'post',
+      body: JSON.stringify({
+        model: body.model,
+        messages: body.messages,
+        stream: false,
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const data = await response.json()
+    categoryId = Number(data.message.content)
+  }
+
   // ensure the returned id actually exists
   const category = categories.find((category) => {
-    return category.id === Number(messageContent)
+    return category.id === categoryId
   })
   // fall back to first category (should be "General") if no category matches the output
   return { categoryId: category?.id || 0 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -35,6 +35,8 @@ const envSchema = z
       z.boolean().default(false),
     ),
     OPENAI_API_KEY: z.string().optional(),
+    LOCAL_AI_URL: z.string().optional(),
+    LOCAL_AI_MODEL: z.string().optional(),
   })
   .superRefine((env, ctx) => {
     if (
@@ -54,7 +56,8 @@ const envSchema = z
     if (
       (env.NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT ||
         env.NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT) &&
-      !env.OPENAI_API_KEY
+      !env.OPENAI_API_KEY &&
+      !(env.LOCAL_AI_MODEL && env.LOCAL_AI_URL)
     ) {
       ctx.addIssue({
         code: ZodIssueCode.custom,


### PR DESCRIPTION
Adding support to use a non-chatGPT service for category extract from title.

Added LOCAL_AI_MODEL and LOCAL_AI_URL env variables, e.g.:

```
NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT=true
LOCAL_AI_MODEL=llama3
LOCAL_AI_URL=http://127.0.0.1:11434/api/chat
```

When set, the messages are sent to this service instead of OpenAI/ChatGPT
