### PR TITLE
Do not remove just created Docker image

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -8,5 +8,3 @@ docker buildx build \
     -t ${SPLIIT_APP_NAME}:${SPLIIT_VERSION} \
     -t ${SPLIIT_APP_NAME}:latest \
     .
-
-docker image prune -f


### PR DESCRIPTION
`docker image prune -f` command removes just created `spliit2` Docker image. We probably want to keep the image.

Fixes #151 