### PR TITLE
Group form: floppy disk icon removed

### DIFF
--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -34,7 +34,7 @@ import {
 import { getGroup } from '@/lib/api'
 import { GroupFormValues, groupFormSchema } from '@/lib/schemas'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Save, Trash2 } from 'lucide-react'
+import { Trash2 } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
@@ -289,7 +289,7 @@ export function GroupForm({
             loadingContent={group ? 'Saving…' : 'Creating…'}
             onClick={updateActiveUser}
           >
-            <Save className="w-4 h-4 mr-2" /> {group ? <>Save</> : <> Create</>}
+            {group ? <>Save</> : <> Create</>}
           </SubmitButton>
           {!group && (
             <Button variant="ghost" asChild>


### PR DESCRIPTION
* floppy disk is not a modern icon
* some users might associate floppy disk icon to saving data to a local device but here we are saving data in cloud
* no icon needed, coloring indicates it is the submit button
* if save button has an icon, then cancel button should have also for symmetry

Refers #132 