### PR TITLE
Use unique name for postgres container

### DIFF
--- a/scripts/start-local-db.sh
+++ b/scripts/start-local-db.sh
@@ -1,4 +1,4 @@
-result=$(docker ps | grep postgres)
+result=$(docker ps | grep spliit-db)
 if [ $? -eq 0 ];
 then
     echo "postgres is already running, doing nothing"
@@ -6,6 +6,6 @@ else
     echo "postgres is not running, starting it"
     docker rm postgres --force
     mkdir -p postgres-data
-    docker run --name postgres -d -p 5432:5432 -e POSTGRES_PASSWORD=1234 -v "/$(pwd)/postgres-data:/var/lib/postgresql/data" postgres
+    docker run --name spliit-db -d -p 5432:5432 -e POSTGRES_PASSWORD=1234 -v "/$(pwd)/postgres-data:/var/lib/postgresql/data" postgres
     sleep 5 # Wait for postgres to start
 fi


### PR DESCRIPTION
I wondered why this script gave me `postgres is already running, doing nothing`. It was because another project was already running a container with `postgres` in its name.

Using more unique name like `spliit-db` solved the issue. Using `spliit-db` makes it clear which project is using this container when making `docker ps`.