### PR TITLE
feat: add auto-balancing for the amount edit

### DIFF
--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -46,7 +46,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { Save } from 'lucide-react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { match } from 'ts-pattern'
 import { DeletePopup } from './delete-popup'
@@ -245,8 +245,77 @@ export function ExpenseForm({
   }
 
   const [isIncome, setIsIncome] = useState(Number(form.getValues().amount) < 0)
+  const [manuallyEditedParticipants, setManuallyEditedParticipants] = useState<
+    Set<string>
+  >(new Set())
+
   const sExpense = isIncome ? 'income' : 'expense'
   const sPaid = isIncome ? 'received' : 'paid'
+
+  useEffect(() => {
+    setManuallyEditedParticipants(new Set())
+    const newPaidFor = defaultSplittingOptions.paidFor.map((participant) => ({
+      ...participant,
+      shares: String(participant.shares) as unknown as number,
+    }))
+    form.setValue('paidFor', newPaidFor, { shouldValidate: true })
+  }, [form.watch('splitMode')])
+
+  useEffect(() => {
+    const totalAmount = Number(form.getValues().amount) || 0
+    const paidFor = form.getValues().paidFor
+    const splitMode = form.getValues().splitMode
+
+    let newPaidFor = [...paidFor]
+
+    if (
+      splitMode === 'EVENLY' ||
+      splitMode === 'BY_SHARES' ||
+      splitMode === 'BY_PERCENTAGE'
+    ) {
+      return
+    } else {
+      // Only process auto-balancing for split mode amount
+      const editedParticipants = Array.from(manuallyEditedParticipants)
+      let remainingAmount = totalAmount
+      let remainingParticipants = newPaidFor.length - editedParticipants.length
+
+      newPaidFor = newPaidFor.map((participant) => {
+        if (editedParticipants.includes(participant.participant)) {
+          const participantShare = Number(participant.shares) || 0
+          if (splitMode === 'BY_AMOUNT') {
+            remainingAmount -= participantShare
+          }
+          return participant
+        }
+        return participant
+      })
+
+      if (remainingParticipants > 0) {
+        let amountPerRemaining = 0
+        if (splitMode === 'BY_AMOUNT') {
+          amountPerRemaining = remainingAmount / remainingParticipants
+        }
+
+        newPaidFor = newPaidFor.map((participant) => {
+          if (!editedParticipants.includes(participant.participant)) {
+            return {
+              ...participant,
+              shares: String(
+                Number(amountPerRemaining.toFixed(2)),
+              ) as unknown as number,
+            }
+          }
+          return participant
+        })
+      }
+      form.setValue('paidFor', newPaidFor, { shouldValidate: true })
+    }
+  }, [
+    manuallyEditedParticipants,
+    form.watch('amount'),
+    form.watch('splitMode'),
+  ])
 
   return (
     <Form {...form}>
@@ -570,7 +639,7 @@ export function ExpenseForm({
                                                   participant === id,
                                               )?.shares
                                             }
-                                            onChange={(event) =>
+                                            onChange={(event) => {
                                               field.onChange(
                                                 field.value.map((p) =>
                                                   p.participant === id
@@ -584,7 +653,10 @@ export function ExpenseForm({
                                                     : p,
                                                 ),
                                               )
-                                            }
+                                              setManuallyEditedParticipants(
+                                                (prev) => new Set(prev).add(id),
+                                              )
+                                            }}
                                             inputMode={
                                               form.getValues().splitMode ===
                                               'BY_AMOUNT'

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -259,7 +259,7 @@ export function ExpenseForm({
       shares: String(participant.shares) as unknown as number,
     }))
     form.setValue('paidFor', newPaidFor, { shouldValidate: true })
-  }, [form.watch('splitMode')])
+  }, [form.watch('splitMode'), form.watch('amount')])
 
   useEffect(() => {
     const totalAmount = Number(form.getValues().amount) || 0
@@ -275,7 +275,7 @@ export function ExpenseForm({
     ) {
       return
     } else {
-      // Only process auto-balancing for split mode amount
+      // Only auto-balance for split mode 'Unevenly - By amount'
       const editedParticipants = Array.from(manuallyEditedParticipants)
       let remainingAmount = totalAmount
       let remainingParticipants = newPaidFor.length - editedParticipants.length


### PR DESCRIPTION
Somewhat related issue: #150 

## Motivation
Very recently I migrated to Spliit from Tricount, and I am missing a feature which I have found very useful when adding shared expenses. 

This occurs for example, when a statement contains a personal purchase which I only want to incur on myself, and I want the rest to be shared evenly.

## Solution

__Example__: I have a shared expense of 20€, and I want to incur a 3€ purchase only to myself and divide the rest evenly.
- In this case when the total is given, the form divides it evenly with participants by default. 
- To achieve the this, I deduct my expense of the total, divide it by the amount of participants, and then add my expense back to my own part.
    - For 4 participants, the process looks like the following:
        - $\frac{Total(€) - Personal(€)}{Participants(n)} + Personal(€)\ \rightarrow \ \frac{20-3}{4} + 3 = 7.25$
        - Then this value can be input to according row, and the rest are allocated automatically (as `4.25 €`)



To avoid errors and provide intuitive balancing on multiple participants, the autobalance occurs only on the participants, whose rows have not yet been edited.

## Issues and ideas

- This implementation does not automatically allocate a surplus/remaining cent on uneven totals, though whether this should even be automatic, is another discussion.

- My implementation reflects how I have worked with expense systems in the past, it works fine when you have the necessary amounts already calculated or arbitrarily given, but its not as intuitive as the proposal in the issue. It quickly becomes obvious that manually calculating these type of expenses is cumbersome. Despite this, I find that my solution is better than none at all
    - If wanted/necessary, I can try improve this later on, to match the behaviour of the issue.

- More so related to the existing default splitting options:
    - For example when `15` and `12` shares is selected and defaulted, this carries over to other split modes. My implementation overrides this behaviour on the amount split, but this remains for example on the percentages, where you end up with `15%` and `12%` in the mentioned situation.







