### PR TITLE
Increase fuzzines of search results

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -4,6 +4,7 @@ import { getGroupExpensesAction } from '@/app/groups/[groupId]/expenses/expense-
 import { Button } from '@/components/ui/button'
 import { SearchBar } from '@/components/ui/search-bar'
 import { Skeleton } from '@/components/ui/skeleton'
+import { normalizeString } from '@/lib/utils'
 import { Participant } from '@prisma/client'
 import dayjs, { type Dayjs } from 'dayjs'
 import Link from 'next/link'
@@ -134,13 +135,13 @@ export function ExpenseList({
 
   return expenses.length > 0 ? (
     <>
-      <SearchBar onValueChange={(value) => setSearchText(value)} />
+      <SearchBar onValueChange={(value) => setSearchText(normalizeString(value))} />
       {Object.values(EXPENSE_GROUPS).map((expenseGroup: string) => {
         let groupExpenses = groupedExpensesByDate[expenseGroup]
         if (!groupExpenses) return null
 
         groupExpenses = groupExpenses.filter(({ title }) =>
-          title.toLowerCase().includes(searchText.toLowerCase()),
+          normalizeString(title).includes(searchText),
         )
 
         if (groupExpenses.length === 0) return null

--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -135,7 +135,9 @@ export function ExpenseList({
 
   return expenses.length > 0 ? (
     <>
-      <SearchBar onValueChange={(value) => setSearchText(normalizeString(value))} />
+      <SearchBar
+        onValueChange={(value) => setSearchText(normalizeString(value))}
+      />
       {Object.values(EXPENSE_GROUPS).map((expenseGroup: string) => {
         let groupExpenses = groupedExpensesByDate[expenseGroup]
         if (!groupExpenses) return null

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -48,3 +48,10 @@ export function formatFileSize(size: number) {
   if (size > 1024) return `${formatNumber(size / 1024)} kB`
   return `${formatNumber(size)} B`
 }
+
+export function normalizeString(input: string): string {
+  // Replaces special characters
+  // Input: áäåèéę
+  // Output: aaaeee
+  return input.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -53,5 +53,8 @@ export function normalizeString(input: string): string {
   // Replaces special characters
   // Input: áäåèéę
   // Output: aaaeee
-  return input.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  return input
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
 }


### PR DESCRIPTION
This is the PR to solve the issue #185 

The PR introduces a `normalizeString` function, which it is used on the `SearchBar` to allow more expenses to be found without an exact match.

**Current Behavior**
Expense entry with title "Park Güell". When Search content is `guell` the expense is not found since `u` is not included in `ü`.

**New Behavior**
Expense entry with title "Park Güell". When Search content is `guell` the expense is found since the function removes all special characters from both search input and expense. ("Park Güell" becoming "park guell")