### PR TITLE
Update splitMode selection

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -177,11 +177,22 @@
     "advancedOptions": "Advanced splitting options…",
     "SplitModeField": {
       "label": "Split mode",
-      "evenly": "Evenly",
-      "byShares": "Unevenly – By shares",
-      "byPercentage": "Unevenly – By percentage",
-      "byAmount": "Unevenly – By amount",
-      "saveAsDefault": "Save as default splitting options"
+      "evenly": {
+        "label": "Evenly",
+        "description": "Split the amount evenly between all participants."
+      },
+      "byShares": {
+        "label": "By shares",
+        "description": "Split the amount based on the shares."
+      },
+      "byPercentage": {
+        "label": "By percentage",
+        "description": "Split the amount based on the percentage."
+      },
+      "byAmount": {
+        "label": "By amount",
+        "description": "Split the amount exactly between all participants."
+      }
     },
     "DeletePopup": {
       "label": "Delete",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -177,11 +177,22 @@
     "advancedOptions": "Lisäasetuksia jakamiseen…",
     "SplitModeField": {
       "label": "Jakamistapa",
-      "evenly": "Tasan",
-      "byShares": "Epätasan – osuuksien mukaan",
-      "byPercentage": "Epätasan – prosenttien mukaan",
-      "byAmount": "Epätasan – summan mukaan",
-      "saveAsDefault": "Tallenna oletustavaksi"
+      "evenly": {
+        "label": "Tasan",
+        "description": "Split the amount evenly between all participants."
+      },
+      "byShares": {
+        "label": "Osuuksien mukaan",
+        "description": "Split the amount based on the shares."
+      },
+      "byPercentage": {
+        "label": "Prosenttien mukaan",
+        "description": "Split the amount based on the percentage."
+      },
+      "byAmount": {
+        "label": "Summan mukaan",
+        "description": "Split the amount exactly between all participants."
+      }
     },
     "DeletePopup": {
       "label": "Poista",

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -92,7 +92,6 @@ export const expenseFormSchema = z
         Object.values(SplitMode) as any,
       )
       .default('EVENLY'),
-    saveDefaultSplittingOptions: z.boolean(),
     isReimbursement: z.boolean(),
     documents: z
       .array(


### PR DESCRIPTION
This PR updates the split mode selection to a tab-like element so users can change the mode with one click. 

If this was the reason for persisting the default mode, it is now unnecessary and therefore deleted.

![screen](https://github.com/user-attachments/assets/6295790d-dadf-4148-9707-3c9def035adb)
