### PR TITLE
Fix: Correctly display loaded expense

### DIFF
--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -256,20 +256,18 @@ export function ExpenseForm({
   }, [form.watch('splitMode'), form.watch('amount')])
 
   useEffect(() => {
-    const totalAmount = Number(form.getValues().amount) || 0
-    const paidFor = form.getValues().paidFor
     const splitMode = form.getValues().splitMode
 
-    let newPaidFor = [...paidFor]
-
+    // Only auto-balance for split mode 'Unevenly - By amount'
     if (
-      splitMode === 'EVENLY' ||
-      splitMode === 'BY_SHARES' ||
-      splitMode === 'BY_PERCENTAGE'
+      splitMode === 'BY_AMOUNT' &&
+      (form.getFieldState('paidFor').isDirty ||
+        form.getFieldState('amount').isDirty)
     ) {
-      return
-    } else {
-      // Only auto-balance for split mode 'Unevenly - By amount'
+      const totalAmount = Number(form.getValues().amount) || 0
+      const paidFor = form.getValues().paidFor
+      let newPaidFor = [...paidFor]
+
       const editedParticipants = Array.from(manuallyEditedParticipants)
       let remainingAmount = totalAmount
       let remainingParticipants = newPaidFor.length - editedParticipants.length

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -253,11 +253,6 @@ export function ExpenseForm({
 
   useEffect(() => {
     setManuallyEditedParticipants(new Set())
-    const newPaidFor = defaultSplittingOptions.paidFor.map((participant) => ({
-      ...participant,
-      shares: String(participant.shares) as unknown as number,
-    }))
-    form.setValue('paidFor', newPaidFor, { shouldValidate: true })
   }, [form.watch('splitMode'), form.watch('amount')])
 
   useEffect(() => {
@@ -569,18 +564,29 @@ export function ExpenseForm({
                                     ({ participant }) => participant === id,
                                   )}
                                   onCheckedChange={(checked) => {
-                                    return checked
-                                      ? field.onChange([
-                                          ...field.value,
-                                          {
-                                            participant: id,
-                                            shares: '1',
-                                          },
-                                        ])
-                                      : field.onChange(
+                                    const options = {
+                                      shouldDirty: true,
+                                      shouldTouch: true,
+                                      shouldValidate: true,
+                                    }
+                                    checked
+                                      ? form.setValue(
+                                          'paidFor',
+                                          [
+                                            ...field.value,
+                                            {
+                                              participant: id,
+                                              shares: '1' as unknown as number,
+                                            },
+                                          ],
+                                          options,
+                                        )
+                                      : form.setValue(
+                                          'paidFor',
                                           field.value?.filter(
                                             (value) => value.participant !== id,
                                           ),
+                                          options,
                                         )
                                   }}
                                 />


### PR DESCRIPTION
- Don't load default split options after displaying an existing expense
- Re-validate form after changing the "paidFor" selection. 
  This fixes the error message "The expense must be paid for at least one participant." after clicking "Select None" and the selecting one participant.