### PR TITLE
Fix missing translation for expense title for reinbursement in expense-form

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -203,7 +203,8 @@
     "creating": "Erstellt…",
     "save": "Speichern",
     "saving": "Speichert…",
-    "cancel": "Abbrechen"
+    "cancel": "Abbrechen",
+    "reimbursement": "Rückzahlung"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -203,7 +203,8 @@
     "creating": "Creating…",
     "save": "Save",
     "saving": "Saving…",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "reimbursement": "Reimbursement"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -203,7 +203,9 @@
     "creating": "Creando",
     "save": "Guardar",
     "saving": "Guardando",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "reimbursement": "Reembolso"
+
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -203,7 +203,8 @@
     "creating": "Luodaan kulua…",
     "save": "Tallenna",
     "saving": "Tallennetaan…",
-    "cancel": "Peruuta"
+    "cancel": "Peruuta",
+    "reimbursement": "Velanmaksu"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -203,7 +203,8 @@
     "creating": "Création…",
     "save": "Sauvegarder",
     "saving": "Sauvegarde…",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "reimbursement": "Remboursement"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -203,7 +203,8 @@
     "creating": "Sto creando…",
     "save": "Salva",
     "saving": "Sto salvando…",
-    "cancel": "Annulla"
+    "cancel": "Annulla",
+    "reimbursement": "Rimborso"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -203,7 +203,8 @@
     "creating": "Создание…",
     "save": "Сохранить",
     "saving": "Сохранение…",
-    "cancel": "Отмена"
+    "cancel": "Отмена",
+    "reimbursement": "Возмещение"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/ua-UA.json
+++ b/messages/ua-UA.json
@@ -203,7 +203,8 @@
     "creating": "Створення..",
     "save": "Зберегти",
     "saving": "Збереження..",
-    "cancel": "Скасувати"
+    "cancel": "Скасувати",
+    "reimbursement": "Відшкодування"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -203,7 +203,8 @@
     "creating": "创建中……",
     "save": "保存",
     "saving": "保存中……",
-    "cancel": "取消"
+    "cancel": "取消",
+    "reimbursement": "报销"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -186,7 +186,7 @@ export function ExpenseForm({
         }
       : searchParams.get('reimbursement')
       ? {
-          title: 'Reimbursement',
+          title: t('reimbursement'),
           expenseDate: new Date(),
           amount: String(
             (Number(searchParams.get('amount')) || 0) / 100,


### PR DESCRIPTION
This pull request adds a translation for the word "Reimbursement" used as a title in the expense form, when marking suggested reimbursements as paid.
The translation has been added to all languages supported in the main branch as of today (10.14.24).
This includes:

- english
- finnish
- french
- spanish
- german
- chinese
- russian
- italian
- ukrainian

This change improves the localization of the application and provides a better user experience for speakers of these languages.