### PR TITLE
Feature: Default currency symbol

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 POSTGRES_PRISMA_URL=postgresql://postgres:1234@localhost
 POSTGRES_URL_NON_POOLING=postgresql://postgres:1234@localhost
+
+NEXT_PUBLIC_DEFAULT_CURRENCY_SYMBOL=""

--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -39,6 +39,7 @@ import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
 import { Textarea } from './ui/textarea'
+import { env } from '@/lib/env'
 
 export type Props = {
   group?: NonNullable<Awaited<ReturnType<typeof getGroup>>>
@@ -59,21 +60,21 @@ export function GroupForm({
     resolver: zodResolver(groupFormSchema),
     defaultValues: group
       ? {
-          name: group.name,
-          information: group.information ?? '',
-          currency: group.currency,
-          participants: group.participants,
-        }
+        name: group.name,
+        information: group.information ?? '',
+        currency: group.currency,
+        participants: group.participants,
+      }
       : {
-          name: '',
-          information: '',
-          currency: '',
-          participants: [
-            { name: t('Participants.John') },
-            { name: t('Participants.Jane') },
-            { name: t('Participants.Jack') },
-          ],
-        },
+        name: '',
+        information: '',
+        currency: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY_SYMBOL || '',
+        participants: [
+          { name: t('Participants.John') },
+          { name: t('Participants.Jane') },
+          { name: t('Participants.Jack') },
+        ],
+      },
   })
   const { fields, append, remove } = useFieldArray({
     control: form.control,
@@ -113,7 +114,7 @@ export function GroupForm({
           await onSubmit(
             values,
             group?.participants.find((p) => p.name === activeUser)?.id ??
-              undefined,
+            undefined,
           )
         })}
       >
@@ -213,7 +214,7 @@ export function GroupForm({
                               placeholder={t('Participants.new')}
                             />
                             {item.id &&
-                            protectedParticipantIds.includes(item.id) ? (
+                              protectedParticipantIds.includes(item.id) ? (
                               <HoverCard>
                                 <HoverCardTrigger>
                                   <Button

--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -39,7 +39,6 @@ import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
 import { Textarea } from './ui/textarea'
-import { env } from '@/lib/env'
 
 export type Props = {
   group?: NonNullable<Awaited<ReturnType<typeof getGroup>>>
@@ -60,21 +59,21 @@ export function GroupForm({
     resolver: zodResolver(groupFormSchema),
     defaultValues: group
       ? {
-        name: group.name,
-        information: group.information ?? '',
-        currency: group.currency,
-        participants: group.participants,
-      }
+          name: group.name,
+          information: group.information ?? '',
+          currency: group.currency,
+          participants: group.participants,
+        }
       : {
-        name: '',
-        information: '',
-        currency: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY_SYMBOL || '',
-        participants: [
-          { name: t('Participants.John') },
-          { name: t('Participants.Jane') },
-          { name: t('Participants.Jack') },
-        ],
-      },
+          name: '',
+          information: '',
+          currency: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY_SYMBOL || '',
+          participants: [
+            { name: t('Participants.John') },
+            { name: t('Participants.Jane') },
+            { name: t('Participants.Jack') },
+          ],
+        },
   })
   const { fields, append, remove } = useFieldArray({
     control: form.control,
@@ -114,7 +113,7 @@ export function GroupForm({
           await onSubmit(
             values,
             group?.participants.find((p) => p.name === activeUser)?.id ??
-            undefined,
+              undefined,
           )
         })}
       >
@@ -214,7 +213,7 @@ export function GroupForm({
                               placeholder={t('Participants.new')}
                             />
                             {item.id &&
-                              protectedParticipantIds.includes(item.id) ? (
+                            protectedParticipantIds.includes(item.id) ? (
                               <HoverCard>
                                 <HoverCardTrigger>
                                   <Button

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -21,6 +21,7 @@ const envSchema = z
       interpretEnvVarAsBool,
       z.boolean().default(false),
     ),
+    NEXT_PUBLIC_DEFAULT_CURRENCY_SYMBOL: z.string().optional(),
     S3_UPLOAD_KEY: z.string().optional(),
     S3_UPLOAD_SECRET: z.string().optional(),
     S3_UPLOAD_BUCKET: z.string().optional(),


### PR DESCRIPTION
In this PR I´ve added a env parameter that can be used to define a default currency symbol on group creation. The symbol can still be changed on creation by inserting another symbol into the input field.

The following variables were added:

| VAR name   |      Default      |  Description |
|----------|:-------------|------|
| NEXT_PUBLIC_DEFAULT_CURRENCY_SYMBOL |  none | This parameter can be used to define a default currency symbol that will be used on group creation. |

ToDo:
Currently the env var is defined directly via `currency: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY_SYMBOL || '',` and not via the env.ts file. It is working fine, but we are missing the validation of zod. I wasn´t able to define the variable via the env.ts file, because some of the vars are missing on the clientside. Maybe we will have to seperate this config file or is there any other solution of doing this?