### PR TITLE
Spliit's version in the footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spliit2",
-  "version": "0.1.0",
+  "version": "1.14.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Suspense } from 'react'
 import './globals.css'
+import { version } from '../../package.json'
 
 export const metadata: Metadata = {
   metadataBase: new URL(env.NEXT_PUBLIC_BASE_URL),
@@ -141,6 +142,7 @@ function Content({ children }: { children: React.ReactNode }) {
             </span>
           </div>
         </div>
+        <div className='flex absolute bottom-0 right-0'>{version}</div>
       </footer>
       <Toaster />
     </TRPCProvider>


### PR DESCRIPTION
Hi,

This pull request will adding a simple badge for version in the footer of project in order to display what version is using.
The version is get from `package.json`.

Each new version of the project will need to update the `package.json` with a version value.

![immagine](https://github.com/user-attachments/assets/9aecaac1-13f3-4fc0-9061-ddf5f6ed86c8)
