### PR TITLE
Add recurring expense functionality

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -136,6 +136,15 @@
         "label": "Empfangen von",
         "description": "Wähle das Mitglied, das die Einnahme erhalten hat."
       },
+      "recurrenceRule": {
+        "label": "Expense Recurrence",
+        "description": "Select how often the expense should repeat.",
+
+        "none": "None",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly"
+      },
       "paidFor": {
         "title": "Empfangen für",
         "description": "Wähle für wen die Einnahme empfangen wurde."

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -160,6 +160,15 @@
         "label": "Paid by",
         "description": "Select the participant who paid the expense."
       },
+      "recurrenceRule": {
+        "label": "Expense Recurrence",
+        "description": "Select how often the expense should recur.",
+
+        "none": "None",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly"
+      },
       "paidFor": {
         "title": "Paid for",
         "description": "Select who the expense was paid for."

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -162,7 +162,7 @@
       },
       "recurrenceRule": {
         "label": "Expense Recurrence",
-        "description": "Select how often the expense should recur.",
+        "description": "Select how often the expense should repeat.",
 
         "none": "None",
         "daily": "Daily",

--- a/messages/es.json
+++ b/messages/es.json
@@ -136,6 +136,15 @@
         "label": "Recibido por",
         "description": "Seleccione el participante que recibió los ingresos."
       },
+      "recurrenceRule": {
+        "label": "Expense Recurrence",
+        "description": "Select how often the expense should repeat.",
+
+        "none": "None",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly"
+      },
       "paidFor": {
         "title": "Recibido para for",
         "description": "Seleccione para quién se recibió el ingreso."

--- a/messages/es.json
+++ b/messages/es.json
@@ -137,13 +137,13 @@
         "description": "Seleccione el participante que recibió los ingresos."
       },
       "recurrenceRule": {
-        "label": "Expense Recurrence",
-        "description": "Select how often the expense should repeat.",
+        "label": "Recurrencia del gasto",
+        "description": "Seleccione con qué frecuencia debe repetirse el gasto.",
 
-        "none": "None",
-        "daily": "Daily",
-        "weekly": "Weekly",
-        "monthly": "Monthly"
+        "none": "Ninguno",
+        "daily": "Diario",
+        "weekly": "Semanal",
+        "monthly": "Mensual"
       },
       "paidFor": {
         "title": "Recibido para for",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -136,6 +136,15 @@
         "label": "Vastaanottaja",
         "description": "Valitse kuka vastaanotti tulon."
       },
+      "recurrenceRule": {
+        "label": "Expense Recurrence",
+        "description": "Select how often the expense should repeat.",
+
+        "none": "None",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly"
+      },
       "paidFor": {
         "title": "Tulon jakaminen",
         "description": "Valitse kenelle tulo jaetaan."

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -136,6 +136,15 @@
         "label": "Reçu par",
         "description": "Sélectionnez le participant qui a reçu le revenu."
       },
+      "recurrenceRule": {
+        "label": "Expense Recurrence",
+        "description": "Select how often the expense should repeat.",
+
+        "none": "None",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly"
+      },
       "paidFor": {
         "title": "Reçu pour",
         "description": "Sélectionnez pour qui le revenu a été reçu."

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -136,6 +136,15 @@
         "label": "Ricevuto da",
         "description": "Seleziona partecipante che ha ricevuto l'entrata."
       },
+      "recurrenceRule": {
+        "label": "Expense Recurrence",
+        "description": "Select how often the expense should repeat.",
+
+        "none": "None",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly"
+      },
       "paidFor": {
         "title": "Ricevuto per",
         "description": "Seleziona per chi è stato ricevuta l'entrata."

--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -136,6 +136,15 @@
         "label": "Otrzymane przez",
         "description": "Wybierz członka, który otrzymał wpływ."
       },
+      "recurrenceRule": {
+        "label": "Expense Recurrence",
+        "description": "Select how often the expense should repeat.",
+
+        "none": "None",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly"
+      },
       "paidFor": {
         "title": "Otrzymany dla",
         "description": "Podaj dla kogo wpływ był przeznaczony."

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -127,6 +127,15 @@
         "placeholder": "Cina de luni seară",
         "description": "Adaugă o descriere pentru venit."
       },
+      "recurrenceRule": {
+        "label": "Expense Recurrence",
+        "description": "Select how often the expense should repeat.",
+
+        "none": "None",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly"
+      },
       "DateField": {
         "label": "Data venitului",
         "description": "Adaugă data la care venitul a fost primit."

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -136,6 +136,15 @@
         "label": "Получивший",
         "description": "Выберите участника, который получил этот доход."
       },
+      "recurrenceRule": {
+        "label": "Expense Recurrence",
+        "description": "Select how often the expense should repeat.",
+
+        "none": "None",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly"
+      },
       "paidFor": {
         "title": "Участники",
         "description": "Выберите тех, между кем этот доход будет распределен."

--- a/messages/ua-UA.json
+++ b/messages/ua-UA.json
@@ -136,6 +136,15 @@
         "label": "Отримав",
         "description": "Оберіть учасника, який отримав дохід"
       },
+      "recurrenceRule": {
+        "label": "Expense Recurrence",
+        "description": "Select how often the expense should repeat.",
+
+        "none": "None",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly"
+      },
       "paidFor": {
         "title": "Учасники",
         "description": "Виберіть тих, між ким цей дохід буде розподілено"

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -136,6 +136,15 @@
         "label": "接收到",
         "description": "选择接收到这笔收入的群组成员。"
       },
+      "recurrenceRule": {
+        "label": "Expense Recurrence",
+        "description": "Select how often the expense should repeat.",
+
+        "none": "None",
+        "daily": "Daily",
+        "weekly": "Weekly",
+        "monthly": "Monthly"
+      },
       "paidFor": {
         "title": "接收给",
         "description": "选择收入是为谁而收。"

--- a/prisma/migrations/20241103205027_add_recurring_expenses/migration.sql
+++ b/prisma/migrations/20241103205027_add_recurring_expenses/migration.sql
@@ -1,0 +1,29 @@
+-- CreateEnum
+CREATE TYPE "RecurrenceRule" AS ENUM ('NONE', 'DAILY', 'WEEKLY', 'MONTHLY');
+
+-- AlterTable
+ALTER TABLE "Expense" ADD COLUMN     "recurrenceRule" "RecurrenceRule" DEFAULT 'NONE',
+ADD COLUMN     "recurringExpenseLinkId" TEXT;
+
+-- CreateTable
+CREATE TABLE "RecurringExpenseLink" (
+    "id" TEXT NOT NULL,
+    "groupId" TEXT NOT NULL,
+    "currentFrameExpenseId" TEXT NOT NULL,
+    "nextExpenseCreatedAt" TIMESTAMP(3),
+    "nextExpenseDate" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RecurringExpenseLink_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RecurringExpenseLink_currentFrameExpenseId_key" ON "RecurringExpenseLink"("currentFrameExpenseId");
+
+-- CreateIndex
+CREATE INDEX "RecurringExpenseLink_groupId_idx" ON "RecurringExpenseLink"("groupId");
+
+-- CreateIndex
+CREATE INDEX "RecurringExpenseLink_groupId_nextExpenseCreatedAt_nextExpen_idx" ON "RecurringExpenseLink"("groupId", "nextExpenseCreatedAt", "nextExpenseDate" DESC);
+
+-- AddForeignKey
+ALTER TABLE "RecurringExpenseLink" ADD CONSTRAINT "RecurringExpenseLink_currentFrameExpenseId_fkey" FOREIGN KEY ("currentFrameExpenseId") REFERENCES "Expense"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,9 +83,9 @@ model RecurringExpenseLink {
   currentFrameExpense Expense @relation(fields: [currentFrameExpenseId], references: [id], onDelete: Cascade)
   currentFrameExpenseId String @unique
 
-  // Note: I do not want to link to the next expense because once it is created, it will be treated as it's own 
-  // entity entirely. This means that if a user wants to delete an Expense and any related 
-  // recurring expenses, they'll need to delete them one by one
+  // Note: We do not want to link to the next expense because once it is created, it should be 
+  // treated as it's own independent entity. This means that if a user wants to delete an Expense
+  // and any prior related recurring expenses, they'll need to delete them one by one.
   nextExpenseCreatedAt DateTime?
   nextExpenseDate DateTime
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,10 @@ model Expense {
   createdAt       DateTime          @default(now())
   documents       ExpenseDocument[]
   notes           String?
+
+  recurrenceRule  RecurrenceRule?    @default(NONE)
+  recurringExpenseLink RecurringExpenseLink?
+  recurringExpenseLinkId String?
 }
 
 model ExpenseDocument {
@@ -71,6 +75,29 @@ enum SplitMode {
   BY_SHARES
   BY_PERCENTAGE
   BY_AMOUNT
+}
+
+model RecurringExpenseLink {
+  id String @id
+  groupId   String
+  currentFrameExpense Expense @relation(fields: [currentFrameExpenseId], references: [id], onDelete: Cascade)
+  currentFrameExpenseId String @unique
+
+  // Note: I do not want to link to the next expense because once it is created, it will be treated as it's own 
+  // entity entirely. This means that if a user wants to delete an Expense and any related 
+  // recurring expenses, they'll need to delete them one by one
+  nextExpenseCreatedAt DateTime?
+  nextExpenseDate DateTime
+
+  @@index([groupId])
+  @@index([groupId, nextExpenseCreatedAt, nextExpenseDate(sort: Desc)])
+}
+
+enum RecurrenceRule {
+  NONE
+  DAILY
+  WEEKLY
+  MONTHLY
 }
 
 model ExpensePaidFor {

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -213,7 +213,6 @@ export function ExpenseForm({
           saveDefaultSplittingOptions: false,
           documents: [],
           notes: '',
-          // TODO(trandall): Add this to the defaultSplittingOptions
           recurrenceRule: RecurrenceRule.NONE,
         }
       : {
@@ -242,7 +241,6 @@ export function ExpenseForm({
               ]
             : [],
           notes: '',
-          // TODO(trandall): Add this to the defaultSplittingOptions
           recurrenceRule: RecurrenceRule.NONE,
         },
   })
@@ -537,7 +535,7 @@ export function ExpenseForm({
                   <FormDescription>
                     {t(`${sExpense}.recurrenceRule.description`)}
                   </FormDescription>
-                  {/* <FormMessage /> */}
+                  <FormMessage />
                 </FormItem>
               )}
             />

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -53,6 +53,7 @@ import { match } from 'ts-pattern'
 import { DeletePopup } from '../../../../components/delete-popup'
 import { extractCategoryFromTitle } from '../../../../components/expense-form-actions'
 import { Textarea } from '../../../../components/ui/textarea'
+import { RecurrenceRule } from '@prisma/client'
 
 const enforceCurrencyPattern = (value: string) =>
   value
@@ -165,6 +166,10 @@ export function ExpenseForm({
     }
     return field?.value
   }
+
+  const getSelectedRecurrenceRule = (field?: { value: string }) => {
+    return field?.value as RecurrenceRule
+  }
   const defaultSplittingOptions = getDefaultSplittingOptions(group)
   const form = useForm<ExpenseFormValues>({
     resolver: zodResolver(expenseFormSchema),
@@ -184,6 +189,7 @@ export function ExpenseForm({
           isReimbursement: expense.isReimbursement,
           documents: expense.documents,
           notes: expense.notes ?? '',
+          recurrenceRule: expense.recurrenceRule,
         }
       : searchParams.get('reimbursement')
       ? {
@@ -207,6 +213,8 @@ export function ExpenseForm({
           saveDefaultSplittingOptions: false,
           documents: [],
           notes: '',
+          // TODO(trandall): Add this to the defaultSplittingOptions
+          recurrenceRule: RecurrenceRule.NONE,
         }
       : {
           title: searchParams.get('title') ?? '',
@@ -234,6 +242,8 @@ export function ExpenseForm({
               ]
             : [],
           notes: '',
+          // TODO(trandall): Add this to the defaultSplittingOptions
+          recurrenceRule: RecurrenceRule.NONE,
         },
   })
   const [isCategoryLoading, setCategoryLoading] = useState(false)
@@ -491,6 +501,43 @@ export function ExpenseForm({
                   <FormControl>
                     <Textarea className="text-base" {...field} />
                   </FormControl>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="recurrenceRule"
+              render={({ field }) => (
+                <FormItem className="sm:order-5">
+                  <FormLabel>{t(`${sExpense}.recurrenceRule.label`)}</FormLabel>
+                  <Select
+                    onValueChange={(value) => {
+                      form.setValue('recurrenceRule', value as RecurrenceRule)
+                    }}
+                    defaultValue={getSelectedRecurrenceRule(field)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="NONE"/>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="NONE">
+                        {t(`${sExpense}.recurrenceRule.none`)}
+                      </SelectItem>
+                      <SelectItem value="DAILY">
+                        {t(`${sExpense}.recurrenceRule.daily`)}
+                      </SelectItem>
+                      <SelectItem value="WEEKLY">
+                        {t(`${sExpense}.recurrenceRule.weekly`)}
+                      </SelectItem>
+                      <SelectItem value="MONTHLY">
+                        {t(`${sExpense}.recurrenceRule.monthly`)}
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    {t(`${sExpense}.recurrenceRule.description`)}
+                  </FormDescription>
+                  {/* <FormMessage /> */}
                 </FormItem>
               )}
             />

--- a/src/app/groups/[groupId]/expenses/export/json/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/json/route.ts
@@ -22,6 +22,7 @@ export async function GET(
           paidFor: { select: { participantId: true, shares: true } },
           isReimbursement: true,
           splitMode: true,
+          recurrenceRule: true,
         },
       },
       participants: { select: { id: true, name: true } },

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { ExpenseFormValues, GroupFormValues } from '@/lib/schemas'
-import { ActivityType, Expense } from '@prisma/client'
+import { ActivityType, Expense, RecurrenceRule, RecurringExpenseLink } from '@prisma/client'
 import { nanoid } from 'nanoid'
 
 export function randomId() {
@@ -50,6 +50,13 @@ export async function createExpense(
     data: expenseFormValues.title,
   })
 
+  let isCreateRecurrence = expenseFormValues.recurrenceRule !== RecurrenceRule.NONE
+  const recurringExpenseLinkPayload = createPayloadForNewRecurringExpenseLink(
+    expenseFormValues.recurrenceRule as RecurrenceRule,
+    expenseFormValues.expenseDate,
+    groupId
+  )
+
   return prisma.expense.create({
     data: {
       id: expenseId,
@@ -60,6 +67,16 @@ export async function createExpense(
       title: expenseFormValues.title,
       paidById: expenseFormValues.paidBy,
       splitMode: expenseFormValues.splitMode,
+      recurrenceRule: expenseFormValues.recurrenceRule,
+      recurringExpenseLink: {
+        ...(isCreateRecurrence
+          ? {
+              create: recurringExpenseLinkPayload
+            }
+          : {}
+          ),
+
+      },
       paidFor: {
         createMany: {
           data: expenseFormValues.paidFor.map((paidFor) => ({
@@ -95,6 +112,13 @@ export async function deleteExpense(
     expenseId,
     data: existingExpense?.title,
   })
+
+  // TODO(trandall): Add a popup (if the expense has a recurrence rule) to tell the user that deleting 
+  // this expense will cause any future recurring expenses not be created and the expenses will need 
+  // to be re-created
+  //
+  // Note: Because the the RecurringExpenseLink model was created with an `onDelete: Cascade` relation to
+  // Expenses, any related RecurringExpenseLinks will be deleted when an Expense is deleted
 
   await prisma.expense.delete({
     where: { id: expenseId },
@@ -152,6 +176,28 @@ export async function updateExpense(
     data: expenseFormValues.title,
   })
 
+  const isDeleteRecurrenceExpenseLink = 
+    existingExpense.recurrenceRule !== RecurrenceRule.NONE && 
+    expenseFormValues.recurrenceRule === RecurrenceRule.NONE &&
+    // Delete the existing RecurrenceExpenseLink only if it has not been acted upon yet
+    existingExpense.recurringExpenseLink?.nextExpenseCreatedAt === null
+
+  const isUpdateRecurrenceExpenseLink = existingExpense.recurrenceRule !== expenseFormValues.recurrenceRule
+  const isCreateRecurrenceExpenseLink = 
+    existingExpense.recurrenceRule === RecurrenceRule.NONE && 
+    expenseFormValues.recurrenceRule !== RecurrenceRule.NONE
+  
+  const newRecurringExpenseLink = createPayloadForNewRecurringExpenseLink(
+    expenseFormValues.recurrenceRule as RecurrenceRule,
+    expenseFormValues.expenseDate,
+    groupId
+  )
+
+  const updatedRecurrenceExpenseLinkNextExpenseDate = calculateNextDate(
+    expenseFormValues.recurrenceRule as RecurrenceRule,
+    existingExpense.expenseDate
+  )
+
   return prisma.expense.update({
     where: { id: expenseId },
     data: {
@@ -161,6 +207,7 @@ export async function updateExpense(
       categoryId: expenseFormValues.category,
       paidById: expenseFormValues.paidBy,
       splitMode: expenseFormValues.splitMode,
+      recurrenceRule: expenseFormValues.recurrenceRule,
       paidFor: {
         create: expenseFormValues.paidFor
           .filter(
@@ -190,6 +237,23 @@ export async function updateExpense(
               (pf) => pf.participant === paidFor.participantId,
             ),
         ),
+      },
+      recurringExpenseLink: {
+        ...(isCreateRecurrenceExpenseLink
+          ? {
+              create: newRecurringExpenseLink
+            }
+          : {}
+          ),
+        ...(isUpdateRecurrenceExpenseLink
+          ? {
+            update: {
+              nextExpenseDate: updatedRecurrenceExpenseLinkNextExpenseDate
+            }
+          }
+          : {}
+        ),
+        delete: isDeleteRecurrenceExpenseLink,
       },
       isReimbursement: expenseFormValues.isReimbursement,
       documents: {
@@ -269,6 +333,8 @@ export async function getGroupExpenses(
   groupId: string,
   options?: { offset?: number; length?: number; filter?: string },
 ) {
+  await createRecurringExpenses()
+
   return prisma.expense.findMany({
     select: {
       amount: true,
@@ -285,6 +351,7 @@ export async function getGroupExpenses(
         },
       },
       splitMode: true,
+      recurrenceRule: true,
       title: true,
     },
     where: {
@@ -306,7 +373,7 @@ export async function getGroupExpenseCount(groupId: string) {
 export async function getExpense(groupId: string, expenseId: string) {
   return prisma.expense.findUnique({
     where: { id: expenseId },
-    include: { paidBy: true, paidFor: true, category: true, documents: true },
+    include: { paidBy: true, paidFor: true, category: true, documents: true, recurringExpenseLink: true },
   })
 }
 
@@ -353,4 +420,185 @@ export async function logActivity(
       ...extra,
     },
   })
+}
+
+async function createRecurringExpenses(){
+  const localDate = new Date(); // Current local date
+  const utcDateFromLocal = new Date(Date.UTC(
+      localDate.getUTCFullYear(),
+      localDate.getUTCMonth(),
+      localDate.getUTCDate(),
+      // More precision beyond date is required to ensure that recurring Expenses are created within <most precises unit> of when expected
+      localDate.getUTCHours(),
+      localDate.getUTCMinutes(),
+  ));
+
+  const recurringExpenseLinksWithExpensesToCreate = await prisma.recurringExpenseLink.findMany({
+    where: {
+      nextExpenseCreatedAt: null,
+      nextExpenseDate: {
+        lte: utcDateFromLocal
+      }
+    },
+    include: {
+      currentFrameExpense: {
+        include: {
+          paidBy: true,
+          paidFor: true, 
+          category: true, 
+          documents: true 
+        },
+      }
+    }
+  })
+
+  // TODO(trandall): try to acquire a lock if there are recurring Expenses that need to be created
+
+  for (const recurringExpenseLink of recurringExpenseLinksWithExpensesToCreate) {
+    let newExpenseDate = recurringExpenseLink.nextExpenseDate
+
+    let currentExpenseRecord = recurringExpenseLink.currentFrameExpense
+    let currentReccuringExpenseLinkId = recurringExpenseLink.id
+
+    while (newExpenseDate < utcDateFromLocal) {
+      const newExpenseId = randomId()
+      const newRecurringExpenseLinkId = randomId()
+      
+      const newRecurringExpenseNextExpenseDate = calculateNextDate(
+        currentExpenseRecord.recurrenceRule as RecurrenceRule, 
+        newExpenseDate
+      )
+
+      const {
+        category, paidBy, paidFor, documents,
+        ...destructeredCurrentExpenseRecord
+      } = currentExpenseRecord
+
+      const newExpense = await prisma.expense.create({
+        data: {
+          ...destructeredCurrentExpenseRecord,
+          categoryId: currentExpenseRecord.categoryId,
+          paidById: currentExpenseRecord.paidById,
+          paidFor: {
+            createMany: {
+              data: currentExpenseRecord.paidFor.map((paidFor) => ({
+                participantId: paidFor.participantId,
+                shares: paidFor.shares,
+              })),
+            },
+          },
+          documents: {
+            connect: currentExpenseRecord.documents.map((documentRecord) => ({
+              id: documentRecord.id
+            })),
+          },
+          id: newExpenseId,
+          expenseDate: newExpenseDate,
+          recurringExpenseLink: {
+            create: {
+              groupId: currentExpenseRecord.groupId,
+              id: newRecurringExpenseLinkId,
+              nextExpenseDate: newRecurringExpenseNextExpenseDate
+            }
+          }
+        },
+        // Ensure that the same information is available on the returned record that was created
+        include: {
+          paidFor: true,
+          documents: true,
+          category: true,
+          paidBy: true
+        }
+      })
+
+      // Mark the RecurringExpenseLink as being "completed" since the new Expense was created
+      await prisma.recurringExpenseLink.update({
+        where: {
+          id: currentReccuringExpenseLinkId,
+        },
+        data: {
+          nextExpenseCreatedAt: newExpense.createdAt
+        }
+      })
+
+      // Set the values for the next iteration of the for-loop in case multiple recurring Expenses need to be created
+      currentExpenseRecord = newExpense
+      currentReccuringExpenseLinkId = newRecurringExpenseLinkId
+      newExpenseDate = newRecurringExpenseNextExpenseDate
+    }
+  }
+
+  // TODO(trandall): release lock if acquired
+}
+
+function createPayloadForNewRecurringExpenseLink(
+  recurrenceRule: RecurrenceRule,
+  priorDateToNextRecurrence: Date,
+  groupId: String,
+): RecurringExpenseLink {
+  const nextExpenseDate = calculateNextDate(
+    recurrenceRule, 
+    priorDateToNextRecurrence
+  )
+
+  const recurringExpenseLinkId = randomId()
+  const recurringExpenseLinkPayload = {
+    id: recurringExpenseLinkId,
+    groupId: groupId,
+    nextExpenseDate: nextExpenseDate
+  }
+
+  return recurringExpenseLinkPayload as RecurringExpenseLink
+}
+
+// TODO: Modify this function to use a more comprehensive recurrence Rule library like rrule (https://github.com/jkbrzt/rrule)
+//
+// Current limitations:
+// - If a date is intended to be repeated monthly on the 29th, 30th or 31st, it will change to repeating on the smallest
+// date that the reccurence has encountered. Ex. If a recurrence is created for Jan 31st on 2025, the recurring expense
+// will be created for Feb 28th, March 28, etc. until it is cancelled or fixed
+function calculateNextDate(
+  recurrenceRule: RecurrenceRule,
+  priorDateToNextRecurrence: Date
+): Date {
+  const nextDate = new Date(priorDateToNextRecurrence)
+  switch(recurrenceRule) {
+    case RecurrenceRule.DAILY:
+      nextDate.setUTCDate(nextDate.getUTCDate() + 1)
+      break
+    case RecurrenceRule.WEEKLY:
+      nextDate.setUTCDate(nextDate.getUTCDate() + 7)
+      break
+    case RecurrenceRule.MONTHLY:
+      let nextDay = nextDate.getUTCDate()
+      let nextMonth = nextDate.getUTCMonth() + 1
+      let nextYear = nextDate.getUTCFullYear()
+
+      // Reduce the next day until it is within the direct next month
+      while (!isDateInNextMonth(nextYear, nextMonth, nextDay)) {
+        nextDay -= 1
+      }
+      nextDate.setUTCMonth(nextDate.getUTCMonth() + 1, nextDay)
+      break
+  }
+
+  return nextDate
+}
+
+function isDateInNextMonth(
+  utcYear: number,
+  utcMonth: number,
+  utcDate: number
+): Boolean {
+  const testDate = new Date(Date.UTC(
+    utcYear, utcMonth, utcDate
+  ))
+
+  // We're not concerned if the year or month changes. We only want to make sure that the date is our target date
+  if (testDate.getUTCDate() !== utcDate
+   ) {
+    return false
+  }
+
+  return true
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -50,7 +50,7 @@ export async function createExpense(
     data: expenseFormValues.title,
   })
 
-  let isCreateRecurrence = expenseFormValues.recurrenceRule !== RecurrenceRule.NONE
+  const isCreateRecurrence = expenseFormValues.recurrenceRule !== RecurrenceRule.NONE
   const recurringExpenseLinkPayload = createPayloadForNewRecurringExpenseLink(
     expenseFormValues.recurrenceRule as RecurrenceRule,
     expenseFormValues.expenseDate,
@@ -573,15 +573,15 @@ function calculateNextDate(
       nextDate.setUTCDate(nextDate.getUTCDate() + 7)
       break
     case RecurrenceRule.MONTHLY:
+      const nextYear = nextDate.getUTCFullYear()  
+      const nextMonth = nextDate.getUTCMonth() + 1
       let nextDay = nextDate.getUTCDate()
-      let nextMonth = nextDate.getUTCMonth() + 1
-      let nextYear = nextDate.getUTCFullYear()
 
       // Reduce the next day until it is within the direct next month
       while (!isDateInNextMonth(nextYear, nextMonth, nextDay)) {
         nextDay -= 1
       }
-      nextDate.setUTCMonth(nextDate.getUTCMonth() + 1, nextDay)
+      nextDate.setUTCMonth(nextMonth, nextDay)
       break
   }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -113,13 +113,6 @@ export async function deleteExpense(
     data: existingExpense?.title,
   })
 
-  // TODO(trandall): Add a popup (if the expense has a recurrence rule) to tell the user that deleting 
-  // this expense will cause any future recurring expenses not be created and the expenses will need 
-  // to be re-created
-  //
-  // Note: Because the the RecurringExpenseLink model was created with an `onDelete: Cascade` relation to
-  // Expenses, any related RecurringExpenseLinks will be deleted when an Expense is deleted
-
   await prisma.expense.delete({
     where: { id: expenseId },
     include: { paidFor: true, paidBy: true },
@@ -452,8 +445,6 @@ async function createRecurringExpenses(){
     }
   })
 
-  // TODO(trandall): try to acquire a lock if there are recurring Expenses that need to be created
-
   for (const recurringExpenseLink of recurringExpenseLinksWithExpensesToCreate) {
     let newExpenseDate = recurringExpenseLink.nextExpenseDate
 
@@ -527,8 +518,6 @@ async function createRecurringExpenses(){
       newExpenseDate = newRecurringExpenseNextExpenseDate
     }
   }
-
-  // TODO(trandall): release lock if acquired
 }
 
 function createPayloadForNewRecurringExpenseLink(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -175,10 +175,14 @@ export async function updateExpense(
     // Delete the existing RecurrenceExpenseLink only if it has not been acted upon yet
     existingExpense.recurringExpenseLink?.nextExpenseCreatedAt === null
 
-  const isUpdateRecurrenceExpenseLink = existingExpense.recurrenceRule !== expenseFormValues.recurrenceRule
+  const isUpdateRecurrenceExpenseLink = existingExpense.recurrenceRule !== expenseFormValues.recurrenceRule &&
+    // Update the exisiting RecurrenceExpenseLink only if it has not been acted upon yet
+    existingExpense.recurringExpenseLink?.nextExpenseCreatedAt === null
   const isCreateRecurrenceExpenseLink = 
     existingExpense.recurrenceRule === RecurrenceRule.NONE && 
-    expenseFormValues.recurrenceRule !== RecurrenceRule.NONE
+    expenseFormValues.recurrenceRule !== RecurrenceRule.NONE &&
+    // Create a new RecurrenceExpenseLink only if one does not already exist for the expense
+    existingExpense.recurringExpenseLink === null
   
   const newRecurringExpenseLink = createPayloadForNewRecurringExpenseLink(
     expenseFormValues.recurrenceRule as RecurrenceRule,

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,4 +1,4 @@
-import { SplitMode } from '@prisma/client'
+import { SplitMode, RecurrenceRule } from '@prisma/client'
 import * as z from 'zod'
 
 export const groupFormSchema = z
@@ -105,6 +105,11 @@ export const expenseFormSchema = z
       )
       .default([]),
     notes: z.string().optional(),
+    recurrenceRule:z
+      .enum<RecurrenceRule, [RecurrenceRule, ...RecurrenceRule[]]>(
+        Object.values(RecurrenceRule) as any
+      )
+      .default('NONE'),
   })
   .superRefine((expense, ctx) => {
     let sum = 0


### PR DESCRIPTION
## What
- Closes issue #5 
  - An expense can be created with a recurrence/repeating rule, and subsequent expenses will be created
  - Deleting the most recent expense causes no further repeating expenses to be created
  - Changing the most recent expense to no longer repeat causes no further repeating expenses to be created
  - Changing the recurrence rule of the most recent expense causes all subsequent expenses to adopt the same recurrence

## Particular shortcomings to note
- Creating a monthly expense on the 29th, 30th, or 31st will not cause the expense to consistently be created for that date
  - If an expense is created on any of these 3 dates, it will eventually adopt the largest date available in the next month if the target date is not available
  - Ex 1
    - A monthly expense is initially created on January 31st, 2024
    - The next 3 expenses will be created on: February 29th, March 29th, and April 29th
  - Ex 2
    - A monthly expense is initially created on March 31st, 2024
    - The next 3 expenses will be created on: April 30th, May 30th, and June 30th
  - Ex 3
    - A monthly expense is initially created on July 31st, 2024
    - The next 3 expenses will be created on: August 31st, September 30th, and October 30th

## Acknowledged decisions
- Only supporting recurrence rules (daily, weekly, and "monthly" -- excluding the 29th, 30th, and 31st)
  - This seems like a good starting place for the feature
- Not indefinitely linking Expenses to their future related Expenses
  - It's still an option to add this linking later. But not adding it now keeps the model more flexible
- Creating repeating Expenses when a user loads all the Expenses from a group
  - I took inspiration from [this earlier PR](https://github.com/spliit-app/spliit/pull/114) which chose to do something similar. I think that it's possible/straightforward to add a job to perform this task. But this method was very lightweight and doesn't preclude a later change.

## Potential Future improvements
- Add usage of the [rrule](https://github.com/jkbrzt/rrule) library to hopefully avoid the poor end-of-month recurrence behavior mentioned above
  - I think it would be best to add this library before adding more `RecurrenceRules` (ex. bi-weekly, etc)
- Add a popup to the Expense page that notifies users about particular deletion behavior:
  - If they are deleting an Expense whose RecurringExpenseLink is pending to create the next Expense, then no further repeating Expenses will be created for that Expense
  - If they are deleting an Expense whose RecurringExpenseLink has already created the next Expense, then only the target Expense will be deleted