### PR TITLE
fix: utc timezone used in activity tracker

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,7 +20,6 @@ export function formatDate(
 ) {
   return date.toLocaleString(locale, {
     ...options,
-    timeZone: 'UTC',
   })
 }
 


### PR DESCRIPTION
Fixes time mismatch mentioned in #217 (utc timezone hardcoded in format date util fn)