### PR TITLE
feat(expense-list): Display the attachment count only when the expense includes attachments

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -42,7 +42,8 @@
   "ExpenseCard": {
     "paidBy": "Paid by <strong>{paidBy}</strong> for <paidFor></paidFor>",
     "receivedBy": "Received by <strong>{paidBy}</strong> for <paidFor></paidFor>",
-    "yourBalance": "Your balance:"
+    "yourBalance": "Your balance:",
+    "attachments": "attachments"
   },
   "Groups": {
     "myGroups": "My groups",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -43,7 +43,8 @@
     "paidBy": "Paid by <strong>{paidBy}</strong> for <paidFor></paidFor>",
     "receivedBy": "Received by <strong>{paidBy}</strong> for <paidFor></paidFor>",
     "yourBalance": "Your balance:",
-    "attachments": "attachments"
+    "attachments": "attachments",
+    "attachment": "attachment"
   },
   "Groups": {
     "myGroups": "My groups",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -42,9 +42,7 @@
   "ExpenseCard": {
     "paidBy": "Paid by <strong>{paidBy}</strong> for <paidFor></paidFor>",
     "receivedBy": "Received by <strong>{paidBy}</strong> for <paidFor></paidFor>",
-    "yourBalance": "Your balance:",
-    "attachments": "attachments",
-    "attachment": "attachment"
+    "yourBalance": "Your balance:"
   },
   "Groups": {
     "myGroups": "My groups",

--- a/src/app/groups/[groupId]/expenses/documents-count.tsx
+++ b/src/app/groups/[groupId]/expenses/documents-count.tsx
@@ -1,18 +1,11 @@
-import { ExpenseFormValues } from '@/lib/schemas'
 import { Paperclip } from 'lucide-react'
-import { useTranslations } from 'next-intl'
 
-type DocumentCount = {
-  documents: ExpenseFormValues['documents']
-}
-export function DocumentsCount({ documents }: DocumentCount) {
-  const t = useTranslations('ExpenseCard')
-  const documentsCount = documents.length
-  if (documentsCount === 0) return <></>
+export function DocumentsCount({ count }: { count: number }) {
+  if (count === 0) return <></>
   return (
     <div className="flex items-center">
       <Paperclip className="w-3.5 h-3.5 mr-1 mt-0.5 text-muted-foreground" />
-      <span>{documentsCount}</span>
+      <span>{count}</span>
     </div>
   )
 }

--- a/src/app/groups/[groupId]/expenses/documents-count.tsx
+++ b/src/app/groups/[groupId]/expenses/documents-count.tsx
@@ -11,11 +11,8 @@ export function DocumentsCount({ documents }: DocumentCount) {
   if (documentsCount === 0) return <></>
   return (
     <div className="flex items-center">
-      <Paperclip className="w-4 h-4 mr-1 mt-0.5 text-muted-foreground" />
-      <span>
-        {documentsCount}{' '}
-        {documentsCount === 1 ? t('attachment') : t('attachments')}
-      </span>
+      <Paperclip className="w-3.5 h-3.5 mr-1 mt-0.5 text-muted-foreground" />
+      <span>{documentsCount}</span>
     </div>
   )
 }

--- a/src/app/groups/[groupId]/expenses/documents-count.tsx
+++ b/src/app/groups/[groupId]/expenses/documents-count.tsx
@@ -15,7 +15,8 @@ export function DocumentsCount({ documents, showMidDot }: DocumentCount) {
       <div className="flex items-center">
         <Paperclip className="w-4 h-4 mr-1 mt-0.5 text-muted-foreground" />
         <span>
-          {documentsCount} {t('attachments')}
+          {documentsCount}{' '}
+          {documentsCount === 1 ? t('attachment') : t('attachments')}
         </span>
       </div>
       {showMidDot ? <span>&nbsp;&middot;&nbsp;</span> : <></>}

--- a/src/app/groups/[groupId]/expenses/documents-count.tsx
+++ b/src/app/groups/[groupId]/expenses/documents-count.tsx
@@ -1,0 +1,24 @@
+import { ExpenseFormValues } from '@/lib/schemas'
+import { Paperclip } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+type DocumentCount = {
+  documents: ExpenseFormValues['documents']
+  showMidDot: Boolean
+}
+export function DocumentsCount({ documents, showMidDot }: DocumentCount) {
+  const t = useTranslations('ExpenseCard')
+  const documentsCount = documents.length
+  if (documentsCount === 0) return <></>
+  return (
+    <>
+      <div className="flex items-center">
+        <Paperclip className="w-4 h-4 mr-1 mt-0.5 text-muted-foreground" />
+        <span>
+          {documentsCount} {t('attachments')}
+        </span>
+      </div>
+      {showMidDot ? <span>&nbsp;&middot;&nbsp;</span> : <></>}
+    </>
+  )
+}

--- a/src/app/groups/[groupId]/expenses/documents-count.tsx
+++ b/src/app/groups/[groupId]/expenses/documents-count.tsx
@@ -4,22 +4,18 @@ import { useTranslations } from 'next-intl'
 
 type DocumentCount = {
   documents: ExpenseFormValues['documents']
-  showMidDot: Boolean
 }
-export function DocumentsCount({ documents, showMidDot }: DocumentCount) {
+export function DocumentsCount({ documents }: DocumentCount) {
   const t = useTranslations('ExpenseCard')
   const documentsCount = documents.length
   if (documentsCount === 0) return <></>
   return (
-    <>
-      <div className="flex items-center">
-        <Paperclip className="w-4 h-4 mr-1 mt-0.5 text-muted-foreground" />
-        <span>
-          {documentsCount}{' '}
-          {documentsCount === 1 ? t('attachment') : t('attachments')}
-        </span>
-      </div>
-      {showMidDot ? <span>&nbsp;&middot;&nbsp;</span> : <></>}
-    </>
+    <div className="flex items-center">
+      <Paperclip className="w-4 h-4 mr-1 mt-0.5 text-muted-foreground" />
+      <span>
+        {documentsCount}{' '}
+        {documentsCount === 1 ? t('attachment') : t('attachments')}
+      </span>
+    </div>
   )
 }

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -77,7 +77,7 @@ export function ExpenseCard({ expense, currency, groupId }: Props) {
           {formatCurrency(currency, expense.amount, locale)}
         </div>
         <div className="text-xs text-muted-foreground">
-          <DocumentsCount documents={expense.documents} />
+          <DocumentsCount count={expense._count.documents} />
         </div>
         <div className="text-xs text-muted-foreground">
           {formatDate(expense.expenseDate, locale, { dateStyle: 'medium' })}

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { ActiveUserBalance } from '@/app/groups/[groupId]/expenses/active-user-balance'
 import { CategoryIcon } from '@/app/groups/[groupId]/expenses/category-icon'
+import { DocumentsCount } from '@/app/groups/[groupId]/expenses/documents-count'
 import { Button } from '@/components/ui/button'
 import { getGroupExpenses } from '@/lib/api'
 import { cn, formatCurrency, formatDate } from '@/lib/utils'
@@ -75,7 +76,8 @@ export function ExpenseCard({ expense, currency, groupId }: Props) {
         >
           {formatCurrency(currency, expense.amount, locale)}
         </div>
-        <div className="text-xs text-muted-foreground">
+        <div className="flex items-center text-xs text-muted-foreground">
+          <DocumentsCount documents={expense.documents} showMidDot />
           {formatDate(expense.expenseDate, locale, { dateStyle: 'medium' })}
         </div>
       </div>

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -76,8 +76,10 @@ export function ExpenseCard({ expense, currency, groupId }: Props) {
         >
           {formatCurrency(currency, expense.amount, locale)}
         </div>
-        <div className="flex items-center text-xs text-muted-foreground">
-          <DocumentsCount documents={expense.documents} showMidDot />
+        <div className="text-xs text-muted-foreground">
+          <DocumentsCount documents={expense.documents} />
+        </div>
+        <div className="text-xs text-muted-foreground">
           {formatDate(expense.expenseDate, locale, { dateStyle: 'medium' })}
         </div>
       </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -286,6 +286,7 @@ export async function getGroupExpenses(
       },
       splitMode: true,
       title: true,
+      documents: true,
     },
     where: {
       groupId,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -286,7 +286,7 @@ export async function getGroupExpenses(
       },
       splitMode: true,
       title: true,
-      documents: true,
+      _count: { select: { documents: true } },
     },
     where: {
       groupId,


### PR DESCRIPTION
We can have attachments for expenses, but in expenses list we do not show if a particular expense has an attachment or not. Relates to [#238](https://github.com/spliit-app/spliit/issues/238)

_**Before:**_
![image](https://github.com/user-attachments/assets/7998e4d5-c65b-455b-a939-dfd85e5b6af1)

**_After:_**

Expense has attachments:

![image](https://github.com/user-attachments/assets/d60200d6-48e5-488c-834e-2d8b321f7fba)
![image](https://github.com/user-attachments/assets/e4e73aa3-04b2-4edf-8566-0a9587d02fe0)

Mobile:

![image](https://github.com/user-attachments/assets/46a43554-1465-4bc9-94b2-14fc0db36eaf)


No attachments:

![image](https://github.com/user-attachments/assets/89a0c20a-1eb6-4cf4-9a1c-d47121b6138b)


