### PR TITLE
Fix typos in i18n keys for Expenses.Groups.lastYear and Activity.Groups.lastYear for most locales

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "Diesen Monat",
       "lastMonth": "Letzten Monat",
       "earlierThisYear": "Dieses Jahr",
-      "lastYera": "Letztes Jahr",
+      "lastYear": "Letztes Jahr",
       "older": "Älter"
     }
   },

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "Earlier this month",
       "lastMonth": "Last month",
       "earlierThisYear": "Earlier this year",
-      "lastYera": "Last year",
+      "lastYear": "Last year",
       "older": "Older"
     }
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "A principios de este mes",
       "lastMonth": "El mes pasado",
       "earlierThisYear": "A principios de este año",
-      "lastYera": "El año pasado",
+      "lastYear": "El año pasado",
       "older": "Más antiguos"
     }
   },

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "Plus tôt ce mois-ci",
       "lastMonth": "Le mois dernier",
       "earlierThisYear": "Plus tôt cette année",
-      "lastYera": "L'année dernière",
+      "lastYear": "L'année dernière",
       "older": "Plus ancien"
     }
   },

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "All'inizio di questo mese",
       "lastMonth": "Ultimo mese",
       "earlierThisYear": "All'inizio di quest'anno",
-      "lastYera": "Ultimo anno",
+      "lastYear": "Ultimo anno",
       "older": "Più vecchio"
     }
   },

--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "Wcześniej w tym miesiącu",
       "lastMonth": "Ostatni miesiąc",
       "earlierThisYear": "Wcześniej w tym roku",
-      "lastYera": "Poprzedni rok",
+      "lastYear": "Poprzedni rok",
       "older": "Starsze"
     }
   },
@@ -281,7 +281,7 @@
       "earlierThisMonth": "Wcześniej w tym miesiącu",
       "lastMonth": "Ostatni miesiąc",
       "earlierThisYear": "Wcześniej w tym roku",
-      "lastYera": "Poprzedni rok",
+      "lastYear": "Poprzedni rok",
       "older": "Starsze"
     }
   },

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "La începutul lunii",
       "lastMonth": "Luna trecută",
       "earlierThisYear": "La începutul anului",
-      "lastYera": "Anul trecut",
+      "lastYear": "Anul trecut",
       "older": "Mai vechi"
     }
   },

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "Ранее в этом месяце",
       "lastMonth": "В прошлом месяце",
       "earlierThisYear": "Ранее в этом году",
-      "lastYera": "В прошлом году",
+      "lastYear": "В прошлом году",
       "older": "Очень давно"
     }
   },

--- a/messages/ua-UA.json
+++ b/messages/ua-UA.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "Раніше цього місяця",
       "lastMonth": "Минулого місяця",
       "earlierThisYear": "Раніше цього року",
-      "lastYera": "Минулого року",
+      "lastYear": "Минулого року",
       "older": "Старіші"
     }
   },

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "本月早些时候",
       "lastMonth": "上个月",
       "earlierThisYear": "本年早些时候",
-      "lastYera": "去年",
+      "lastYear": "去年",
       "older": "更早"
     }
   },

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "本月稍早",
       "lastMonth": "上個月",
       "earlierThisYear": "今年稍早",
-      "lastYera": "去年",
+      "lastYear": "去年",
       "older": "更早"
     }
   },


### PR DESCRIPTION
Discovered when using the official Spliit instance:

https://spliit.app/groups/ycyaejYHrUW6O9CVtwugA/expenses

![image](https://github.com/user-attachments/assets/78a9dbf6-cce4-40b2-b640-f3f046afffc3)

Note that only the i18n files contain the typo. The code that builds the i18n key and performs the translation has the correct spelling:

https://github.com/spliit-app/spliit/blob/9302a32f4c0e3081985f6410debed7f863bfd67b/src/app/groups/%5BgroupId%5D/expenses/expense-list.tsx#L28

https://github.com/spliit-app/spliit/blob/9302a32f4c0e3081985f6410debed7f863bfd67b/src/app/groups/%5BgroupId%5D/activity/activity-list.tsx#L24

Thanks for making this app!