### PR TITLE
fix: Properly check for 0 value expenses

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -52,7 +52,7 @@ export const expenseFormSchema = z
         ],
         { required_error: 'amountRequired' },
       )
-      .refine((amount) => amount != 1, 'amountNotZero')
+      .refine((amount) => amount != 0, 'amountNotZero')
       .refine((amount) => amount <= 10_000_000_00, 'amountTenMillion'),
     paidBy: z.string({ required_error: 'paidByRequired' }),
     paidFor: z


### PR DESCRIPTION
https://github.com/spliit-app/spliit/pull/158 had a bug in its change from `amount >= 1` to `amount != 1` instead of being `amount != 0` ([exact diff](https://github.com/spliit-app/spliit/pull/158/files#diff-a885111d0e257733338200492311189d88201ef52bce6a079edad77c74bb2ef0R65))
![Screenshot 2024-12-16 at 5 58 57 PM](https://github.com/user-attachments/assets/ec791d9b-6b21-49a8-a09c-94ab02962061)

Repro case on spliit.app: 
![Screenshot 2024-12-19 at 8 09 32 PM](https://github.com/user-attachments/assets/1533f64c-88d0-456c-b761-aabaaee6d1b5)


Let me know if there are other steps I should do to make this PR reviewable / mergeable. I didn't see a contributing guideline at a glance. 


