### PR TITLE
Fixes in polish translation

### DIFF
--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -81,7 +81,7 @@
     "NameField": {
       "label": "Nazwa grupy",
       "placeholder": "Letni wyjazd",
-      "description": "Podaj nazwę dla twojej grupy."
+      "description": "Podaj nazwę dla grupy."
     },
     "InformationField": {
       "label": "Informacje o grupie",
@@ -90,7 +90,7 @@
     "CurrencyField": {
       "label": "Symbol waluty",
       "placeholder": "PLN, zł, $, €, £…",
-      "description": "Użyjemy go do wyświetlania ilości."
+      "description": "Użyjemy go do wyświetlania kwot."
     },
     "Participants": {
       "title": "Członkowie",
@@ -104,10 +104,10 @@
     },
     "Settings": {
       "title": "Ustawienia lokalne",
-      "description": "Te ustawienia są ustawiane dla konkretnego urządzenia i służą do dostosowania twoich doświadczeń z aplikacją.",
+      "description": "Te ustawienia są zapisywane dla tego urządzenia i służą do dostosowania twoich doświadczeń z aplikacją.",
       "ActiveUserField": {
         "label": "Aktywny użytkownik",
-        "placeholder": "Wybierz członka",
+        "placeholder": "Wybierz użytkownika",
         "none": "Brak",
         "description": "Użytkownik używany domyślnie do wprowadzania wydatków."
       },
@@ -153,7 +153,7 @@
       },
       "DateField": {
         "label": "Data wydatku",
-        "description": "Podaj datę opłacenia wydatku."
+        "description": "Podaj datę wydatku."
       },
       "categoryFieldDescription": "Podaj kategorię wydatku.",
       "paidByField": {
@@ -168,10 +168,10 @@
       "attachDescription": "Zobacz i załącz rachunki do wydatku."
     },
     "amountField": {
-      "label": "Ilość"
+      "label": "Suma"
     },
     "isReimbursementField": {
-      "label": "To jest zwrot kosztów"
+      "label": "Oznacz jako zwrot kosztów"
     },
     "categoryField": {
       "label": "Kategoria"
@@ -179,8 +179,8 @@
     "notesField": {
       "label": "Notatki"
     },
-    "selectNone": "Nie wybieraj żadnego",
-    "selectAll": "Wybierz wszystkie",
+    "selectNone": "Nie wybieraj nikogo",
+    "selectAll": "Wybierz wszystkich",
     "shares": "udział(y)",
     "advancedOptions": "Zaawansowane opcje podziału...",
     "SplitModeField": {
@@ -203,7 +203,8 @@
     "creating": "Tworzenie…",
     "save": "Zapisz",
     "saving": "Zapisywanie…",
-    "cancel": "Anuluj"
+    "cancel": "Anuluj",
+    "reimbursement": "Zwrot środków"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {
@@ -225,7 +226,7 @@
       "selectImage": "Wybierz obraz...",
       "titleLabel": "Tytuł:",
       "categoryLabel": "Kategoria:",
-      "amountLabel": "Ilość:",
+      "amountLabel": "Suma:",
       "dateLabel": "Data:",
       "editNext": "Następnie będziesz mógł edytować informacje o wydatkach.",
       "continue": "Kontynuuj"


### PR DESCRIPTION
Minor updates to Polish translation:
- in some contexts the phrasing was a bit misleading
- There was missing field for default reimbursement title (`ExpenseForm.reimbursement`)