### PR TITLE
fix the amount validation while creating an expense

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -52,7 +52,7 @@ export const expenseFormSchema = z
         ],
         { required_error: 'amountRequired' },
       )
-      .refine((amount) => amount != 1, 'amountNotZero')
+      .refine((amount) => amount != 0, 'amountNotZero')
       .refine((amount) => amount <= 10_000_000_00, 'amountTenMillion'),
     paidBy: z.string({ required_error: 'paidByRequired' }),
     paidFor: z


### PR DESCRIPTION
This PR is to fix this issue #290 
The current validation logic is not restricting the expense creation when the amount is "0".

After:
![image](https://github.com/user-attachments/assets/7acfa20a-d0c2-4d26-987d-ee67920d53bb)
