### PR TITLE
Ensure the exported data is sorted by the expense date

### DIFF
--- a/src/app/groups/[groupId]/expenses/export/json/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/json/route.ts
@@ -14,6 +14,7 @@ export async function GET(
       currency: true,
       expenses: {
         select: {
+          createdAt: true,
           expenseDate: true,
           title: true,
           category: { select: { grouping: true, name: true } },
@@ -23,6 +24,7 @@ export async function GET(
           isReimbursement: true,
           splitMode: true,
         },
+        orderBy: [{ expenseDate: 'asc' }, { createdAt: 'asc' }],
       },
       participants: { select: { id: true, name: true } },
     },


### PR DESCRIPTION
According to the [getGroupExpenses](https://github.com/spliit-app/spliit/blob/72ad0a4c90054cdb28c115ccd2d144b946e58d51/src/lib/api.ts#L297), the UI appears to sort expenses by expense date first, and then by creation date if multiple expenses have the same expense date.

This PR adds a `createdAt` column to the export feature and sorts the data in ascending order using the same logic as the UI.