### PR TITLE
Fix typo in translation files

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "Diesen Monat",
       "lastMonth": "Letzten Monat",
       "earlierThisYear": "Dieses Jahr",
-      "lastYera": "Letztes Jahr",
+      "lastYear": "Letztes Jahr",
       "older": "Älter"
     }
   },

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "Earlier this month",
       "lastMonth": "Last month",
       "earlierThisYear": "Earlier this year",
-      "lastYera": "Last year",
+      "lastYear": "Last year",
       "older": "Older"
     }
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "A principios de este mes",
       "lastMonth": "El mes pasado",
       "earlierThisYear": "A principios de este año",
-      "lastYera": "El año pasado",
+      "lastYear": "El año pasado",
       "older": "Más antiguos"
     }
   },

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "Plus tôt ce mois-ci",
       "lastMonth": "Le mois dernier",
       "earlierThisYear": "Plus tôt cette année",
-      "lastYera": "L'année dernière",
+      "lastYear": "L'année dernière",
       "older": "Plus ancien"
     }
   },

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "All'inizio di questo mese",
       "lastMonth": "Ultimo mese",
       "earlierThisYear": "All'inizio di quest'anno",
-      "lastYera": "Ultimo anno",
+      "lastYear": "Ultimo anno",
       "older": "Più vecchio"
     }
   },

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "Ранее в этом месяце",
       "lastMonth": "В прошлом месяце",
       "earlierThisYear": "Ранее в этом году",
-      "lastYera": "В прошлом году",
+      "lastYear": "В прошлом году",
       "older": "Очень давно"
     }
   },

--- a/messages/ua-UA.json
+++ b/messages/ua-UA.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "Раніше цього місяця",
       "lastMonth": "Минулого місяця",
       "earlierThisYear": "Раніше цього року",
-      "lastYera": "Минулого року",
+      "lastYear": "Минулого року",
       "older": "Старіші"
     }
   },

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -35,7 +35,7 @@
       "earlierThisMonth": "本月早些时候",
       "lastMonth": "上个月",
       "earlierThisYear": "本年早些时候",
-      "lastYera": "去年",
+      "lastYear": "去年",
       "older": "更早"
     }
   },

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
@@ -22,7 +22,7 @@ export async function extractExpenseInformationFromImage(imageUrl: string) {
             text: `
               This image contains a receipt.
               Read the total amount and store it as a non-formatted number without any other text or currency.
-              Then guess the category for this receipt amoung the following categories and store its ID: ${categories.map(
+              Then guess the category for this receipt among the following categories and store its ID: ${categories.map(
                 (category) => formatCategoryForAIPrompt(category),
               )}.
               Guess the expense’s date and store it as yyyy-mm-dd.


### PR DESCRIPTION
This PR corrects a misspelled property name in several language JSON files, including German. The same typo was partially addressed in PR #303 (for German only), but this PR extends the fix to all affected language files to ensure correct translations display to users.

It also fixes a minor typo in the open AI prompt in src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts