### PR TITLE
Use exec in container entryptoint to replace the shell process

### DIFF
--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -3,4 +3,4 @@
 set -euxo pipefail
 
 npx prisma migrate deploy
-npm run start
+exec npm run start


### PR DESCRIPTION
This will replace the `sh` process from the container entrypoint with the node process as PID 1, to properly handle SIGTERM signals and gracefully shut down the container.

Currently, `sh` will intercept any signals and not forward them to node, leaving the container in the terminating state before docker force kills it after the 10s grace period. This means that db connections won't be closed and that requests will get interrupted during shutdown.