### PR TITLE
Added a pipeline to buid container and push to ghcr.io

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,43 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    tags: 
+      - '*'
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Downcase repo
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
+        
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ env.REPO }}:${{ github.ref_name }}
+            ghcr.io/${{ env.REPO }}:latest

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ If you want to contribute financially and help us keep the application free and 
 3. Run `npm run start-container` to start the postgres and the spliit2 containers
 4. You can access the app by browsing to http://localhost:3000
 
+You could also pull it from the container registry:
+```docker pull ghcr.io/spliit-app/spliit:latest```
+
 ## Opt-in features
 
 ### Expense documents


### PR DESCRIPTION
I've created a pipeline that builds the container image and and pushes it to ghcr.io whenever a new release is created. I've created this to make it easier for me to self host this app although I'm sure it could help many others too.

After this PR has been merged and the first release is created, I'd ask the maintainer to double check that the package visibility it set to public so anybody can pull it.
https://github.com/orgs/spliit-app/packages/container/spliit/settings