### PR TITLE
update de-DE translation for recurrenceRule

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -138,8 +138,8 @@
         "description": "Wähle das Mitglied, das die Einnahme erhalten hat."
       },
       "recurrenceRule": {
-        "label": "Wiederholung der Ausgabe",
-        "description": "Wähle aus, wie oft die Ausgabe wiederholt werden soll.",
+        "label": "Wiederholung der Einnahme",
+        "description": "Wähle aus, wie oft die Einnahme wiederholt werden soll.",
 
         "none": "Keine Wiederholung",
         "daily": "Täglich",

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -138,13 +138,13 @@
         "description": "Wähle das Mitglied, das die Einnahme erhalten hat."
       },
       "recurrenceRule": {
-        "label": "Expense Recurrence",
-        "description": "Select how often the expense should repeat.",
+        "label": "Wiederholung der Ausgabe",
+        "description": "Wähle aus, wie oft die Ausgabe wiederholt werden soll.",
 
-        "none": "None",
-        "daily": "Daily",
-        "weekly": "Weekly",
-        "monthly": "Monthly"
+        "none": "Keine Wiederholung",
+        "daily": "Täglich",
+        "weekly": "Wöchentlich",
+        "monthly": "Monatlich"
       },
       "paidFor": {
         "title": "Empfangen für",
@@ -169,6 +169,15 @@
       "paidByField": {
         "label": "Gezahlt von",
         "description": "Wähle das Mitglied, das die Ausgabe bezahlt hat."
+      },
+      "recurrenceRule": {
+        "label": "Wiederholung der Ausgabe",
+        "description": "Wähle aus, wie oft die Ausgabe wiederholt werden soll.",
+
+        "none": "Keine Wiederholung",
+        "daily": "Täglich",
+        "weekly": "Wöchentlich",
+        "monthly": "Monatlich"
       },
       "paidFor": {
         "title": "Gezahlt für",


### PR DESCRIPTION
Hi, I've noticed missing translations for:
- ExpenseForm.Expense.recurrenceRule.label
- ExpenseForm.Expense.recurrenceRule.description
- ExpenseForm.Expense.recurrenceRule.none
- ExpenseForm.Expense.recurrenceRule.daily
- ExpenseForm.Expense.recurrenceRule.weekly
- ExpenseForm.Expense.recurrenceRule.monthly

and added them.

I also adjusted some the translations that were previously english for:
- ExpenseForm.Income.recurrenceRule.label
- ExpenseForm.Income.recurrenceRule.description
- ExpenseForm.Income.recurrenceRule.none
- ExpenseForm.Income.recurrenceRule.daily
- ExpenseForm.Income.recurrenceRule.weekly
- ExpenseForm.Income.recurrenceRule.monthly