### PR TITLE
Translate expense recurrence labels and descriptions to German

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -138,13 +138,13 @@
         "description": "Wähle das Mitglied, das die Einnahme erhalten hat."
       },
       "recurrenceRule": {
-        "label": "Expense Recurrence",
-        "description": "Select how often the expense should repeat.",
+        "label": "Wiederholung",
+        "description": "Wähle wie oft die Einnahme wiederholt werden soll.",
 
-        "none": "None",
-        "daily": "Daily",
-        "weekly": "Weekly",
-        "monthly": "Monthly"
+        "none": "Niemals",
+        "daily": "Täglich",
+        "weekly": "Wöchentlich",
+        "monthly": "Monatlich"
       },
       "paidFor": {
         "title": "Empfangen für",
@@ -173,6 +173,15 @@
       "paidFor": {
         "title": "Gezahlt für",
         "description": "Wähle für wen die Ausgabe gezahlt wurde."
+      },
+      "recurrenceRule": {
+        "label": "Wiederholung",
+        "description": "Wähle wie oft die Ausgabe wiederholt werden soll.",
+
+        "none": "Niemals",
+        "daily": "Täglich",
+        "weekly": "Wöchentlich",
+        "monthly": "Monatlich"
       },
       "splitModeDescription": "Wähle, wie die Ausgabe aufgeteilt werden soll.",
       "attachDescription": "Füge der Ausgabe einen Beleg hinzu."


### PR DESCRIPTION
The new recurring expenses feature had a missing german translation. Fixed it.

Thanks!