### PR TITLE
Add English fallback for i18n messages

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,6 +1,19 @@
 import { getRequestConfig } from 'next-intl/server'
 import { getUserLocale } from './lib/locale'
 
+function mergeDeep<T>(target: T, source: Partial<T>): T {
+  for (const key in source) {
+    const value = (source as any)[key]
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      ;(target as any)[key] = mergeDeep((target as any)[key] || {}, value)
+    } else {
+      ;(target as any)[key] = value
+    }
+  }
+  return target
+}
+
+
 export const localeLabels = {
   'en-US': 'English',
   fi: 'Suomi',
@@ -29,8 +42,14 @@ export const defaultLocale: Locale = 'en-US'
 export default getRequestConfig(async () => {
   const locale = await getUserLocale()
 
+  const defaultMessages = (await import('../messages/en-US.json')).default
+  const localeMessages = (await import(`../messages/${locale}.json`)).default
+
+  const messages = mergeDeep(structuredClone(defaultMessages), localeMessages)
+
+
   return {
-    locale,
-    messages: (await import(`../messages/${locale}.json`)).default,
+    locale,   
+    messages,
   }
 })


### PR DESCRIPTION
See #368 

Introduced a mergeDeep helper to merge locale-specific messages with the English defaults. src/i18n.ts now loads both the en-US messages and the selected locale’s messages, merges them, and supplies the result so missing translations appear in English instead of as placeholders.