### PR TITLE
fix: Resolve 500 error on CSV export for group names with umlauts

### DIFF
--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -151,13 +151,23 @@ export async function GET(
   const csv = json2csvParser.parse(expenses)
 
   const date = new Date().toISOString().split('T')[0]
-  const filename = `Spliit Export - ${group.name} - ${date}.csv`
+
+  // Create an ASCII-safe version of the group name for the 'filename' parameter
+  const asciiSafeGroupName = group.name.replace(/[^\x00-\x7F]/g, '_') // Replace non-ASCII with underscore
+  const asciiFilename = `Spliit Export - ${asciiSafeGroupName} - ${date}.csv`
+
+  // Use the original group name for the 'filename*' parameter (UTF-8 encoded)
+  const fullFilename = `Spliit Export - ${group.name} - ${date}.csv`
+  const encodedFullFilename = encodeURIComponent(fullFilename)
 
   // \uFEFF character is added at the beginning of the CSV content to ensure that it is interpreted as UTF-8 with BOM (Byte Order Mark), which helps some applications correctly interpret the encoding.
   return new NextResponse(`\uFEFF${csv}`, {
     headers: {
       'Content-Type': 'text/csv; charset=utf-8',
-      'Content-Disposition': contentDisposition(filename),
+      'Content-Disposition': contentDisposition(fullFilename, {
+        type: 'attachment',
+        fallback: asciiFilename,
+      }),
     },
   })
 }


### PR DESCRIPTION
Previously, exporting groups with German umlauts in their names resulted in a 500 error due to incorrect handling of the  header. This commit corrects the usage of the  library to properly generate both ASCII () and UTF-8 () compatible filenames, ensuring successful CSV exports for all group names.