### PR TITLE
Fix missing translation string in de-DE

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -159,6 +159,7 @@
       "categoryFieldDescription": "Wähle eine Kategorie für die Ausgabe.",
       "paidByField": {
         "label": "Gezahlt von",
+        "placeholder": "Wähle ein Mitglied",
         "description": "Wähle das Mitglied, das die Ausgabe bezahlt hat."
       },
       "recurrenceRule": {

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -137,15 +137,6 @@
         "label": "Empfangen von",
         "description": "Wähle das Mitglied, das die Einnahme erhalten hat."
       },
-      "recurrenceRule": {
-        "label": "Expense Recurrence",
-        "description": "Select how often the expense should repeat.",
-
-        "none": "None",
-        "daily": "Daily",
-        "weekly": "Weekly",
-        "monthly": "Monthly"
-      },
       "paidFor": {
         "title": "Empfangen für",
         "description": "Wähle für wen die Einnahme empfangen wurde."
@@ -169,6 +160,15 @@
       "paidByField": {
         "label": "Gezahlt von",
         "description": "Wähle das Mitglied, das die Ausgabe bezahlt hat."
+      },
+      "recurrenceRule": {
+        "label": "Wiederkehrende Ausgabe",
+        "description": "Wähle, wie oft sich die Ausgabe wiederholen soll.",
+
+        "none": "Nicht wiederkehrend",
+        "daily": "Täglich",
+        "weekly": "Wöchentlich",
+        "monthly": "Monatlich"
       },
       "paidFor": {
         "title": "Gezahlt für",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -160,6 +160,7 @@
       "categoryFieldDescription": "Select the expense category.",
       "paidByField": {
         "label": "Paid by",
+        "placeholder": "Select a participant",
         "description": "Select the participant who paid the expense."
       },
       "recurrenceRule": {

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -474,7 +474,7 @@ export function ExpenseForm({
                     defaultValue={getSelectedPayer(field)}
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select a participant" />
+                      <SelectValue placeholder={t(`${sExpense}.paidByField.placeholder`)} />
                     </SelectTrigger>
                     <SelectContent>
                       {group.participants.map(({ id, name }) => (


### PR DESCRIPTION
The object `recurrenceRule` was in the wrong section. Also, the strings in it were not translated.

The placeholder for the "paid by" field was hard-coded in English. I also made this translatable and added a translation to de-DE. Translations to other languages should be done as well, but I don't know what process you have for that, if you have one. (The issue with `recurrenceRule` is also an issue in other languages, by the way.)