### PR TITLE
Force UTC in expense card to correct date displayed in the expenses list

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -80,7 +80,7 @@ export function ExpenseCard({ expense, currency, groupId }: Props) {
           <DocumentsCount count={expense._count.documents} />
         </div>
         <div className="text-xs text-muted-foreground">
-          {formatDate(expense.expenseDate, locale, { dateStyle: 'medium' })}
+          {formatDate(expense.expenseDate, locale, { dateStyle: 'medium', timeZone: 'UTC' })}
         </div>
       </div>
       <Button

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,7 +16,7 @@ export type DateTimeStyle = NonNullable<
 export function formatDate(
   date: Date,
   locale: string,
-  options: { dateStyle?: DateTimeStyle; timeStyle?: DateTimeStyle } = {},
+  options: { dateStyle?: DateTimeStyle; timeStyle?: DateTimeStyle; timeZone?: string } = {},
 ) {
   return date.toLocaleString(locale, {
     ...options,


### PR DESCRIPTION
Related to issue #275

Date is stored in database as a simple Date without time zone. date.toLocaleString is using the client time zone to convert the date which result in discrepancies. 