### PR TITLE
Add health check endpoint and resolve locale detection bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ If you want to contribute financially and help us keep the application free and 
 3. Run `npm run start-container` to start the postgres and the spliit2 containers
 4. You can access the app by browsing to http://localhost:3000
 
+### Health check
+
+The application has a health check endpoint that can be used to check if the application is running and if the database is accessible.
+
+- `GET /api/health/readiness` or `GET /api/health` - Check if the application is ready to serve requests, including database connectivity.
+- `GET /api/health/liveness` - Check if the application is running, but not necessarily ready to serve requests.
+
 ## Opt-in features
 
 ### Expense documents

--- a/src/app/api/health/liveness/route.ts
+++ b/src/app/api/health/liveness/route.ts
@@ -1,0 +1,7 @@
+import { checkLiveness } from '@/lib/health'
+
+// Liveness: Is the app itself healthy? (no external dependencies)
+// If this fails, Kubernetes should restart the pod
+export async function GET() {
+  return checkLiveness()
+}

--- a/src/app/api/health/readiness/route.ts
+++ b/src/app/api/health/readiness/route.ts
@@ -1,0 +1,7 @@
+import { checkReadiness } from '@/lib/health'
+
+// Readiness: Can the app serve requests? (includes all external dependencies)
+// If this fails, Kubernetes should stop sending traffic but not restart
+export async function GET() {
+  return checkReadiness()
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,70 @@
+import { prisma } from '@/lib/prisma'
+
+interface HealthCheckStatus {
+  status: 'healthy' | 'unhealthy'
+  services: {
+    database: {
+      status: 'healthy' | 'unhealthy'
+      error?: string
+    }
+  }
+}
+
+async function checkDatabase(): Promise<HealthCheckStatus['services']['database']> {
+  try {
+    // Simple query to test database connectivity
+    await prisma.$queryRaw`SELECT 1`
+    return {
+      status: 'healthy'
+    }
+  } catch (error) {
+    return {
+      status: 'unhealthy',
+      error: error instanceof Error ? error.message : 'Database connection failed'
+    }
+  }
+}
+
+export async function GET() {
+  try {
+    const databaseStatus = await checkDatabase()
+
+    const services: HealthCheckStatus['services'] = {
+      database: databaseStatus
+    }
+
+    // Determine overall health status
+    const isHealthy = databaseStatus.status === 'healthy'
+
+    const healthStatus: HealthCheckStatus = {
+      status: isHealthy ? 'healthy' : 'unhealthy',
+      services
+    }
+
+    return new Response(JSON.stringify(healthStatus), {
+      status: isHealthy ? 200 : 503,
+      headers: {
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': 'application/json'
+      }
+    })
+  } catch (error) {
+    const errorStatus: HealthCheckStatus = {
+      status: 'unhealthy',
+      services: {
+        database: {
+          status: 'unhealthy',
+          error: error instanceof Error ? error.message : 'Health check failed'
+        }
+      }
+    }
+
+    return new Response(JSON.stringify(errorStatus), {
+      status: 503,
+      headers: {
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': 'application/json'
+      }
+    })
+  }
+} 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,70 +1,7 @@
-import { prisma } from '@/lib/prisma'
+import { checkReadiness } from '@/lib/health'
 
-interface HealthCheckStatus {
-  status: 'healthy' | 'unhealthy'
-  services: {
-    database: {
-      status: 'healthy' | 'unhealthy'
-      error?: string
-    }
-  }
-}
-
-async function checkDatabase(): Promise<HealthCheckStatus['services']['database']> {
-  try {
-    // Simple query to test database connectivity
-    await prisma.$queryRaw`SELECT 1`
-    return {
-      status: 'healthy'
-    }
-  } catch (error) {
-    return {
-      status: 'unhealthy',
-      error: error instanceof Error ? error.message : 'Database connection failed'
-    }
-  }
-}
-
+// Default health check - same as readiness (includes database check)
+// This is readiness-focused for monitoring tools like uptime-kuma
 export async function GET() {
-  try {
-    const databaseStatus = await checkDatabase()
-
-    const services: HealthCheckStatus['services'] = {
-      database: databaseStatus
-    }
-
-    // Determine overall health status
-    const isHealthy = databaseStatus.status === 'healthy'
-
-    const healthStatus: HealthCheckStatus = {
-      status: isHealthy ? 'healthy' : 'unhealthy',
-      services
-    }
-
-    return new Response(JSON.stringify(healthStatus), {
-      status: isHealthy ? 200 : 503,
-      headers: {
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Content-Type': 'application/json'
-      }
-    })
-  } catch (error) {
-    const errorStatus: HealthCheckStatus = {
-      status: 'unhealthy',
-      services: {
-        database: {
-          status: 'unhealthy',
-          error: error instanceof Error ? error.message : 'Health check failed'
-        }
-      }
-    }
-
-    return new Response(JSON.stringify(errorStatus), {
-      status: 503,
-      headers: {
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Content-Type': 'application/json'
-      }
-    })
-  }
-} 
+  return checkReadiness()
+}

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -1,0 +1,87 @@
+import { prisma } from '@/lib/prisma'
+
+export interface HealthCheckStatus {
+  status: 'healthy' | 'unhealthy'
+  services: {
+    database: {
+      status: 'healthy' | 'unhealthy'
+      error?: string
+    }
+  }
+}
+
+async function checkDatabase(): Promise<
+  HealthCheckStatus['services']['database']
+> {
+  try {
+    // Simple query to test database connectivity
+    await prisma.$queryRaw`SELECT 1`
+    return {
+      status: 'healthy',
+    }
+  } catch (error) {
+    return {
+      status: 'unhealthy',
+      error:
+        error instanceof Error ? error.message : 'Database connection failed',
+    }
+  }
+}
+
+function createHealthResponse(
+  data: HealthCheckStatus,
+  isHealthy: boolean,
+): Response {
+  return new Response(JSON.stringify(data), {
+    status: isHealthy ? 200 : 503,
+    headers: {
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+async function performHealthCheck(isLiveness: boolean): Promise<Response> {
+  try {
+    const databaseStatus = await checkDatabase()
+
+    const services: HealthCheckStatus['services'] = {
+      database: databaseStatus,
+    }
+
+    // For liveness: always healthy if app responds (ignore DB status for HTTP code)
+    // For readiness: healthy only if all services are healthy
+    const isHealthy = isLiveness ? true : databaseStatus.status === 'healthy'
+    const status = isHealthy ? 'healthy' : 'unhealthy'
+
+    const healthStatus: HealthCheckStatus = {
+      status,
+      services,
+    }
+
+    return createHealthResponse(healthStatus, isHealthy)
+  } catch (error) {
+    const errorStatus: HealthCheckStatus = {
+      status: 'unhealthy',
+      services: {
+        database: {
+          status: 'unhealthy',
+          error:
+            error instanceof Error
+              ? error.message
+              : `${isLiveness ? 'Liveness' : 'Readiness'} check failed`,
+        },
+      },
+    }
+
+    return createHealthResponse(errorStatus, false)
+  }
+}
+
+export async function checkReadiness(): Promise<Response> {
+  return performHealthCheck(false)
+}
+
+export async function checkLiveness(): Promise<Response> {
+  return performHealthCheck(true)
+}

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -17,7 +17,8 @@ function getAcceptLanguageLocale(requestHeaders: Headers, locales: Locales) {
   try {
     locale = match(languages, locales, defaultLocale)
   } catch (e) {
-    // invalid language
+    // invalid language - fallback to default
+    locale = defaultLocale
   }
   return locale
 }


### PR DESCRIPTION
Hi,

After being impacted by #221 I wanted to contribute to this great replacement for Tricount.
I let loose Cursor to get this very basic implementation for:

- A health check endpoint, useful in environments such as Kubernetes

I differentiated "liveness" and "readiness" probe but for most cases just the `/api/health` will be enough.

- Fix the locale selection with a sane default in case of error  --> default to en-US

## New Endpoints

```bash
GET /api/health           # Default (same as readiness) - for monitoring tools
GET /api/health/liveness  # App health only - for Kubernetes liveness probe
GET /api/health/readiness # All dependencies - for Kubernetes readiness probe
```

The response looks like this (code 200 or 503). We could add test to other external services such as S3/openAI but I think it would be overkill for the moment

```json
{
  "status": "healthy",
  "services": {
    "database": {
      "status": "healthy"
    }
  }
}
```

## Local Testing
- `curl http://localhost:3000` - No more 500 errors with missing Accept-Language
- All health endpoints work correctly with/without database


Let me know if you want to spliit this into two PR, but it should close #221.
