### PR TITLE
feat: add expense duplication functionality

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -189,6 +189,8 @@
     "notesField": {
       "label": "Notizen"
     },
+    "copy": "Kopie",
+    "duplicate": "Ausgabe duplizieren",
     "selectNone": "Keine auswählen",
     "selectAll": "Alle auswählen",
     "shares": "Anteil(e)",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -190,6 +190,8 @@
     "notesField": {
       "label": "Notes"
     },
+    "copy": "Copy",
+    "duplicate": "Duplicate expense",
     "selectNone": "Select none",
     "selectAll": "Select all",
     "shares": "share(s)",

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -189,6 +189,8 @@
     "notesField": {
       "label": "Notes"
     },
+    "copy": "Copie",
+    "duplicate": "Dupliquer la dépense",
     "selectNone": "Tout désélectionner",
     "selectAll": "Tout sélectionner",
     "shares": "part(s)",


### PR DESCRIPTION
- Add "Copy" and "Duplicate expense" translations in DE, EN, and FR
- Implement duplicate expense feature in edit form with URL parameter
- Add duplicate button to expense form with copy icon
- Auto-prefix duplicated expense titles with "(Copy)" suffix
- Set current date for duplicated expenses
- Hide cancel button and duplicate button in duplicate mode
- Navigate to edit page of new duplicated expense

Closes #286 