### PR TITLE
bugfix: Store originalAmount in minor units to match amount and avoid issues with fractional values in int database fields.

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -191,7 +191,9 @@ export function ExpenseForm({
           expenseDate: expense.expenseDate ?? new Date(),
           amount: amountAsDecimal(expense.amount, groupCurrency),
           originalCurrency: expense.originalCurrency ?? group.currencyCode,
-          originalAmount: expense.originalAmount ?? undefined,
+          originalAmount: expense.originalAmount
+            ? amountAsDecimal(expense.originalAmount, getCurrency(expense.originalCurrency ?? group.currencyCode, locale, 'Custom'))
+            : undefined,
           conversionRate: expense.conversionRate?.toNumber(),
           category: expense.categoryId,
           paidBy: expense.paidById,
@@ -289,6 +291,8 @@ export function ExpenseForm({
     if (!conversionRequired) {
       delete values.originalAmount
       delete values.originalCurrency
+    } else if (values.originalAmount !== undefined) {
+      values.originalAmount = amountAsMinorUnits(values.originalAmount, originalCurrency)
     }
     return onSubmit(values, activeUserId ?? undefined)
   }


### PR DESCRIPTION
`originalAmount` was previously not stored in minor units, causing data loss when saving fractional values since the database field is `int`. This change aligns `originalAmount` with `amount`, ensuring consistent storage and behaviour.