### PR TITLE
Fix/refactor expense calculation

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -915,6 +915,8 @@ export function ExpenseForm({
                                             Number(form.watch('amount')),
                                             groupCurrency,
                                           ), // Convert to cents
+                                          expenseDate:
+                                            form.watch('expenseDate') ?? new Date(),
                                           paidFor: field.value.map(
                                             ({ participant, shares }) => ({
                                               participant: {
@@ -940,8 +942,15 @@ export function ExpenseForm({
                                           splitMode: form.watch('splitMode'),
                                           isReimbursement:
                                             form.watch('isReimbursement'),
+                                          paidBy: {
+                                            id:
+                                              form.watch('paidBy') ??
+                                              field.value[0]?.participant,
+                                            // name is required for the helper but irrelevant here
+                                            name: '',
+                                          },
                                         }),
-                                        locale,
+                                        locale
                                       )}
                                       )
                                     </span>

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -916,7 +916,8 @@ export function ExpenseForm({
                                             groupCurrency,
                                           ), // Convert to cents
                                           expenseDate:
-                                            form.watch('expenseDate') ?? new Date(),
+                                            form.watch('expenseDate') ??
+                                            new Date(),
                                           paidFor: field.value.map(
                                             ({ participant, shares }) => ({
                                               participant: {
@@ -950,7 +951,7 @@ export function ExpenseForm({
                                             name: '',
                                           },
                                         }),
-                                        locale
+                                        locale,
                                       )}
                                       )
                                     </span>

--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -1,4 +1,5 @@
 import { getCurrency } from '@/lib/currency'
+import { calculateShares } from '@/lib/totals'
 import { formatAmountAsDecimal, getCurrencyFromGroup } from '@/lib/utils'
 import { Parser } from '@json2csv/plainjs'
 import { PrismaClient } from '@prisma/client'
@@ -43,8 +44,13 @@ export async function GET(
           originalAmount: true,
           originalCurrency: true,
           conversionRate: true,
-          paidById: true,
-          paidFor: { select: { participantId: true, shares: true } },
+          paidBy: { select: { id: true, name: true } },
+          paidFor: {
+            select: {
+              participant: { select: { id: true, name: true } },
+              shares: true,
+            },
+          },
           isReimbursement: true,
           splitMode: true,
         },
@@ -102,50 +108,54 @@ export async function GET(
 
   const currency = getCurrencyFromGroup(group)
 
-  const expenses = group.expenses.map((expense) => ({
-    date: formatDate(expense.expenseDate),
-    title: expense.title,
-    categoryName: expense.category?.name || '',
-    currency: group.currencyCode ?? group.currency,
-    amount: formatAmountAsDecimal(expense.amount, currency),
-    originalAmount: expense.originalAmount
-      ? formatAmountAsDecimal(
-          expense.originalAmount,
-          getCurrency(expense.originalCurrency),
-        )
-      : null,
-    originalCurrency: expense.originalCurrency,
-    conversionRate: expense.conversionRate
-      ? expense.conversionRate.toString()
-      : null,
-    isReimbursement: expense.isReimbursement ? 'Yes' : 'No',
-    splitMode: splitModeLabel[expense.splitMode],
-    ...Object.fromEntries(
-      group.participants.map((participant) => {
-        const { totalShares, participantShare } = expense.paidFor.reduce(
-          (acc, { participantId, shares }) => {
-            acc.totalShares += shares
-            if (participantId === participant.id) {
-              acc.participantShare = shares
-            }
-            return acc
-          },
-          { totalShares: 0, participantShare: 0 },
-        )
+  const expenses = group.expenses.map((expense) => {
+    const shares = calculateShares({
+      amount: expense.amount,
+      paidFor: expense.paidFor,
+      splitMode: expense.splitMode,
+      isReimbursement: expense.isReimbursement,
+      paidBy: expense.paidBy,
+      expenseDate: expense.expenseDate,
+    })
 
-        const isPaidByParticipant = expense.paidById === participant.id
-        const participantAmountShare = +formatAmountAsDecimal(
-          (expense.amount / totalShares) * participantShare,
-          currency,
-        )
+    const payerId =
+      expense.paidBy?.id ?? expense.paidFor[0]?.participant.id ?? null
 
-        return [
-          participant.name,
-          participantAmountShare * (isPaidByParticipant ? 1 : -1),
-        ]
-      }),
-    ),
-  }))
+    return {
+      date: formatDate(expense.expenseDate),
+      title: expense.title,
+      categoryName: expense.category?.name || '',
+      currency: group.currencyCode ?? group.currency,
+      amount: formatAmountAsDecimal(expense.amount, currency),
+      originalAmount: expense.originalAmount
+        ? formatAmountAsDecimal(
+            expense.originalAmount,
+            getCurrency(expense.originalCurrency),
+          )
+        : null,
+      originalCurrency: expense.originalCurrency,
+      conversionRate: expense.conversionRate
+        ? expense.conversionRate.toString()
+        : null,
+      isReimbursement: expense.isReimbursement ? 'Yes' : 'No',
+      splitMode: splitModeLabel[expense.splitMode],
+      ...Object.fromEntries(
+        group.participants.map((participant) => {
+          const participantShare = shares[participant.id] ?? 0
+          const isPaidByParticipant = payerId === participant.id
+          const netAmount = isPaidByParticipant
+            ? expense.amount - participantShare
+            : -participantShare
+
+          return [
+            participant.name,
+            // keep as formatted string to preserve trailing zeros
+            formatAmountAsDecimal(netAmount, currency),
+          ]
+        }),
+      ),
+    }
+  })
 
   const json2csvParser = new Parser({ fields })
   const csv = json2csvParser.parse(expenses)

--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -1,6 +1,6 @@
 import { getGroupExpenses } from '@/lib/api'
-import { Participant } from '@prisma/client'
 import { calculateShares } from '@/lib/totals'
+import { Participant } from '@prisma/client'
 
 export type Balances = Record<
   Participant['id'],

--- a/src/lib/totals.test.ts
+++ b/src/lib/totals.test.ts
@@ -1,0 +1,385 @@
+import { calculateShare, calculateShares } from './totals';
+
+const p1 = { id: 'p1', name: 'Participant 1' };
+const p2 = { id: 'p2', name: 'Participant 2' };
+const p3 = { id: 'p3', name: 'Participant 3' };
+
+const expenseBase = {
+  id: 'expense-1',
+  amount: 10000,
+  isReimbursement: false,
+  paidBy: p1,
+  expenseDate: new Date('2024-01-01T00:00:00.000Z'),
+};
+
+describe('calculateShares', () => {
+  it('should split evenly among all participants', () => {
+    const expense = {
+      ...expenseBase,
+      splitMode: 'EVENLY',
+      paidFor: [
+        { participant: p1, shares: 1 },
+        { participant: p2, shares: 1 },
+        { participant: p3, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(Object.values(shares).sort()).toEqual([3333, 3333, 3334]);
+    expect(
+      Object.entries(shares).reduce((sum, [, value]) => sum + value, 0),
+    ).toBe(10000);
+  });
+
+  it('should split by amount', () => {
+    const expense = {
+      ...expenseBase,
+      splitMode: 'BY_AMOUNT',
+      paidFor: [
+        { participant: p1, shares: 5000 },
+        { participant: p2, shares: 2500 },
+        { participant: p3, shares: 2500 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1']).toBe(5000);
+    expect(shares['p2']).toBe(2500);
+    expect(shares['p3']).toBe(2500);
+  });
+
+  it('should split by shares', () => {
+    const expense = {
+      ...expenseBase,
+      splitMode: 'BY_SHARES',
+      paidFor: [
+        { participant: p1, shares: 2 },
+        { participant: p2, shares: 1 },
+        { participant: p3, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1']).toBe(5000);
+    expect(shares['p2']).toBe(2500);
+    expect(shares['p3']).toBe(2500);
+  });
+
+  it('should split by percentage', () => {
+    const expense = {
+      ...expenseBase,
+      splitMode: 'BY_PERCENTAGE',
+      paidFor: [
+        { participant: p1, shares: 5000 }, // 50%
+        { participant: p2, shares: 2500 }, // 25%
+        { participant: p3, shares: 2500 }, // 25%
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1']).toBe(5000);
+    expect(shares['p2']).toBe(2500);
+    expect(shares['p3']).toBe(2500);
+  });
+
+  it('should handle rounding differences by assigning the remainder to trailing participants', () => {
+    const expense = {
+      ...expenseBase,
+      amount: 100,
+      splitMode: 'EVENLY',
+      paidFor: [
+        { participant: p1, shares: 1 },
+        { participant: p2, shares: 1 },
+        { participant: p3, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p3']).toBe(34);
+    expect(shares['p1']).toBe(33);
+    expect(shares['p2']).toBe(33);
+    expect(
+      Object.entries(shares).reduce((sum, [, value]) => sum + value, 0),
+    ).toBe(100);
+  });
+
+  it('should apply the same split logic for reimbursements', () => {
+    const expense = {
+      ...expenseBase,
+      isReimbursement: true,
+      splitMode: 'EVENLY',
+      paidFor: [
+        { participant: p2, shares: 1 },
+      ],
+      paidBy: p1,
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p2']).toBe(10000);
+    expect(shares['p1'] ?? 0).toBe(0);
+  });
+
+  it('should include reimbursements when requesting a single participant share', () => {
+    const expense = {
+      ...expenseBase,
+      isReimbursement: true,
+      splitMode: 'EVENLY',
+      paidFor: [{ participant: p2, shares: 1 }],
+      paidBy: p1,
+    };
+    expect(calculateShare('p2', expense)).toBe(10000);
+    expect(calculateShare('p1', expense)).toBe(0);
+  });
+
+  it('should handle the payer not being in the paidFor list', () => {
+    const expense = {
+      ...expenseBase,
+      paidBy: p1,
+      splitMode: 'EVENLY',
+      paidFor: [
+        { participant: p2, shares: 1 },
+        { participant: p3, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1'] ?? 0).toBe(0);
+    expect(shares['p2']).toBe(5000);
+    expect(shares['p3']).toBe(5000);
+  });
+
+  it('should distribute rounding differences deterministically even if payer changes', () => {
+    const expense = {
+      ...expenseBase,
+      amount: 100,
+      paidBy: p2,
+      splitMode: 'EVENLY',
+      paidFor: [
+        { participant: p1, shares: 1 },
+        { participant: p2, shares: 1 },
+        { participant: p3, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(Object.values(shares).sort()).toEqual([33, 33, 34]);
+    expect(
+      Object.entries(shares).reduce((sum, [, value]) => sum + value, 0),
+    ).toBe(100);
+  });
+
+  it('should handle percentages not summing to 100%', () => {
+    const expense = {
+      ...expenseBase,
+      splitMode: 'BY_PERCENTAGE',
+      paidFor: [
+        { participant: p1, shares: 4000 }, // 40%
+        { participant: p2, shares: 4000 }, // 40%
+      ],
+    };
+    const shares = calculateShares(expense);
+    // 80% of 10000 is 8000. Remainder is 2000. Payer (p1) gets it.
+    expect(shares['p1'] + shares['p2']).toBe(10000);
+    expect(shares['p1']).toBeGreaterThanOrEqual(4000);
+    expect(shares['p2']).toBeGreaterThanOrEqual(4000);
+  });
+
+  it('should handle an empty paidFor list', () => {
+    const expense = {
+      ...expenseBase,
+      splitMode: 'EVENLY',
+      paidFor: [],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1']).toBe(10000);
+  });
+
+  it('should handle 0 total shares in BY_SHARES mode', () => {
+    const expense = {
+      ...expenseBase,
+      splitMode: 'BY_SHARES',
+      paidFor: [
+        { participant: p1, shares: 0 },
+        { participant: p2, shares: 0 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(
+      Object.entries(shares).reduce((sum, [, value]) => sum + value, 0),
+    ).toBe(10000);
+    expect(Object.values(shares).every((value) => value >= 0)).toBe(true);
+  });
+
+  it('should handle a zero amount expense', () => {
+    const expense = {
+      ...expenseBase,
+      amount: 0,
+      splitMode: 'EVENLY',
+      paidFor: [
+        { participant: p1, shares: 1 },
+        { participant: p2, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1'] + 0).toBe(0); // avoid -0 vs 0
+    expect(shares['p2']).toBe(0);
+  });
+
+  it('should give any leftover cents to the last participants first', () => {
+    const expense = {
+      ...expenseBase,
+      amount: 101,
+      splitMode: 'EVENLY' as const,
+      paidFor: [
+        { participant: p1, shares: 1 },
+        { participant: p2, shares: 1 },
+        { participant: p3, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1']).toBe(33);
+    expect(shares['p2']).toBe(34);
+    expect(shares['p3']).toBe(34);
+    expect(Object.values(shares).reduce((sum, value) => sum + value, 0)).toBe(
+      101,
+    );
+  });
+
+  it('should subtract leftover cents from the end for negative expenses', () => {
+    const expense = {
+      ...expenseBase,
+      amount: -101,
+      splitMode: 'EVENLY' as const,
+      paidFor: [
+        { participant: p1, shares: 1 },
+        { participant: p2, shares: 1 },
+        { participant: p3, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1']).toBe(-33);
+    expect(shares['p2']).toBe(-34);
+    expect(shares['p3']).toBe(-34);
+    expect(Object.values(shares).reduce((sum, value) => sum + value, 0)).toBe(
+      -101,
+    );
+  });
+
+  it('should distribute remainder in BY_AMOUNT mode if amounts do not sum up', () => {
+    const expense = {
+      ...expenseBase,
+      amount: 10000,
+      splitMode: 'BY_AMOUNT',
+      paidFor: [
+        { participant: p1, shares: 4000 },
+        { participant: p2, shares: 4000 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    const totalShares = Object.values(shares).reduce((sum, v) => sum + v, 0);
+    expect(totalShares).toBe(10000);
+    // p1 is the payer and should get the remainder
+    expect(shares['p1']).toBe(6000);
+    expect(shares['p2']).toBe(4000);
+  });
+
+  it('should handle negative expense amounts (refunds)', () => {
+    const expense = {
+      ...expenseBase,
+      amount: -10000,
+      splitMode: 'EVENLY',
+      paidFor: [
+        { participant: p1, shares: 1 },
+        { participant: p2, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1']).toBe(-5000);
+    expect(shares['p2']).toBe(-5000);
+    const totalShares = Object.values(shares).reduce((sum, v) => sum + v, 0);
+    expect(totalShares).toBe(-10000);
+  });
+
+  it('should handle an undefined payer by falling back to the first participant', () => {
+    const expense = {
+      ...expenseBase,
+      amount: 100,
+      paidBy: undefined as any,
+      splitMode: 'EVENLY',
+      paidFor: [
+        { participant: p2, shares: 1 },
+        { participant: p3, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    const totalShares = Object.values(shares).reduce((sum, v) => sum + v, 0);
+    expect(totalShares).toBe(100);
+    expect(shares['p2']).toBe(50);
+    expect(shares['p3']).toBe(50);
+  });
+
+  it('should break ties by giving remainders to later participants (EVENLY, amount=2, 3 participants)', () => {
+    const expense = {
+      ...expenseBase,
+      amount: 2,
+      splitMode: 'EVENLY' as const,
+      paidFor: [
+        { participant: p1, shares: 1 },
+        { participant: p2, shares: 1 },
+        { participant: p3, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    // fractions are equal; remainder (2) should go to the last two participants
+    expect(shares['p1'] + 0).toBe(0);
+    expect(shares['p2']).toBe(1);
+    expect(shares['p3']).toBe(1);
+    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(2);
+  });
+
+  it('should break ties for negative amounts by subtracting from later participants first (EVENLY, amount=-2, 3 participants)', () => {
+    const expense = {
+      ...expenseBase,
+      amount: -2,
+      splitMode: 'EVENLY' as const,
+      paidFor: [
+        { participant: p1, shares: 1 },
+        { participant: p2, shares: 1 },
+        { participant: p3, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1'] + 0).toBe(0);
+    expect(shares['p2']).toBe(-1);
+    expect(shares['p3']).toBe(-1);
+    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(-2);
+  });
+
+  it('should break ties in BY_SHARES by giving remainders to later participants (amount=2, shares equal)', () => {
+    const expense = {
+      ...expenseBase,
+      amount: 2,
+      splitMode: 'BY_SHARES' as const,
+      paidFor: [
+        { participant: p1, shares: 1 },
+        { participant: p2, shares: 1 },
+        { participant: p3, shares: 1 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1']).toBe(0);
+    expect(shares['p2']).toBe(1);
+    expect(shares['p3']).toBe(1);
+    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(2);
+  });
+
+  it('should break ties in BY_PERCENTAGE by giving remainders to later participants (amount=2, equal percentages)', () => {
+    const expense = {
+      ...expenseBase,
+      amount: 2,
+      splitMode: 'BY_PERCENTAGE' as const,
+      paidFor: [
+        { participant: p1, shares: 3333 },
+        { participant: p2, shares: 3333 },
+        { participant: p3, shares: 3333 },
+      ],
+    };
+    const shares = calculateShares(expense);
+    expect(shares['p1']).toBe(0);
+    expect(shares['p2']).toBe(1);
+    expect(shares['p3']).toBe(1);
+    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(2);
+  });
+});

--- a/src/lib/totals.test.ts
+++ b/src/lib/totals.test.ts
@@ -1,3 +1,4 @@
+import { SplitMode } from '@prisma/client'
 import { calculateShare, calculateShares } from './totals';
 
 const p1 = { id: 'p1', name: 'Participant 1' };
@@ -16,7 +17,7 @@ describe('calculateShares', () => {
   it('should split evenly among all participants', () => {
     const expense = {
       ...expenseBase,
-      splitMode: 'EVENLY',
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
@@ -33,7 +34,7 @@ describe('calculateShares', () => {
   it('should split by amount', () => {
     const expense = {
       ...expenseBase,
-      splitMode: 'BY_AMOUNT',
+      splitMode: SplitMode.BY_AMOUNT,
       paidFor: [
         { participant: p1, shares: 5000 },
         { participant: p2, shares: 2500 },
@@ -49,7 +50,7 @@ describe('calculateShares', () => {
   it('should split by shares', () => {
     const expense = {
       ...expenseBase,
-      splitMode: 'BY_SHARES',
+      splitMode: SplitMode.BY_SHARES,
       paidFor: [
         { participant: p1, shares: 2 },
         { participant: p2, shares: 1 },
@@ -65,7 +66,7 @@ describe('calculateShares', () => {
   it('should split by percentage', () => {
     const expense = {
       ...expenseBase,
-      splitMode: 'BY_PERCENTAGE',
+      splitMode: SplitMode.BY_PERCENTAGE,
       paidFor: [
         { participant: p1, shares: 5000 }, // 50%
         { participant: p2, shares: 2500 }, // 25%
@@ -82,7 +83,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       amount: 100,
-      splitMode: 'EVENLY',
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
@@ -102,7 +103,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       isReimbursement: true,
-      splitMode: 'EVENLY',
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p2, shares: 1 },
       ],
@@ -117,7 +118,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       isReimbursement: true,
-      splitMode: 'EVENLY',
+      splitMode: SplitMode.EVENLY,
       paidFor: [{ participant: p2, shares: 1 }],
       paidBy: p1,
     };
@@ -129,7 +130,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       paidBy: p1,
-      splitMode: 'EVENLY',
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
@@ -146,7 +147,7 @@ describe('calculateShares', () => {
       ...expenseBase,
       amount: 100,
       paidBy: p2,
-      splitMode: 'EVENLY',
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
@@ -163,7 +164,7 @@ describe('calculateShares', () => {
   it('should handle percentages not summing to 100%', () => {
     const expense = {
       ...expenseBase,
-      splitMode: 'BY_PERCENTAGE',
+      splitMode: SplitMode.BY_PERCENTAGE,
       paidFor: [
         { participant: p1, shares: 4000 }, // 40%
         { participant: p2, shares: 4000 }, // 40%
@@ -179,7 +180,7 @@ describe('calculateShares', () => {
   it('should handle an empty paidFor list', () => {
     const expense = {
       ...expenseBase,
-      splitMode: 'EVENLY',
+      splitMode: SplitMode.EVENLY,
       paidFor: [],
     };
     const shares = calculateShares(expense);
@@ -189,7 +190,7 @@ describe('calculateShares', () => {
   it('should handle 0 total shares in BY_SHARES mode', () => {
     const expense = {
       ...expenseBase,
-      splitMode: 'BY_SHARES',
+      splitMode: SplitMode.BY_SHARES,
       paidFor: [
         { participant: p1, shares: 0 },
         { participant: p2, shares: 0 },
@@ -206,7 +207,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       amount: 0,
-      splitMode: 'EVENLY',
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
@@ -221,7 +222,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       amount: 101,
-      splitMode: 'EVENLY' as const,
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
@@ -241,7 +242,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       amount: -101,
-      splitMode: 'EVENLY' as const,
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
@@ -261,7 +262,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       amount: 10000,
-      splitMode: 'BY_AMOUNT',
+      splitMode: SplitMode.BY_AMOUNT,
       paidFor: [
         { participant: p1, shares: 4000 },
         { participant: p2, shares: 4000 },
@@ -279,7 +280,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       amount: -10000,
-      splitMode: 'EVENLY',
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
@@ -297,7 +298,7 @@ describe('calculateShares', () => {
       ...expenseBase,
       amount: 100,
       paidBy: undefined as any,
-      splitMode: 'EVENLY',
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
@@ -314,7 +315,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       amount: 2,
-      splitMode: 'EVENLY' as const,
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
@@ -333,7 +334,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       amount: -2,
-      splitMode: 'EVENLY' as const,
+      splitMode: SplitMode.EVENLY,
       paidFor: [
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
@@ -351,7 +352,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       amount: 2,
-      splitMode: 'BY_SHARES' as const,
+      splitMode: SplitMode.BY_SHARES,
       paidFor: [
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
@@ -369,7 +370,7 @@ describe('calculateShares', () => {
     const expense = {
       ...expenseBase,
       amount: 2,
-      splitMode: 'BY_PERCENTAGE' as const,
+      splitMode: SplitMode.BY_PERCENTAGE,
       paidFor: [
         { participant: p1, shares: 3333 },
         { participant: p2, shares: 3333 },

--- a/src/lib/totals.test.ts
+++ b/src/lib/totals.test.ts
@@ -1,9 +1,9 @@
 import { SplitMode } from '@prisma/client'
-import { calculateShare, calculateShares } from './totals';
+import { calculateShare, calculateShares } from './totals'
 
-const p1 = { id: 'p1', name: 'Participant 1' };
-const p2 = { id: 'p2', name: 'Participant 2' };
-const p3 = { id: 'p3', name: 'Participant 3' };
+const p1 = { id: 'p1', name: 'Participant 1' }
+const p2 = { id: 'p2', name: 'Participant 2' }
+const p3 = { id: 'p3', name: 'Participant 3' }
 
 const expenseBase = {
   id: 'expense-1',
@@ -11,7 +11,7 @@ const expenseBase = {
   isReimbursement: false,
   paidBy: p1,
   expenseDate: new Date('2024-01-01T00:00:00.000Z'),
-};
+}
 
 describe('calculateShares', () => {
   it('should split evenly among all participants', () => {
@@ -23,13 +23,13 @@ describe('calculateShares', () => {
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(Object.values(shares).sort()).toEqual([3333, 3333, 3334]);
+    }
+    const shares = calculateShares(expense)
+    expect(Object.values(shares).sort()).toEqual([3333, 3333, 3334])
     expect(
       Object.entries(shares).reduce((sum, [, value]) => sum + value, 0),
-    ).toBe(10000);
-  });
+    ).toBe(10000)
+  })
 
   it('should split by amount', () => {
     const expense = {
@@ -40,12 +40,12 @@ describe('calculateShares', () => {
         { participant: p2, shares: 2500 },
         { participant: p3, shares: 2500 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1']).toBe(5000);
-    expect(shares['p2']).toBe(2500);
-    expect(shares['p3']).toBe(2500);
-  });
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1']).toBe(5000)
+    expect(shares['p2']).toBe(2500)
+    expect(shares['p3']).toBe(2500)
+  })
 
   it('should split by shares', () => {
     const expense = {
@@ -56,12 +56,12 @@ describe('calculateShares', () => {
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1']).toBe(5000);
-    expect(shares['p2']).toBe(2500);
-    expect(shares['p3']).toBe(2500);
-  });
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1']).toBe(5000)
+    expect(shares['p2']).toBe(2500)
+    expect(shares['p3']).toBe(2500)
+  })
 
   it('should split by percentage', () => {
     const expense = {
@@ -72,12 +72,12 @@ describe('calculateShares', () => {
         { participant: p2, shares: 2500 }, // 25%
         { participant: p3, shares: 2500 }, // 25%
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1']).toBe(5000);
-    expect(shares['p2']).toBe(2500);
-    expect(shares['p3']).toBe(2500);
-  });
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1']).toBe(5000)
+    expect(shares['p2']).toBe(2500)
+    expect(shares['p3']).toBe(2500)
+  })
 
   it('should handle rounding differences by assigning the remainder to trailing participants', () => {
     const expense = {
@@ -89,30 +89,28 @@ describe('calculateShares', () => {
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p3']).toBe(34);
-    expect(shares['p1']).toBe(33);
-    expect(shares['p2']).toBe(33);
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p3']).toBe(34)
+    expect(shares['p1']).toBe(33)
+    expect(shares['p2']).toBe(33)
     expect(
       Object.entries(shares).reduce((sum, [, value]) => sum + value, 0),
-    ).toBe(100);
-  });
+    ).toBe(100)
+  })
 
   it('should apply the same split logic for reimbursements', () => {
     const expense = {
       ...expenseBase,
       isReimbursement: true,
       splitMode: SplitMode.EVENLY,
-      paidFor: [
-        { participant: p2, shares: 1 },
-      ],
+      paidFor: [{ participant: p2, shares: 1 }],
       paidBy: p1,
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p2']).toBe(10000);
-    expect(shares['p1'] ?? 0).toBe(0);
-  });
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p2']).toBe(10000)
+    expect(shares['p1'] ?? 0).toBe(0)
+  })
 
   it('should include reimbursements when requesting a single participant share', () => {
     const expense = {
@@ -121,10 +119,10 @@ describe('calculateShares', () => {
       splitMode: SplitMode.EVENLY,
       paidFor: [{ participant: p2, shares: 1 }],
       paidBy: p1,
-    };
-    expect(calculateShare('p2', expense)).toBe(10000);
-    expect(calculateShare('p1', expense)).toBe(0);
-  });
+    }
+    expect(calculateShare('p2', expense)).toBe(10000)
+    expect(calculateShare('p1', expense)).toBe(0)
+  })
 
   it('should handle the payer not being in the paidFor list', () => {
     const expense = {
@@ -135,12 +133,12 @@ describe('calculateShares', () => {
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1'] ?? 0).toBe(0);
-    expect(shares['p2']).toBe(5000);
-    expect(shares['p3']).toBe(5000);
-  });
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1'] ?? 0).toBe(0)
+    expect(shares['p2']).toBe(5000)
+    expect(shares['p3']).toBe(5000)
+  })
 
   it('should distribute rounding differences deterministically even if payer changes', () => {
     const expense = {
@@ -153,13 +151,13 @@ describe('calculateShares', () => {
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(Object.values(shares).sort()).toEqual([33, 33, 34]);
+    }
+    const shares = calculateShares(expense)
+    expect(Object.values(shares).sort()).toEqual([33, 33, 34])
     expect(
       Object.entries(shares).reduce((sum, [, value]) => sum + value, 0),
-    ).toBe(100);
-  });
+    ).toBe(100)
+  })
 
   it('should handle percentages not summing to 100%', () => {
     const expense = {
@@ -169,23 +167,23 @@ describe('calculateShares', () => {
         { participant: p1, shares: 4000 }, // 40%
         { participant: p2, shares: 4000 }, // 40%
       ],
-    };
-    const shares = calculateShares(expense);
+    }
+    const shares = calculateShares(expense)
     // 80% of 10000 is 8000. Remainder is 2000. Payer (p1) gets it.
-    expect(shares['p1'] + shares['p2']).toBe(10000);
-    expect(shares['p1']).toBeGreaterThanOrEqual(4000);
-    expect(shares['p2']).toBeGreaterThanOrEqual(4000);
-  });
+    expect(shares['p1'] + shares['p2']).toBe(10000)
+    expect(shares['p1']).toBeGreaterThanOrEqual(4000)
+    expect(shares['p2']).toBeGreaterThanOrEqual(4000)
+  })
 
   it('should handle an empty paidFor list', () => {
     const expense = {
       ...expenseBase,
       splitMode: SplitMode.EVENLY,
       paidFor: [],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1']).toBe(10000);
-  });
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1']).toBe(10000)
+  })
 
   it('should handle 0 total shares in BY_SHARES mode', () => {
     const expense = {
@@ -195,13 +193,13 @@ describe('calculateShares', () => {
         { participant: p1, shares: 0 },
         { participant: p2, shares: 0 },
       ],
-    };
-    const shares = calculateShares(expense);
+    }
+    const shares = calculateShares(expense)
     expect(
       Object.entries(shares).reduce((sum, [, value]) => sum + value, 0),
-    ).toBe(10000);
-    expect(Object.values(shares).every((value) => value >= 0)).toBe(true);
-  });
+    ).toBe(10000)
+    expect(Object.values(shares).every((value) => value >= 0)).toBe(true)
+  })
 
   it('should handle a zero amount expense', () => {
     const expense = {
@@ -212,11 +210,11 @@ describe('calculateShares', () => {
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1'] + 0).toBe(0); // avoid -0 vs 0
-    expect(shares['p2']).toBe(0);
-  });
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1'] + 0).toBe(0) // avoid -0 vs 0
+    expect(shares['p2']).toBe(0)
+  })
 
   it('should give any leftover cents to the last participants first', () => {
     const expense = {
@@ -228,15 +226,15 @@ describe('calculateShares', () => {
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1']).toBe(33);
-    expect(shares['p2']).toBe(34);
-    expect(shares['p3']).toBe(34);
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1']).toBe(33)
+    expect(shares['p2']).toBe(34)
+    expect(shares['p3']).toBe(34)
     expect(Object.values(shares).reduce((sum, value) => sum + value, 0)).toBe(
       101,
-    );
-  });
+    )
+  })
 
   it('should subtract leftover cents from the end for negative expenses', () => {
     const expense = {
@@ -248,15 +246,15 @@ describe('calculateShares', () => {
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1']).toBe(-33);
-    expect(shares['p2']).toBe(-34);
-    expect(shares['p3']).toBe(-34);
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1']).toBe(-33)
+    expect(shares['p2']).toBe(-34)
+    expect(shares['p3']).toBe(-34)
     expect(Object.values(shares).reduce((sum, value) => sum + value, 0)).toBe(
       -101,
-    );
-  });
+    )
+  })
 
   it('should distribute remainder in BY_AMOUNT mode if amounts do not sum up', () => {
     const expense = {
@@ -267,14 +265,14 @@ describe('calculateShares', () => {
         { participant: p1, shares: 4000 },
         { participant: p2, shares: 4000 },
       ],
-    };
-    const shares = calculateShares(expense);
-    const totalShares = Object.values(shares).reduce((sum, v) => sum + v, 0);
-    expect(totalShares).toBe(10000);
+    }
+    const shares = calculateShares(expense)
+    const totalShares = Object.values(shares).reduce((sum, v) => sum + v, 0)
+    expect(totalShares).toBe(10000)
     // p1 is the payer and should get the remainder
-    expect(shares['p1']).toBe(6000);
-    expect(shares['p2']).toBe(4000);
-  });
+    expect(shares['p1']).toBe(6000)
+    expect(shares['p2']).toBe(4000)
+  })
 
   it('should handle negative expense amounts (refunds)', () => {
     const expense = {
@@ -285,13 +283,13 @@ describe('calculateShares', () => {
         { participant: p1, shares: 1 },
         { participant: p2, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1']).toBe(-5000);
-    expect(shares['p2']).toBe(-5000);
-    const totalShares = Object.values(shares).reduce((sum, v) => sum + v, 0);
-    expect(totalShares).toBe(-10000);
-  });
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1']).toBe(-5000)
+    expect(shares['p2']).toBe(-5000)
+    const totalShares = Object.values(shares).reduce((sum, v) => sum + v, 0)
+    expect(totalShares).toBe(-10000)
+  })
 
   it('should handle an undefined payer by falling back to the first participant', () => {
     const expense = {
@@ -303,13 +301,13 @@ describe('calculateShares', () => {
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    const totalShares = Object.values(shares).reduce((sum, v) => sum + v, 0);
-    expect(totalShares).toBe(100);
-    expect(shares['p2']).toBe(50);
-    expect(shares['p3']).toBe(50);
-  });
+    }
+    const shares = calculateShares(expense)
+    const totalShares = Object.values(shares).reduce((sum, v) => sum + v, 0)
+    expect(totalShares).toBe(100)
+    expect(shares['p2']).toBe(50)
+    expect(shares['p3']).toBe(50)
+  })
 
   it('should break ties by giving remainders to later participants (EVENLY, amount=2, 3 participants)', () => {
     const expense = {
@@ -321,14 +319,14 @@ describe('calculateShares', () => {
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
+    }
+    const shares = calculateShares(expense)
     // fractions are equal; remainder (2) should go to the last two participants
-    expect(shares['p1'] + 0).toBe(0);
-    expect(shares['p2']).toBe(1);
-    expect(shares['p3']).toBe(1);
-    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(2);
-  });
+    expect(shares['p1'] + 0).toBe(0)
+    expect(shares['p2']).toBe(1)
+    expect(shares['p3']).toBe(1)
+    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(2)
+  })
 
   it('should break ties for negative amounts by subtracting from later participants first (EVENLY, amount=-2, 3 participants)', () => {
     const expense = {
@@ -340,13 +338,13 @@ describe('calculateShares', () => {
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1'] + 0).toBe(0);
-    expect(shares['p2']).toBe(-1);
-    expect(shares['p3']).toBe(-1);
-    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(-2);
-  });
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1'] + 0).toBe(0)
+    expect(shares['p2']).toBe(-1)
+    expect(shares['p3']).toBe(-1)
+    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(-2)
+  })
 
   it('should break ties in BY_SHARES by giving remainders to later participants (amount=2, shares equal)', () => {
     const expense = {
@@ -358,13 +356,13 @@ describe('calculateShares', () => {
         { participant: p2, shares: 1 },
         { participant: p3, shares: 1 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1']).toBe(0);
-    expect(shares['p2']).toBe(1);
-    expect(shares['p3']).toBe(1);
-    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(2);
-  });
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1']).toBe(0)
+    expect(shares['p2']).toBe(1)
+    expect(shares['p3']).toBe(1)
+    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(2)
+  })
 
   it('should break ties in BY_PERCENTAGE by giving remainders to later participants (amount=2, equal percentages)', () => {
     const expense = {
@@ -376,11 +374,11 @@ describe('calculateShares', () => {
         { participant: p2, shares: 3333 },
         { participant: p3, shares: 3333 },
       ],
-    };
-    const shares = calculateShares(expense);
-    expect(shares['p1']).toBe(0);
-    expect(shares['p2']).toBe(1);
-    expect(shares['p3']).toBe(1);
-    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(2);
-  });
-});
+    }
+    const shares = calculateShares(expense)
+    expect(shares['p1']).toBe(0)
+    expect(shares['p2']).toBe(1)
+    expect(shares['p3']).toBe(1)
+    expect(Object.values(shares).reduce((s, v) => s + v, 0)).toBe(2)
+  })
+})

--- a/src/lib/totals.ts
+++ b/src/lib/totals.ts
@@ -88,8 +88,7 @@ export function calculateShares(
   }
 
   if (expense.splitMode === 'BY_AMOUNT') {
-    const payerId =
-      expense.paidBy?.id ?? expense.paidFor[0]?.participant.id
+    const payerId = expense.paidBy?.id ?? expense.paidFor[0]?.participant.id
     if (payerId) {
       result[payerId] = (result[payerId] ?? 0) + diff.toNumber()
     }
@@ -97,8 +96,7 @@ export function calculateShares(
   }
 
   if (participantOrder.length === 0) {
-    const payerId =
-      expense.paidBy?.id ?? expense.paidFor[0]?.participant.id
+    const payerId = expense.paidBy?.id ?? expense.paidFor[0]?.participant.id
     if (payerId) {
       result[payerId] = (result[payerId] ?? 0) + diff.toNumber()
     }
@@ -113,7 +111,8 @@ export function calculateShares(
     let part = new Decimal(0)
     switch (expense.splitMode) {
       case 'EVENLY':
-        if (expense.paidFor.length > 0) part = amount.div(expense.paidFor.length)
+        if (expense.paidFor.length > 0)
+          part = amount.div(expense.paidFor.length)
         break
       case 'BY_AMOUNT':
         part = shares

--- a/src/lib/totals.ts
+++ b/src/lib/totals.ts
@@ -1,3 +1,5 @@
+import Decimal from 'decimal.js'
+
 import { getGroupExpenses } from '@/lib/api'
 
 export function getTotalGroupSpending(
@@ -25,54 +27,151 @@ export function getTotalActiveUserPaidFor(
 
 type Expense = NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>[number]
 
-export function calculateShare(
-  participantId: string | null,
-  expense: Pick<
-    Expense,
-    'amount' | 'paidFor' | 'splitMode' | 'isReimbursement'
-  >,
-): number {
-  if (expense.isReimbursement) return 0
+type ExpenseForShares = Pick<
+  Expense,
+  'amount' | 'paidFor' | 'splitMode' | 'isReimbursement' | 'paidBy'
+> & {
+  expenseDate?: Expense['expenseDate']
+}
 
-  const paidFors = expense.paidFor
-  const userPaidFor = paidFors.find(
-    (paidFor) => paidFor.participant.id === participantId,
+export function calculateShares(
+  expense: ExpenseForShares,
+): Record<string, number> {
+  // Algorithm outline:
+  // 1. Compute every participant's exact share in minor units (`part`).
+  // 2. Truncate toward zero so that the sum never exceeds the available amount.
+  // 3. Track how many cents remain (`diff`) after truncation.
+  // 4. Distribute the remaining cents one by one to participants based on tie-break rules.
+  const result: Record<string, number> = {}
+  const amount = new Decimal(expense.amount)
+
+  const totalShares = expense.paidFor.reduce(
+    (sum, pf) => sum.add(new Decimal(pf.shares ?? 0)),
+    new Decimal(0),
   )
 
-  if (!userPaidFor) return 0
+  let sumRounded = new Decimal(0)
+  const participantOrder: string[] = []
 
-  const shares = Number(userPaidFor.shares)
+  expense.paidFor.forEach((pf) => {
+    const shares = new Decimal(pf.shares ?? 0)
+    let part = new Decimal(0)
+    switch (expense.splitMode) {
+      case 'EVENLY':
+        if (expense.paidFor.length > 0) {
+          part = amount.div(expense.paidFor.length)
+        }
+        break
+      case 'BY_AMOUNT':
+        part = shares
+        break
+      case 'BY_PERCENTAGE':
+        part = amount.mul(shares).div(10000)
+        break
+      case 'BY_SHARES':
+        if (totalShares.gt(0)) {
+          part = amount.mul(shares).div(totalShares)
+        }
+        break
+      default:
+        part = new Decimal(0)
+    }
+    const rounded = part.gte(0) ? part.floor() : part.ceil()
+    result[pf.participant.id] = rounded.toNumber()
+    sumRounded = sumRounded.add(rounded)
+    participantOrder.push(pf.participant.id)
+  })
 
-  switch (expense.splitMode) {
-    case 'EVENLY':
-      // Divide the total expense evenly among all participants
-      return expense.amount / paidFors.length
-    case 'BY_AMOUNT':
-      // Directly add the user's share if the split mode is BY_AMOUNT
-      return shares
-    case 'BY_PERCENTAGE':
-      // Calculate the user's share based on their percentage of the total expense
-      return (expense.amount * shares) / 10000 // Assuming shares are out of 10000 for percentage
-    case 'BY_SHARES':
-      // Calculate the user's share based on their shares relative to the total shares
-      const totalShares = paidFors.reduce(
-        (sum, paidFor) => sum + Number(paidFor.shares),
-        0,
-      )
-      return (expense.amount * shares) / totalShares
-    default:
-      return 0
+  let diff = amount.minus(sumRounded)
+  if (diff.isZero()) {
+    return result
   }
+
+  if (expense.splitMode === 'BY_AMOUNT') {
+    const payerId =
+      expense.paidBy?.id ?? expense.paidFor[0]?.participant.id
+    if (payerId) {
+      result[payerId] = (result[payerId] ?? 0) + diff.toNumber()
+    }
+    return result
+  }
+
+  if (participantOrder.length === 0) {
+    const payerId =
+      expense.paidBy?.id ?? expense.paidFor[0]?.participant.id
+    if (payerId) {
+      result[payerId] = (result[payerId] ?? 0) + diff.toNumber()
+    }
+    return result
+  }
+
+  // Distribute leftover cents by descending fractional parts
+  // Compute fractional remainders for each participant based on the exact part
+  const fractions: Array<{ id: string; frac: Decimal }> = []
+  expense.paidFor.forEach((pf) => {
+    const shares = new Decimal(pf.shares ?? 0)
+    let part = new Decimal(0)
+    switch (expense.splitMode) {
+      case 'EVENLY':
+        if (expense.paidFor.length > 0) part = amount.div(expense.paidFor.length)
+        break
+      case 'BY_AMOUNT':
+        part = shares
+        break
+      case 'BY_PERCENTAGE':
+        part = amount.mul(shares).div(10000)
+        break
+      case 'BY_SHARES':
+        if (totalShares.gt(0)) part = amount.mul(shares).div(totalShares)
+        break
+      default:
+        part = new Decimal(0)
+    }
+    const rounded = part.gte(0) ? part.floor() : part.ceil()
+    const frac = part.minus(rounded).abs() // magnitude of the truncated fractional part
+    fractions.push({ id: pf.participant.id, frac })
+  })
+
+  if (!diff.isZero() && participantOrder.length > 0) {
+    const direction = diff.gt(0) ? 1 : -1
+    let remaining = diff.abs().toNumber()
+
+    // Sort by fractional magnitude desc; tie-breaker by stable participant order
+    const orderIndex = new Map<string, number>(
+      participantOrder.map((id, idx) => [id, idx]),
+    )
+    fractions.sort((a, b) => {
+      const cmp = b.frac.comparedTo(a.frac)
+      if (cmp !== 0) return cmp
+      // tie-break by original order: prefer later participants first ("last" gets remainder)
+      return (orderIndex.get(b.id) ?? 0) - (orderIndex.get(a.id) ?? 0)
+    })
+
+    for (let i = 0; i < remaining; i++) {
+      const target = fractions[i % fractions.length]?.id
+      if (!target) break
+      result[target] = (result[target] ?? 0) + direction
+    }
+    diff = new Decimal(0)
+  }
+
+  return result
+}
+
+export function calculateShare(
+  participantId: string | null,
+  expense: ExpenseForShares,
+): number {
+  if (!participantId) return 0
+  return calculateShares(expense)[participantId] ?? 0
 }
 
 export function getTotalActiveUserShare(
   activeUserId: string | null,
   expenses: NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>,
 ): number {
-  const total = expenses.reduce(
+  return expenses.reduce(
     (sum, expense) => sum + calculateShare(activeUserId, expense),
     0,
   )
-
-  return parseFloat(total.toFixed(2))
 }


### PR DESCRIPTION
## Summary
- Fix #374: Every expense now distributes its full amount, even when minor units do not divide cleanly. Shares are computed with `decimal.js`, truncated toward zero to whole cents, and any remainder is distributed afterward.
- Remainder distribution by fractional parts: leftover cents (positive/negative) are allocated one by one to participants with the largest truncated fractional parts; on ties, later participants (by original order) receive the cent first.
- BY_AMOUNT stays deterministic: if submitted amounts do not sum exactly to the total, the payer gets the difference credited/debited.
- Balances and CSV export use the centralized `calculateShares` logic, keeping UI, exports, and summaries consistent.
- Comprehensive tests cover the new logic and the tie-break rules.
- The “Your share” preview in the form uses the new calculation logic.

### Refactoring Details

This PR goes beyond a simple bug fix and constitutes a significant refactoring of a core piece of the application's business logic.

**Before:**

*   **Fragmented Logic:** Expense share calculations were implemented independently and inconsistently in multiple places:
    *   The balance calculation in `src/lib/balances.ts`.
    *   The CSV export generation in `src/app/groups/[groupId]/expenses/export/csv/route.ts`.
    *   A simplistic `calculateShare` helper in `src/lib/totals.ts`.
*   **Inconsistent Behavior:** Each implementation had its own way of handling rounding and division, leading to potential bugs and inconsistencies between what users saw in the balance sheet versus what they got in an export.
*   **Precision Issues:** Calculations were performed using standard JavaScript numbers, making them susceptible to floating-point precision errors.

**After:**

*   **Single Source of Truth:** All calculation logic is consolidated in `calculateShares` (src/lib/totals.ts).
*   **Guaranteed Precision:** All internal arithmetic uses `decimal.js` for precise, finance-safe calculations.
*   **Centralized & Consistent:** `balances.ts`, `export/csv/route.ts`, and the form preview all use the central function — the same numbers everywhere.
*   **Deterministic & Testable:** Clear deterministic remainder distribution with a tie-break rule; a comprehensive test suite (`totals.test.ts`) locks behavior.

## Testing
- `npx jest src/lib/totals.test.ts --runInBand`
- Includes tie-break tests for equal fractions in EVENLY, BY_SHARES, and BY_PERCENTAGE (positive and negative amounts).

## Explanation of Remainder Distribution
- Compute each participant’s exact share using the selected split mode (evenly, by shares, by percentage, by amount).
- Truncate each exact share toward zero to whole cents. This guarantees the rounded shares never exceed the total amount.
- Compute the remainder: `remainder = totalAmount - sum(truncatedShares)`.
- Special case BY_AMOUNT: if the submitted amounts don’t sum to the total, give the entire remainder to the payer (credit or debit).
- Otherwise, distribute the remainder one cent at a time:
  - For each participant, compute the fractional part magnitude from their exact share (the portion that was cut off by truncation).
  - Order participants by larger fractional parts first. If multiple participants have the same fractional part, later participants (by the original list order) come first.
  - Add +1 cent to the first participant in this order for a positive remainder (or -1 cent for a negative remainder), move to the next participant, and repeat until the remainder is zero. 

## Examples
#### Split $1.00 evenly among 3 people (P1, P2, P3)
  - Exact shares: $1.00 ÷ 3 = $0.333333… each.
  - Truncate to cents (toward zero): $0.33, $0.33, $0.33.
  - Remainder: $1.00 − ($0.33 + $0.33 + $0.33) = $0.01.
  - Tie-break on equal fractions: later participants get leftover first.
  - Distribute remainder (one cent):
      - +$0.01 → P3
  - Final amounts: P1 = $0.33, P2 = $0.33, P3 = $0.34 (sum = $1.00).

#### Split $1.00 between 2 people with shares 2:1 (P1:P2)
  - Exact shares: $1.00 × (2/3) = $0.666666… for P1, and $1.00 × (1/3) = $0.333333… for P2.
  - Truncate to cents (toward zero): P1 = $0.66, P2 = $0.33.
  - Remainder: $1.00 − ($0.66 + $0.33) = $0.01.
  - Who gets the extra cent? The one with the larger fractional part (P1: .0066… vs P2: .0033…).
  - Final amounts: P1 = $0.67, P2 = $0.33 (sum = $1.00).
