### PR TITLE
fix: use correct volume mount for modern postgres images when running app on Container

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -19,7 +19,7 @@ services:
     env_file:
       - container.env
     volumes:
-      - ./postgres-data:/var/lib/postgresql/data
+      - ./postgres-data:/var/lib/postgresql/
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U postgres']
       interval: 5s


### PR DESCRIPTION
## Fixes Issue https://github.com/spliit-app/spliit/issues/463 

## How to test
Follow the README to run the container locally and it should run correctly without errors