### PR TITLE
[Feature request] CSV export: switch to per‑expense saldo format and remove reimbursement column

### DIFF
--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -127,8 +127,22 @@ export async function GET(
         shares,
       ]),
     ) as Record<string, number>
-    const totalShares = expense.paidFor.reduce(
-      (sum, { shares }) => sum + shares,
+    // Normalize shares based on split mode to mirror app logic
+    const isEvenly = expense.splitMode === 'EVENLY'
+    const normalizedSharesByParticipant: Record<string, number> = {}
+    for (const p of group.participants) {
+      if (isEvenly) {
+        normalizedSharesByParticipant[p.id] = expense.paidFor.some(
+          (pf) => pf.participantId === p.id,
+        )
+          ? 1
+          : 0
+      } else {
+        normalizedSharesByParticipant[p.id] = shareByParticipant[p.id] ?? 0
+      }
+    }
+    const totalShares = Object.values(normalizedSharesByParticipant).reduce(
+      (sum, v) => sum + v,
       0,
     )
 
@@ -154,36 +168,40 @@ export async function GET(
         : null,
       paidBy: participantIdNameMap[expense.paidById],
       splitMode: splitModeLabel[expense.splitMode],
-      // For every participant we export the *saldo* (net effect) of this single expense:
-      // - For the paying participant (paidBy):
-      //     saldo = totalAmount - participantShareAmount
-      //   -> how much they effectively advance for others.
-      // - For all other participants:
-      //     saldo = -participantShareAmount
-      //   -> how much they owe to the payer for this expense.
-      //
-      // The sum of all participant saldos for a given expense is always 0,
-      // which makes the CSV easy to aggregate in tools like Excel.
-      ...Object.fromEntries(
-        group.participants.map((participant) => {
-          const participantShare = shareByParticipant[participant.id] ?? 0
+      // For every participant we export the saldo (net effect) of this single expense.
+      // Compute participant shares in minor units first to avoid rounding drift.
+      ...(() => {
+        const entries: [string, number][] = []
+        // Determine ordered list of participants that actually have shares
+        const participantsWithShares = group.participants
+          .map((p, idx) => ({ p, idx }))
+          .filter(({ p }) => (normalizedSharesByParticipant[p.id] ?? 0) > 0)
+          .map(({ p }) => p.id)
 
-          const participantShareAmount =
-            totalShares === 0
-              ? 0
-              : +formatAmountAsDecimal(
-                  (normalizedAmount / totalShares) * participantShare,
-                  currency,
-                )
-
+        let remaining = normalizedAmount // minor units remaining to allocate
+        group.participants.forEach((participant) => {
+          const shares = normalizedSharesByParticipant[participant.id] ?? 0
+          let shareMinor = 0
+          if (totalShares > 0 && shares > 0) {
+            const isLast =
+              participant.id ===
+              participantsWithShares[participantsWithShares.length - 1]
+            if (isLast) {
+              shareMinor = remaining
+            } else {
+              shareMinor = Math.floor((normalizedAmount * shares) / totalShares)
+              remaining -= shareMinor
+            }
+          }
+          const shareMajor = +formatAmountAsDecimal(shareMinor, currency)
           const isPaidByParticipant = expense.paidById === participant.id
           const saldo = isPaidByParticipant
-            ? totalAmount - participantShareAmount
-            : -participantShareAmount
-
-          return [participant.name, saldo]
-        }),
-      ),
+            ? totalAmount - shareMajor
+            : -shareMajor
+          entries.push([participant.name, saldo])
+        })
+        return Object.fromEntries(entries)
+      })(),
     }
   })
 

--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -72,16 +72,17 @@ export async function GET(
   - Conversion rate: The rate used to convert the amount.
   - Is Reimbursement: Whether the expense is a reimbursement or not.
   - Split mode: The method used to split the expense (e.g., Evenly, By shares, By percentage, By amount).
+  - Paid By: The paying user
   - UserA, UserB: User-specific data or balances (e.g., amount owed or contributed by each user).
 
   Example Table:
-  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+--------+-----------+
-  | Date       | Description      | Category | Currency | Cost     | Original cost | Original currency | Conversion rate | Is reinbursement | Split mode           | User A | User B    |
-  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+--------+-----------+
-  | 2025-01-06 | Dinner with team | Food     | INR      | 5000     |               |                   |                 | No               | Evenly               | 2500   | -2500     |
-  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+--------+-----------+
-  | 2025-02-07 | Plane tickets    | Travel   | INR      | 97264.09 | 1000          | EUR               | 97.2641         | No               | Unevenly - By amount | -80000 | -17264.09 |
-  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+--------+-----------+
+  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+----------+--------+-----------+
+  | Date       | Description      | Category | Currency | Cost     | Original cost | Original currency | Conversion rate | Is reinbursement | Split mode           | Paid By  | User A | User B    |
+  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+----------+--------+-----------+
+  | 2025-01-06 | Dinner with team | Food     | INR      | 5000     |               |                   |                 | No               | Evenly               | User A   | 2500   | -2500     |
+  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+----------+--------+-----------+
+  | 2025-02-07 | Plane tickets    | Travel   | INR      | 97264.09 | 1000          | EUR               | 97.2641         | No               | Unevenly - By amount | User B   | -80000 | -17264.09 |
+  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+----------+--------+-----------+
 
   */
 
@@ -96,6 +97,7 @@ export async function GET(
     { label: 'Conversion rate', value: 'conversionRate' },
     { label: 'Is Reimbursement', value: 'isReimbursement' },
     { label: 'Split mode', value: 'splitMode' },
+    { label: 'Paid By', value: 'paidBy'},
     ...group.participants.map((participant) => ({
       label: participant.name,
       value: participant.name,
@@ -103,6 +105,9 @@ export async function GET(
   ]
 
   const currency = getCurrencyFromGroup(group)
+
+  const participantIdNameMap = Object.fromEntries(group.participants.map(p => [p.id, p.name])) as Record<string, string>
+
   const expenses = group.expenses.map((expense) => ({
     date: formatDate(expense.expenseDate),
     title: expense.title,
@@ -119,6 +124,7 @@ export async function GET(
     conversionRate: expense.conversionRate
       ? expense.conversionRate.toString()
       : null,
+    paidBy: participantIdNameMap[expense.paidById],
     isReimbursement: expense.isReimbursement ? 'Yes' : 'No',
     splitMode: splitModeLabel[expense.splitMode],
     ...Object.fromEntries(

--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -36,6 +36,7 @@ export async function GET(
       currencyCode: true,
       expenses: {
         select: {
+          createdAt: true,
           expenseDate: true,
           title: true,
           category: { select: { name: true } },
@@ -48,6 +49,7 @@ export async function GET(
           isReimbursement: true,
           splitMode: true,
         },
+        orderBy: [{ expenseDate: 'asc' }, { createdAt: 'asc' }],
       },
       participants: { select: { id: true, name: true } },
     },
@@ -101,7 +103,6 @@ export async function GET(
   ]
 
   const currency = getCurrencyFromGroup(group)
-
   const expenses = group.expenses.map((expense) => ({
     date: formatDate(expense.expenseDate),
     title: expense.title,

--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -10,7 +10,7 @@ const splitModeLabel = {
   BY_SHARES: 'Unevenly – By shares',
   BY_PERCENTAGE: 'Unevenly – By percentage',
   BY_AMOUNT: 'Unevenly – By amount',
-}
+} as const
 
 function formatDate(isoDateString: Date): string {
   const date = new Date(isoDateString)
@@ -70,19 +70,18 @@ export async function GET(
   - Original cost: The amount spent in the original currency.
   - Original currency: The currency the amount was originally spent in.
   - Conversion rate: The rate used to convert the amount.
-  - Is Reimbursement: Whether the expense is a reimbursement or not.
   - Split mode: The method used to split the expense (e.g., Evenly, By shares, By percentage, By amount).
   - Paid By: The paying user
-  - UserA, UserB: User-specific data or balances (e.g., amount owed or contributed by each user).
+  - UserA, UserB: Per-participant saldo for this expense (payer advances vs owed amount). Saldos per row sum to 0.
 
   Example Table:
-  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+----------+--------+-----------+
-  | Date       | Description      | Category | Currency | Cost     | Original cost | Original currency | Conversion rate | Is reinbursement | Split mode           | Paid By  | User A | User B    |
-  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+----------+--------+-----------+
-  | 2025-01-06 | Dinner with team | Food     | INR      | 5000     |               |                   |                 | No               | Evenly               | User A   | 2500   | -2500     |
-  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+----------+--------+-----------+
-  | 2025-02-07 | Plane tickets    | Travel   | INR      | 97264.09 | 1000          | EUR               | 97.2641         | No               | Unevenly - By amount | User B   | -80000 | -17264.09 |
-  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+------------------+----------------------+----------+--------+-----------+
+  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+----------------------+----------+--------+-----------+
+  | Date       | Description      | Category | Currency | Cost     | Original cost | Original currency | Conversion rate | Split mode           | Paid By  | User A | User B    |
+  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+----------------------+----------+--------+-----------+
+  | 2025-01-06 | Dinner with team | Food     | INR      | 5000     |               |                   |                 | Evenly               | User A   | 2500   | -2500     |
+  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+----------------------+----------+--------+-----------+
+  | 2025-02-07 | Plane tickets    | Travel   | INR      | 97264.09 | 1000          | EUR               | 97.2641         | Unevenly - By amount | User B   | -80000 | -17264.09 |
+  +------------+------------------+----------+----------+----------+---------------+-------------------+-----------------+----------------------+----------+--------+-----------+
 
   */
 
@@ -95,9 +94,8 @@ export async function GET(
     { label: 'Original cost', value: 'originalAmount' },
     { label: 'Original currency', value: 'originalCurrency' },
     { label: 'Conversion rate', value: 'conversionRate' },
-    { label: 'Is Reimbursement', value: 'isReimbursement' },
     { label: 'Split mode', value: 'splitMode' },
-    { label: 'Paid By', value: 'paidBy'},
+    { label: 'Paid By', value: 'paidBy' },
     ...group.participants.map((participant) => ({
       label: participant.name,
       value: participant.name,
@@ -106,53 +104,88 @@ export async function GET(
 
   const currency = getCurrencyFromGroup(group)
 
-  const participantIdNameMap = Object.fromEntries(group.participants.map(p => [p.id, p.name])) as Record<string, string>
+  const participantIdNameMap = Object.fromEntries(
+    group.participants.map((p) => [p.id, p.name]),
+  ) as Record<string, string>
 
-  const expenses = group.expenses.map((expense) => ({
-    date: formatDate(expense.expenseDate),
-    title: expense.title,
-    categoryName: expense.category?.name || '',
-    currency: group.currencyCode ?? group.currency,
-    amount: formatAmountAsDecimal(expense.amount, currency),
-    originalAmount: expense.originalAmount
-      ? formatAmountAsDecimal(
-          expense.originalAmount,
-          getCurrency(expense.originalCurrency),
-        )
-      : null,
-    originalCurrency: expense.originalCurrency,
-    conversionRate: expense.conversionRate
-      ? expense.conversionRate.toString()
-      : null,
-    paidBy: participantIdNameMap[expense.paidById],
-    isReimbursement: expense.isReimbursement ? 'Yes' : 'No',
-    splitMode: splitModeLabel[expense.splitMode],
-    ...Object.fromEntries(
-      group.participants.map((participant) => {
-        const { totalShares, participantShare } = expense.paidFor.reduce(
-          (acc, { participantId, shares }) => {
-            acc.totalShares += shares
-            if (participantId === participant.id) {
-              acc.participantShare = shares
-            }
-            return acc
-          },
-          { totalShares: 0, participantShare: 0 },
-        )
+  const expenses = group.expenses.map((expense) => {
+    const normalizedAmount = Number(expense.amount)
+    const normalizedOriginalAmount = expense.originalAmount
+      ? Number(expense.originalAmount)
+      : null
+    const normalizedConversionRate = expense.conversionRate
+      ? Number(expense.conversionRate)
+      : null
 
-        const isPaidByParticipant = expense.paidById === participant.id
-        const participantAmountShare = +formatAmountAsDecimal(
-          (expense.amount / totalShares) * participantShare,
-          currency,
-        )
+    // Total amount of the expense in major currency units (e.g. cents -> dollars)
+    // This is used to compute the payer's net saldo for this single expense.
+    const totalAmount = +formatAmountAsDecimal(normalizedAmount, currency)
+    // Map of participantId -> shares for quick lookups when building saldos.
+    const shareByParticipant = Object.fromEntries(
+      expense.paidFor.map(({ participantId, shares }) => [
+        participantId,
+        shares,
+      ]),
+    ) as Record<string, number>
+    const totalShares = expense.paidFor.reduce(
+      (sum, { shares }) => sum + shares,
+      0,
+    )
 
-        return [
-          participant.name,
-          participantAmountShare * (isPaidByParticipant ? 1 : -1),
-        ]
-      }),
-    ),
-  }))
+    return {
+      date: formatDate(expense.expenseDate),
+      title: expense.title,
+      categoryName: expense.category?.name || '',
+      currency: group.currencyCode ?? group.currency,
+      // Costs should not count reimbursements as spending in CSV totals
+      amount: formatAmountAsDecimal(
+        expense.isReimbursement ? 0 : normalizedAmount,
+        currency,
+      ),
+      originalAmount: normalizedOriginalAmount
+        ? formatAmountAsDecimal(
+            normalizedOriginalAmount,
+            getCurrency(expense.originalCurrency),
+          )
+        : null,
+      originalCurrency: expense.originalCurrency,
+      conversionRate: normalizedConversionRate
+        ? normalizedConversionRate.toString()
+        : null,
+      paidBy: participantIdNameMap[expense.paidById],
+      splitMode: splitModeLabel[expense.splitMode],
+      // For every participant we export the *saldo* (net effect) of this single expense:
+      // - For the paying participant (paidBy):
+      //     saldo = totalAmount - participantShareAmount
+      //   -> how much they effectively advance for others.
+      // - For all other participants:
+      //     saldo = -participantShareAmount
+      //   -> how much they owe to the payer for this expense.
+      //
+      // The sum of all participant saldos for a given expense is always 0,
+      // which makes the CSV easy to aggregate in tools like Excel.
+      ...Object.fromEntries(
+        group.participants.map((participant) => {
+          const participantShare = shareByParticipant[participant.id] ?? 0
+
+          const participantShareAmount =
+            totalShares === 0
+              ? 0
+              : +formatAmountAsDecimal(
+                  (normalizedAmount / totalShares) * participantShare,
+                  currency,
+                )
+
+          const isPaidByParticipant = expense.paidById === participant.id
+          const saldo = isPaidByParticipant
+            ? totalAmount - participantShareAmount
+            : -participantShareAmount
+
+          return [participant.name, saldo]
+        }),
+      ),
+    }
+  })
 
   const json2csvParser = new Parser({ fields })
   const csv = json2csvParser.parse(expenses)


### PR DESCRIPTION
## Background

Discussion status and references:
- PR #456 introduces “Paid By” + sorting; reviewers requested the format change in a separate PR.
- Issue #455 asks for CSV↔JSON parity (incl. “Paid By” and ordering).
- Issue #471 shows the payer can appear negative in participant columns, which is not useful for “personal cost” or for balancing.
- Issue #342 discusses that the current “signed shares” columns lose information and are awkward in spreadsheets; a per‑expense saldo is more practical.

Problem statement:
- Participant columns encode “signed shares,” which are neither clear personal costs nor per‑expense balances; this makes the export unintuitive compared to the JSON data model.
- Reimbursements appear as expenses, distorting totals and requiring a special flag.

Proposed direction:
- Switch participant columns to per‑expense saldo (payer advances; others owe). Model reimbursements as internal transfers by using `Cost=0`.

Why now:
- This follows Jessica’s PR (#456) that fixed sorting and added "Paid By". To keep scope clean, this PR focuses on the CSV format revamp as a dedicated, reviewable change.

## Summary

This PR switches the CSV export to a per‑expense saldo format that aligns better with user expectations and spreadsheet workflows. Participant columns carry the net effect (saldo) of each expense. Reimbursements use `Cost=0`, which removes the need for a dedicated reimbursement flag.

## Changes
- Columns
  - Keep: `Date`, `Description`, `Category`, `Currency`, `Cost`, `Original cost`, `Original currency`, `Conversion rate`, `Split mode`, `Paid By`.
  - Remove: `Is Reimbursement` (redundant once reimbursements use `Cost=0`).
  - Participant columns: per‑expense saldos (payer positive advance; others negative owed amounts).
- Behaviour
  - Reimbursements: exported as internal transfers with `Cost=0`; participant saldos reflect direction/amount.
  - Incomes: negative `Cost` values; participant saldos remain consistent.
  - Sorting: consistent with JSON export (by `expenseDate`, then `createdAt`).
- Implementation
  - CSV route updated to compute participant saldos; paid amounts and conversion values normalized to plain numbers before formatting.

## CSV Format (Descriptive)
- Fixed columns: `Date`, `Description`, `Category`, `Currency`, `Cost`, `Original cost`, `Original currency`, `Conversion rate`, `Split mode`, `Paid By`.
- Participant columns: per‑expense saldo per participant.
- Semantics:
  - Payer: `saldo = totalAmount - ownShareAmount` (advance for others).
  - Others: `saldo = - ownShareAmount` (owed to the payer).
- Special cases:
  - Reimbursements → `Cost = 0` (internal transfer; not group spending).
  - Incomes → negative `Cost` (distribution to participants).

## Testing
- Manual: export CSVs for classical expenses, altruist payments, self‑payments, incomes, and reimbursements; verify that “who owes whom” is directly readable and that reimbursements use `Cost=0`.
- Script‑assisted: run the CSV→sentences helper (attached) to cross‑check narrative output and totals.

## Rationale
- Practical and close to intent: participant columns show the real‑world effect per expense (advance vs. owed), matching users’ mental model and spreadsheet usage.
- Trade‑off: the exact split method (shares/percentages) is not serialized; amounts are. In practice, amounts are what downstream tools operate on.
- Clarity: `Is Reimbursement` becomes unnecessary with `Cost=0`; totals remain correct and the transfer direction is visible in participant columns.

## Why remove the `Is Reimbursement` column?
- Reimbursements are internal transfers, not spending. Using `Cost=0` keeps group totals correct without an extra flag.
- The participant columns already encode direction and amount; the boolean adds no additional value.

## Evidence
- Exercised against a comprehensive set of scenarios (classical expenses, altruist payments, self‑payments, incomes, reimbursements) using a CSV→sentences helper and curated test CSVs (attached via PR comment).

## Files for testing
[testcases.csv](https://github.com/user-attachments/files/23591251/testcases.csv)
[convert-csv-to-sentences.py](https://github.com/user-attachments/files/23591253/convert-csv-to-sentences.py)
