### PR TITLE
fix: Restore keyboard navigation in category and currency selectors

### DIFF
--- a/src/components/category-selector.tsx
+++ b/src/components/category-selector.tsx
@@ -8,6 +8,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandList,
 } from '@/components/ui/command'
 import { Drawer, DrawerContent, DrawerTrigger } from '@/components/ui/drawer'
 import {
@@ -113,8 +114,8 @@ function CategoryCommand({
   return (
     <Command>
       <CommandInput placeholder={t('search')} className="text-base" />
-      <CommandEmpty>{t('noCategory')}</CommandEmpty>
-      <div className="w-full max-h-[300px] overflow-y-auto">
+      <CommandList>
+        <CommandEmpty>{t('noCategory')}</CommandEmpty>
         {Object.entries(categoriesByGroup).map(
           ([group, groupCategories], index) => (
             <CommandGroup key={index} heading={t(`${group}.heading`)}>
@@ -135,7 +136,7 @@ function CategoryCommand({
             </CommandGroup>
           ),
         )}
-      </div>
+      </CommandList>
     </Command>
   )
 }

--- a/src/components/currency-selector.tsx
+++ b/src/components/currency-selector.tsx
@@ -7,6 +7,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandList,
 } from '@/components/ui/command'
 import { Drawer, DrawerContent, DrawerTrigger } from '@/components/ui/drawer'
 import {
@@ -128,8 +129,8 @@ function CurrencyCommand({
   return (
     <Command>
       <CommandInput placeholder={t('search')} className="text-base" />
-      <CommandEmpty>{t('noCurrency')}</CommandEmpty>
-      <div className="w-full max-h-[300px] overflow-y-auto">
+      <CommandList>
+        <CommandEmpty>{t('noCurrency')}</CommandEmpty>
         {Object.entries(currenciesByGroup).map(
           ([group, groupCurrencies], index) => (
             <CommandGroup key={index} heading={t(`${group}.heading`)}>
@@ -147,7 +148,7 @@ function CurrencyCommand({
             </CommandGroup>
           ),
         )}
-      </div>
+      </CommandList>
     </Command>
   )
 }


### PR DESCRIPTION
My navigation for entering expenses used to be possible using just Tab and Up/Down Arrow Keys; searching for the Category and then choosing the right one with the arrow keys. This broke recently, this PR restores keyboard navigation (Up/Down arrow keys) in category and currency selector dropdowns.

The category and currency selectors use the https://github.com/dip/cmdk library for searchable command menus, according to the examples items should be wrapped in Command.List.  The selectors were using a plain <div> with custom overflow styling instead of CommandList, which seems to have broke arrow key navigation. 
