### PR TITLE
Fix exchange rates: migrate from frankfurter.app to frankfurter.dev

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -93,7 +93,7 @@ export function useCurrencyRate(
     !!baseCurrency.length &&
     !!targetCurrency.length &&
     baseCurrency !== targetCurrency &&
-    `https://api.frankfurter.app/${dateString}?base=${baseCurrency}`
+    `https://api.frankfurter.dev/v1/${dateString}?base=${baseCurrency}`
   const { data, error, isLoading, mutate } = useSWR<FrankfurterAPIResponse>(
     url,
     fetcher,


### PR DESCRIPTION
## Summary

Fixes #514

The Frankfurter API has moved from `api.frankfurter.app` to `api.frankfurter.dev`. 
The old domain returns a 301 redirect without CORS headers, which causes the browser 
to block exchange rate requests.

## Problem

- `https://api.frankfurter.app/2026-04-05?base=CNY` → 301 redirect to `api.frankfurter.dev`
- The 301 response is missing the `Access-Control-Allow-Origin` header
- Browser blocks the request due to CORS policy

## Fix

Replace `api.frankfurter.app` with `api.frankfurter.dev/v1` in the exchange rate client.

Note: `frankfurter.dev` also offers a v2 API, but it has a different response schema. 
This PR intentionally uses `/v1/` to maintain compatibility without requiring 
additional changes to the response parsing logic.

## Test plan

- [ ] Open a group
- [ ] Verify exchange rates load without CORS errors