### PR TITLE
Support tricount imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Spliit is a free and open source alternative to Splitwise. You can either use th
 - [x] Search for expenses in a group [(#51)](https://github.com/spliit-app/spliit/issues/51)
 - [x] Upload and attach images to expenses [(#63)](https://github.com/spliit-app/spliit/issues/63)
 - [x] Create expense by scanning a receipt [(#23)](https://github.com/spliit-app/spliit/issues/23)
+- [x] Import group and expenses from Tricount CSV export
 
 ### Possible incoming features
 

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -75,6 +75,21 @@
       "description": "If a group was shared with you, you can paste its URL here to add it to your list.",
       "error": "Oops, we are not able to find the group from the URL you provided…"
     },
+    "ImportTricount": {
+      "title": "Import from Tricount",
+      "description": "Upload a CSV export from Tricount to import the group with its expenses and participants.",
+      "button": "Import CSV File",
+      "error": "Failed to import Tricount group. Please check the CSV file format.",
+      "stepsTitle": "How to get your Tricount data:",
+      "step1": "Go to the profile tab in the Tricount app.",
+      "step2": "Access support through the green chat button.",
+      "step3": "Request a data export under GDPR terms from the assistant.",
+      "step4": "Accept the offer to forward your request to a human support agent.",
+      "step5": "Once processed, you will receive a full dump of your groups in CSV format by email.",
+      "step6": "Upload the CSV file below.",
+      "currencyLabel": "Group Main Currency",
+      "currencyDescription": "All imported expenses will be automatically converted to this main currency."
+    },
     "NotFound": {
       "text": "This group does not exist.",
       "link": "Go to recently visited groups"

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -191,7 +191,12 @@ export function ExpenseForm({
           expenseDate: expense.expenseDate ?? new Date(),
           amount: amountAsDecimal(expense.amount, groupCurrency),
           originalCurrency: expense.originalCurrency ?? group.currencyCode,
-          originalAmount: expense.originalAmount ?? undefined,
+          originalAmount: expense.originalAmount
+            ? amountAsDecimal(
+                expense.originalAmount,
+                getCurrency(expense.originalCurrency),
+              )
+            : undefined,
           conversionRate: expense.conversionRate?.toNumber(),
           category: expense.categoryId,
           paidBy: expense.paidById,
@@ -283,6 +288,14 @@ export function ExpenseForm({
           ? amountAsMinorUnits(shares, groupCurrency)
           : shares,
     }))
+
+    if (values.originalAmount) {
+      const origCurrency = getCurrency(values.originalCurrency)
+      values.originalAmount = amountAsMinorUnits(
+        values.originalAmount,
+        origCurrency,
+      )
+    }
 
     // Currency should be blank if same as group currency
     if (!conversionRequired) {
@@ -523,6 +536,7 @@ export function ExpenseForm({
                         className="text-base"
                         disabled={true}
                         {...field}
+                        value={field.value ?? ''}
                         placeholder={group.currency}
                       />
                     )}
@@ -560,6 +574,7 @@ export function ExpenseForm({
                             onChange(v)
                           }}
                           {...field}
+                          value={field.value ?? ''}
                           onFocus={(e) => {
                             const target = e.currentTarget
                             setTimeout(() => target.select(), 1)
@@ -633,6 +648,7 @@ export function ExpenseForm({
                                 onChange(v)
                               }}
                               {...field}
+                              value={field.value ?? ''}
                               onFocus={(e) => {
                                 const target = e.currentTarget
                                 setTimeout(() => target.select(), 1)
@@ -1100,7 +1116,7 @@ export function ExpenseForm({
                                                 field.value?.find(
                                                   ({ participant }) =>
                                                     participant === id,
-                                                )?.shares
+                                                )?.shares ?? ''
                                               }
                                               onChange={(event) => {
                                                 field.onChange(

--- a/src/app/groups/create/create-group.tsx
+++ b/src/app/groups/create/create-group.tsx
@@ -1,21 +1,156 @@
 'use client'
 
+import { CurrencySelector } from '@/components/currency-selector'
 import { GroupForm } from '@/components/group-form'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { defaultCurrencyList } from '@/lib/currency'
 import { trpc } from '@/trpc/client'
+import { FileDown, Loader2, Upload } from 'lucide-react'
+import { useLocale, useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 
 export const CreateGroup = () => {
   const { mutateAsync } = trpc.groups.create.useMutation()
+  const importTricount = trpc.groups.importTricount.useMutation()
   const utils = trpc.useUtils()
   const router = useRouter()
+  const locale = useLocale()
+  const t = useTranslations('Groups.ImportTricount')
+
+  const [currencyCode, setCurrencyCode] = useState(
+    process.env.NEXT_PUBLIC_DEFAULT_CURRENCY_CODE || 'USD',
+  )
+  const [isImporting, setIsImporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setIsImporting(true)
+    setError(null)
+
+    const reader = new FileReader()
+    reader.onload = async (event) => {
+      const text = event.target?.result
+      if (typeof text === 'string') {
+        try {
+          const { groupId } = await importTricount.mutateAsync({
+            csvText: text,
+            targetCurrencyCode: currencyCode,
+          })
+          await utils.groups.invalidate()
+          router.push(`/groups/${groupId}`)
+        } catch (err: any) {
+          setError(err.message || t('error'))
+          setIsImporting(false)
+        }
+      } else {
+        setError(t('error'))
+        setIsImporting(false)
+      }
+    }
+    reader.onerror = () => {
+      setError(t('error'))
+      setIsImporting(false)
+    }
+    reader.readAsText(file)
+  }
 
   return (
-    <GroupForm
-      onSubmit={async (groupFormValues) => {
-        const { groupId } = await mutateAsync({ groupFormValues })
-        await utils.groups.invalidate()
-        router.push(`/groups/${groupId}`)
-      }}
-    />
+    <div className="flex flex-col gap-6">
+      <GroupForm
+        onSubmit={async (groupFormValues) => {
+          const { groupId } = await mutateAsync({ groupFormValues })
+          await utils.groups.invalidate()
+          router.push(`/groups/${groupId}`)
+        }}
+      />
+
+      <Card className="border-dashed border-2 hover:border-solid hover:border-primary/50 transition-all duration-300 relative overflow-hidden group">
+        <div className="absolute inset-0 bg-gradient-to-br from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none" />
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileDown className="w-5 h-5 text-primary animate-pulse" />
+            {t('title')}
+          </CardTitle>
+          <CardDescription>{t('description')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="mb-6 space-y-3">
+            <h3 className="text-sm font-semibold text-foreground">
+              {t('stepsTitle')}
+            </h3>
+            <ol className="text-xs text-muted-foreground space-y-2 list-none pl-0">
+              {([1, 2, 3, 4, 5, 6] as const).map((num) => (
+                <li key={num} className="flex gap-3 items-start">
+                  <span className="flex items-center justify-center w-4 h-4 rounded-full bg-primary/10 text-primary text-[9px] font-bold shrink-0">
+                    {num}
+                  </span>
+                  <span className="leading-4">{t(`step${num}` as any)}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <div className="mb-6 space-y-2">
+            <label className="text-sm font-semibold text-foreground">
+              {t('currencyLabel')}
+            </label>
+            <CurrencySelector
+              currencies={defaultCurrencyList(locale as any, 'Custom')}
+              defaultValue={currencyCode}
+              onValueChange={(newCurrency) => {
+                setCurrencyCode(newCurrency)
+              }}
+              isLoading={false}
+            />
+            <p className="text-xs text-muted-foreground">
+              {t('currencyDescription')}
+            </p>
+          </div>
+
+          <label className="flex flex-col items-center justify-center border-2 border-dashed rounded-lg p-6 cursor-pointer hover:bg-accent/50 transition-colors duration-200">
+            {isImporting ? (
+              <div className="flex flex-col items-center gap-2 py-4">
+                <Loader2 className="w-10 h-10 animate-spin text-primary" />
+                <span className="text-sm font-medium text-muted-foreground">
+                  Importing group...
+                </span>
+              </div>
+            ) : (
+              <div className="flex flex-col items-center gap-2 py-2">
+                <Upload className="w-10 h-10 text-muted-foreground group-hover:text-primary group-hover:scale-110 transition-transform duration-300" />
+                <span className="text-sm font-semibold mt-2">
+                  {t('button')}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  Drag & drop or click to choose your Tricount .csv file
+                </span>
+              </div>
+            )}
+            <input
+              type="file"
+              accept=".csv"
+              className="hidden"
+              disabled={isImporting}
+              onChange={handleFileChange}
+            />
+          </label>
+          {error && (
+            <p className="text-sm text-destructive font-medium mt-4 bg-destructive/10 p-3 rounded-lg border border-destructive/20">
+              {error}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   )
 }

--- a/src/trpc/routers/groups/importTricount.procedure.ts
+++ b/src/trpc/routers/groups/importTricount.procedure.ts
@@ -1,0 +1,382 @@
+import { randomId } from '@/lib/api'
+import { getCurrency } from '@/lib/currency'
+import { prisma } from '@/lib/prisma'
+import { baseProcedure } from '@/trpc/init'
+import { z } from 'zod'
+
+const rateCache = new Map<string, number>()
+
+async function getExchangeRate(
+  date: Date,
+  base: string,
+  target: string,
+): Promise<number> {
+  const dateString = date.toISOString().split('T')[0]
+  try {
+    const res = await fetch(
+      `https://api.frankfurter.app/${dateString}?base=${base}&symbols=${target}`,
+    )
+    if (res.ok) {
+      const data = (await res.json()) as any
+      if (data.rates && data.rates[target]) {
+        return data.rates[target]
+      }
+    }
+  } catch (e) {
+    // ignore
+  }
+  return 1
+}
+
+async function getRate(
+  date: Date,
+  base: string,
+  target: string,
+): Promise<number> {
+  const dateString = date.toISOString().split('T')[0]
+  const cacheKey = `${dateString}_${base}_${target}`
+  if (rateCache.has(cacheKey)) {
+    return rateCache.get(cacheKey)!
+  }
+  const rate = await getExchangeRate(date, base, target)
+  rateCache.set(cacheKey, rate)
+  return rate
+}
+
+function parseCSV(text: string): string[][] {
+  const lines: string[][] = []
+  let row: string[] = []
+  let field = ''
+  let inQuotes = false
+
+  const cleanText = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+
+  for (let i = 0; i < cleanText.length; i++) {
+    const char = cleanText[i]
+    const nextChar = cleanText[i + 1]
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (nextChar === '"') {
+          field += '"'
+          i++
+        } else {
+          inQuotes = false
+        }
+      } else {
+        field += char
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true
+      } else if (char === ',') {
+        row.push(field)
+        field = ''
+      } else if (char === '\n') {
+        row.push(field)
+        lines.push(row)
+        row = []
+        field = ''
+      } else {
+        field += char
+      }
+    }
+  }
+  if (field || row.length > 0) {
+    row.push(field)
+    lines.push(row)
+  }
+  return lines.filter((r) => r.length > 0)
+}
+
+export const importTricountProcedure = baseProcedure
+  .input(
+    z.object({
+      csvText: z.string(),
+      targetCurrencyCode: z.string().length(3),
+    }),
+  )
+  .mutation(async ({ input: { csvText, targetCurrencyCode } }) => {
+    const rows = parseCSV(csvText)
+    if (rows.length < 2) {
+      throw new Error('CSV file is empty or invalid')
+    }
+    const headers = rows[0]
+
+    const titleIdx = headers.indexOf('Title')
+    const amountIdx = headers.indexOf('Amount')
+    const currencyIdx = headers.indexOf('Currency')
+    const exchangeRateIdx = headers.indexOf('Exchange rate')
+    const amountInDefaultIdx = headers.findIndex((h) =>
+      h.startsWith('Amount in default currency'),
+    )
+    const transactionTypeIdx = headers.indexOf('Transaction type')
+    const categoryIdx = headers.indexOf('Category')
+    const paidByIdx = headers.indexOf('Paid by')
+    const dateTimeIdx = headers.indexOf('Date & time')
+
+    if (
+      titleIdx === -1 ||
+      amountIdx === -1 ||
+      currencyIdx === -1 ||
+      paidByIdx === -1
+    ) {
+      throw new Error('Invalid Tricount CSV format: missing required columns')
+    }
+
+    let defaultCurrencyCode = 'EUR'
+    if (amountInDefaultIdx !== -1) {
+      const match = headers[amountInDefaultIdx].match(/\(([^)]+)\)/)
+      if (match) {
+        defaultCurrencyCode = match[1]
+      }
+    }
+
+    const participantNames: string[] = []
+    const participantMap = new Map<
+      string,
+      { paidByIdx: number; impactedIdx: number }
+    >()
+
+    for (let i = 0; i < headers.length; i++) {
+      const header = headers[i]
+      if (header.startsWith('Paid by ') && header !== 'Paid by') {
+        const name = header.substring('Paid by '.length).trim()
+        if (name) {
+          if (!participantMap.has(name)) {
+            participantMap.set(name, { paidByIdx: -1, impactedIdx: -1 })
+          }
+          participantMap.get(name)!.paidByIdx = i
+          if (!participantNames.includes(name)) participantNames.push(name)
+        }
+      } else if (header.startsWith('Impacted to ')) {
+        const name = header.substring('Impacted to '.length).trim()
+        if (name) {
+          if (!participantMap.has(name)) {
+            participantMap.set(name, { paidByIdx: -1, impactedIdx: -1 })
+          }
+          participantMap.get(name)!.impactedIdx = i
+          if (!participantNames.includes(name)) participantNames.push(name)
+        }
+      }
+    }
+
+    if (participantNames.length === 0) {
+      throw new Error('No participants found in the Tricount CSV')
+    }
+
+    let groupName = 'Imported Tricount Group'
+    for (let i = rows.length - 1; i >= 0; i--) {
+      if (rows[i] && rows[i].length > 0) {
+        const cell = rows[i][0]
+        const groupNameMatch = cell.match(/^tricount (.*) - Exported on /)
+        if (groupNameMatch) {
+          groupName = groupNameMatch[1]
+          break
+        }
+      }
+    }
+
+    const targetCurrency = getCurrency(targetCurrencyCode)
+
+    const result = await prisma.$transaction(async (tx) => {
+      const groupId = randomId()
+      const dbCategories = await tx.category.findMany()
+
+      // Create Group
+      const group = await tx.group.create({
+        data: {
+          id: groupId,
+          name: groupName,
+          currency: targetCurrency.symbol || '$',
+          currencyCode: targetCurrencyCode,
+          participants: {
+            createMany: {
+              data: participantNames.map((name) => ({
+                id: randomId(),
+                name,
+              })),
+            },
+          },
+        },
+        include: { participants: true },
+      })
+
+      // Map participant name -> db id
+      const participantDbIds = new Map<string, string>()
+      for (const p of group.participants) {
+        participantDbIds.set(p.name, p.id)
+      }
+
+      // Helper for categories
+      const findCategoryId = (
+        tricountCategory: string,
+        isReimbursement: boolean,
+      ) => {
+        if (isReimbursement) return 1 // Payment category
+        const normalized = tricountCategory.toLowerCase().trim()
+        if (normalized === 'no category') return 0 // General category
+        const match = dbCategories.find(
+          (c) =>
+            c.name.toLowerCase() === normalized ||
+            c.grouping.toLowerCase() === normalized,
+        )
+        return match ? match.id : 0
+      }
+
+      // Parse expenses
+      for (let rowIndex = 1; rowIndex < rows.length; rowIndex++) {
+        const row = rows[rowIndex]
+        if (row.length < 8) continue // Skip invalid/short rows
+        if (row[0].startsWith('tricount ') && row[0].includes(' - Exported on'))
+          continue
+
+        const title = row[titleIdx] || 'Untitled'
+        const amountStr = row[amountIdx]
+        const currencyStr = row[currencyIdx]
+        const exchangeRateStr = row[exchangeRateIdx]
+        const amountInDefaultStr =
+          amountInDefaultIdx !== -1 ? row[amountInDefaultIdx] : amountStr
+
+        if (!amountStr || isNaN(parseFloat(amountStr))) continue
+
+        const amountOriginalVal = parseFloat(amountStr)
+        const amountDefaultVal = parseFloat(amountInDefaultStr || amountStr)
+        const isReimbursement =
+          title.toLowerCase().includes('recouvrement de dette') ||
+          title.toLowerCase().includes('repayment') ||
+          title.toLowerCase().includes('reimbursement') ||
+          title.toLowerCase().includes('transfer') ||
+          title.toLowerCase().includes('settlement')
+
+        const categoryName = categoryIdx !== -1 ? row[categoryIdx] : ''
+        const categoryId = findCategoryId(categoryName, isReimbursement)
+
+        const paidBy = row[paidByIdx]
+        const paidById = participantDbIds.get(paidBy)
+        if (!paidById) continue // Skip if payer not found
+
+        let expenseDate = new Date()
+        if (dateTimeIdx !== -1 && row[dateTimeIdx]) {
+          try {
+            const parsedDate = new Date(row[dateTimeIdx])
+            if (!isNaN(parsedDate.getTime())) {
+              expenseDate = parsedDate
+            }
+          } catch (e) {}
+        }
+
+        // Find exchange rate targetCurrencyCode -> defaultCurrencyCode
+        let targetToDefaultRate = 1
+        if (targetCurrencyCode !== defaultCurrencyCode) {
+          let foundRate = false
+          for (let i = 1; i < rows.length; i++) {
+            const r = rows[i]
+            if (r.length >= 8 && r[currencyIdx] === targetCurrencyCode) {
+              const rate = parseFloat(r[exchangeRateIdx])
+              if (rate && !isNaN(rate)) {
+                targetToDefaultRate = rate
+                foundRate = true
+                break
+              }
+            }
+          }
+          if (!foundRate) {
+            targetToDefaultRate = await getRate(
+              expenseDate,
+              targetCurrencyCode,
+              defaultCurrencyCode,
+            )
+          }
+        }
+
+        const targetCurrencyDigits = targetCurrency.decimal_digits ?? 2
+        let amountCents = 0
+        let originalAmountCents: number | null = null
+        let originalCurrencyCode: string | null = null
+        let conversionRateVal: number | null = null
+
+        if (currencyStr === targetCurrencyCode) {
+          amountCents = Math.round(
+            amountOriginalVal * 10 ** targetCurrencyDigits,
+          )
+        } else {
+          const amountTargetVal = amountDefaultVal / targetToDefaultRate
+          amountCents = Math.round(amountTargetVal * 10 ** targetCurrencyDigits)
+
+          const origCurrency = getCurrency(currencyStr)
+          originalAmountCents = Math.round(
+            amountOriginalVal * 10 ** (origCurrency.decimal_digits ?? 2),
+          )
+          originalCurrencyCode = currencyStr
+          conversionRateVal = amountTargetVal / amountOriginalVal
+        }
+
+        // Build paidFor list (participants with non-zero impact)
+        const paidForList: { participantId: string; shares: number }[] = []
+        let sumShares = 0
+
+        for (const name of participantNames) {
+          const pMap = participantMap.get(name)!
+          if (pMap.impactedIdx !== -1 && row[pMap.impactedIdx]) {
+            const impactedVal = parseFloat(row[pMap.impactedIdx])
+            if (impactedVal < 0) {
+              const impactedTargetVal =
+                Math.abs(impactedVal) / targetToDefaultRate
+              const shareAmount = Math.round(
+                impactedTargetVal * 10 ** targetCurrencyDigits,
+              )
+              if (shareAmount > 0) {
+                paidForList.push({
+                  participantId: participantDbIds.get(name)!,
+                  shares: shareAmount,
+                })
+                sumShares += shareAmount
+              }
+            }
+          }
+        }
+
+        // Adjust discrepancy if any
+        const discrepancy = amountCents - sumShares
+        if (discrepancy !== 0 && paidForList.length > 0) {
+          paidForList[paidForList.length - 1].shares += discrepancy
+        }
+
+        // If no one is impacted, default to the payer themselves.
+        if (paidForList.length === 0) {
+          paidForList.push({
+            participantId: paidById,
+            shares: amountCents,
+          })
+        }
+
+        const expenseId = randomId()
+        await tx.expense.create({
+          data: {
+            id: expenseId,
+            groupId,
+            expenseDate,
+            categoryId,
+            amount: amountCents,
+            originalAmount: originalAmountCents,
+            originalCurrency: originalCurrencyCode,
+            conversionRate: conversionRateVal,
+            title,
+            paidById,
+            splitMode: 'BY_AMOUNT',
+            isReimbursement,
+            paidFor: {
+              createMany: {
+                data: paidForList,
+              },
+            },
+          },
+        })
+      }
+
+      return { groupId }
+    })
+
+    return result
+  })

--- a/src/trpc/routers/groups/index.ts
+++ b/src/trpc/routers/groups/index.ts
@@ -7,6 +7,7 @@ import { getGroupProcedure } from '@/trpc/routers/groups/get.procedure'
 import { groupStatsRouter } from '@/trpc/routers/groups/stats'
 import { updateGroupProcedure } from '@/trpc/routers/groups/update.procedure'
 import { getGroupDetailsProcedure } from './getDetails.procedure'
+import { importTricountProcedure } from './importTricount.procedure'
 import { listGroupsProcedure } from './list.procedure'
 
 export const groupsRouter = createTRPCRouter({
@@ -20,4 +21,5 @@ export const groupsRouter = createTRPCRouter({
   list: listGroupsProcedure,
   create: createGroupProcedure,
   update: updateGroupProcedure,
+  importTricount: importTricountProcedure,
 })


### PR DESCRIPTION
Hi!

I have been hosting my own instance of Spliit for a long time and really appreciate the project. As I see that there is currently a high level of activity that can be a lot to handle for you, I wanted to offer my help. I would be more than happy to commit as a new maintainer to help with handling issues, reviewing MRs, and driving new updates to keep the project moving forward!

To start off, this MR implements a much-requested feature: importing groups and expenses. I implemented it for Tricount but it could be reused for splitwise.

#### What this MR does:

Adds a clean, interactive import section to the Group Creation page with step-by-step instructions guiding the user on how to obtain their data export under GDPR terms from Tricount.

It allows the user to select the group's main currency during the import. All imported expenses are converted to this currency using the rates in the CSV file (falling back to Frankfurter API if a rate is missing).

It also fixes an existing bug where the database field  originalAmount  was stored in minor units (cents) but was not converted to/from decimals in the frontend form ( submit  and  defaultValues ), causing 100x scaling display issues.
  