### PR TITLE
Fix bug when pasting currency amount (parsing commas and decimals)

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -38,6 +38,7 @@ import { randomId } from '@/lib/api'
 import { defaultCurrencyList, getCurrency } from '@/lib/currency'
 import { RuntimeFeatureFlags } from '@/lib/featureFlags'
 import { useActiveUser, useCurrencyRate } from '@/lib/hooks'
+import { normalizeNumberInput } from '@/lib/number-input'
 import {
   ExpenseFormValues,
   SplittingOptions,
@@ -64,15 +65,6 @@ import { match } from 'ts-pattern'
 import { DeletePopup } from '../../../../components/delete-popup'
 import { extractCategoryFromTitle } from '../../../../components/expense-form-actions'
 import { Textarea } from '../../../../components/ui/textarea'
-
-const enforceCurrencyPattern = (value: string) =>
-  value
-    .replace(/^\s*-/, '_') // replace leading minus with _
-    .replace(/[.,]/, '#') // replace first comma with #
-    .replace(/[-.,]/g, '') // remove other minus and commas characters
-    .replace(/_/, '-') // change back _ to minus
-    .replace(/#/, '.') // change back # to dot
-    .replace(/[^-\d.]/g, '') // remove all non-numeric characters
 
 const getDefaultSplittingOptions = (
   group: NonNullable<AppRouterOutput['groups']['get']['group']>,
@@ -393,8 +385,9 @@ export function ExpenseForm({
       const rate = Number(conversionRate)
       const convertedAmount = originalAmount * rate
       if (!Number.isNaN(convertedAmount)) {
-        const v = enforceCurrencyPattern(
+        const v = normalizeNumberInput(
           convertedAmount.toFixed(groupCurrency.decimal_digits),
+          { decimalDigits: groupCurrency.decimal_digits },
         )
         const income = Number(v) < 0
         setIsIncome(income)
@@ -556,7 +549,9 @@ export function ExpenseForm({
                           inputMode="decimal"
                           placeholder="0.00"
                           onChange={(event) => {
-                            const v = enforceCurrencyPattern(event.target.value)
+                            const v = normalizeNumberInput(event.target.value, {
+                              decimalDigits: originalCurrency.decimal_digits,
+                            })
                             onChange(v)
                           }}
                           {...field}
@@ -627,7 +622,7 @@ export function ExpenseForm({
                               inputMode="decimal"
                               placeholder="0.00"
                               onChange={(event) => {
-                                const v = enforceCurrencyPattern(
+                                const v = normalizeNumberInput(
                                   event.target.value,
                                 )
                                 onChange(v)
@@ -684,7 +679,9 @@ export function ExpenseForm({
                         inputMode="decimal"
                         placeholder="0.00"
                         onChange={(event) => {
-                          const v = enforceCurrencyPattern(event.target.value)
+                          const v = normalizeNumberInput(event.target.value, {
+                            decimalDigits: groupCurrency.decimal_digits,
+                          })
                           const income = Number(v) < 0
                           setIsIncome(income)
                           if (income) form.setValue('isReimbursement', false)
@@ -996,9 +993,16 @@ export function ExpenseForm({
                                                   )?.originalAmount ?? ''
                                                 }
                                                 onChange={(event) => {
-                                                  const originalAmount = Number(
-                                                    event.target.value,
-                                                  )
+                                                  const originalAmountValue =
+                                                    normalizeNumberInput(
+                                                      event.target.value,
+                                                      {
+                                                        decimalDigits:
+                                                          originalCurrency.decimal_digits,
+                                                      },
+                                                    )
+                                                  const originalAmount =
+                                                    Number(originalAmountValue)
                                                   let convertedAmount = ''
                                                   if (
                                                     !Number.isNaN(
@@ -1019,11 +1023,14 @@ export function ExpenseForm({
                                                         ? {
                                                             participant: id,
                                                             originalAmount:
-                                                              event.target
-                                                                .value,
+                                                              originalAmountValue,
                                                             shares:
-                                                              enforceCurrencyPattern(
+                                                              normalizeNumberInput(
                                                                 convertedAmount,
+                                                                {
+                                                                  decimalDigits:
+                                                                    groupCurrency.decimal_digits,
+                                                                },
                                                               ),
                                                           }
                                                         : p,
@@ -1103,15 +1110,24 @@ export function ExpenseForm({
                                                 )?.shares
                                               }
                                               onChange={(event) => {
+                                                const isSplitByAmount =
+                                                  form.getValues().splitMode ===
+                                                  'BY_AMOUNT'
                                                 field.onChange(
                                                   field.value.map((p) =>
                                                     p.participant === id
                                                       ? {
                                                           participant: id,
                                                           shares:
-                                                            enforceCurrencyPattern(
+                                                            normalizeNumberInput(
                                                               event.target
                                                                 .value,
+                                                              isSplitByAmount
+                                                                ? {
+                                                                    decimalDigits:
+                                                                      groupCurrency.decimal_digits,
+                                                                  }
+                                                                : undefined,
                                                             ),
                                                         }
                                                       : p,

--- a/src/lib/number-input.test.ts
+++ b/src/lib/number-input.test.ts
@@ -1,0 +1,37 @@
+import { normalizeNumberInput } from './number-input'
+
+describe('normalizeNumberInput', () => {
+  it('normalizes pasted US currency values', () => {
+    expect(normalizeNumberInput('-$1,659.84', { decimalDigits: 2 })).toBe(
+      '-1659.84',
+    )
+  })
+
+  it('treats three trailing digits as grouped money digits', () => {
+    expect(normalizeNumberInput('$1,659', { decimalDigits: 2 })).toBe('1659')
+  })
+
+  it('normalizes pasted European currency values', () => {
+    expect(normalizeNumberInput('-\u20ac1.659,84', { decimalDigits: 2 })).toBe(
+      '-1659.84',
+    )
+  })
+
+  it('preserves comma decimal entry for simple values', () => {
+    expect(normalizeNumberInput('1,23')).toBe('1.23')
+  })
+
+  it('preserves long decimal entry for conversion rates', () => {
+    expect(normalizeNumberInput('1.2345')).toBe('1.2345')
+    expect(normalizeNumberInput('1,2345')).toBe('1.2345')
+  })
+
+  it('normalizes grouped US and European values', () => {
+    expect(normalizeNumberInput('1,234,567.89', { decimalDigits: 2 })).toBe(
+      '1234567.89',
+    )
+    expect(normalizeNumberInput('1.234.567,89', { decimalDigits: 2 })).toBe(
+      '1234567.89',
+    )
+  })
+})

--- a/src/lib/number-input.ts
+++ b/src/lib/number-input.ts
@@ -1,0 +1,58 @@
+export function normalizeNumberInput(
+  value: string,
+  options: { decimalDigits?: number } = {},
+) {
+  const valueWithoutLeadingDecoration = value
+    .trimStart()
+    .replace(/^[^\d,.-]+/, '')
+  const isNegative = valueWithoutLeadingDecoration.startsWith('-')
+  const numericValue = value.replace(/[^\d.,]/g, '')
+
+  if (numericValue.length === 0) return isNegative ? '-' : ''
+
+  const separatorMatches = numericValue.match(/[.,]/g) ?? []
+  if (separatorMatches.length === 0) {
+    return `${isNegative ? '-' : ''}${numericValue}`
+  }
+
+  const dotCount = separatorMatches.filter(
+    (separator) => separator === '.',
+  ).length
+  const commaCount = separatorMatches.length - dotCount
+
+  if (dotCount > 0 && commaCount > 0) {
+    return buildNumberWithRightmostDecimalSeparator(numericValue, isNegative)
+  }
+
+  if (separatorMatches.length > 1) {
+    return `${isNegative ? '-' : ''}${numericValue.replace(/[.,]/g, '')}`
+  }
+
+  const separatorIndex = numericValue.search(/[.,]/)
+  const fractionDigits = numericValue.length - separatorIndex - 1
+  if (
+    options.decimalDigits !== undefined &&
+    fractionDigits === 3 &&
+    separatorIndex > 0
+  ) {
+    return `${isNegative ? '-' : ''}${numericValue.replace(/[.,]/g, '')}`
+  }
+
+  return `${isNegative ? '-' : ''}${numericValue.replace(/[.,]/, '.')}`
+}
+
+function buildNumberWithRightmostDecimalSeparator(
+  value: string,
+  isNegative: boolean,
+) {
+  const decimalSeparatorIndex = Math.max(
+    value.lastIndexOf('.'),
+    value.lastIndexOf(','),
+  )
+  const integerPart = value.slice(0, decimalSeparatorIndex).replace(/[.,]/g, '')
+  const fractionPart = value
+    .slice(decimalSeparatorIndex + 1)
+    .replace(/[.,]/g, '')
+
+  return `${isNegative ? '-' : ''}${integerPart}.${fractionPart}`
+}


### PR DESCRIPTION
## Summary

Fixes pasted currency values being misread when they include thousands separators.

For example, `-$1,659.84` was previously normalized as `-1.65984` because the first separator was treated as the decimal separator. This change normalizes common US and European pasted number formats into the existing internal format: digits, optional leading `-`, and `.` as the decimal separator.

## Changes

- Added a small `normalizeNumberInput` helper
- Replaced the old expense form currency sanitizer
- Supports common pasted values like:
  - `-$1,659.84`
  - `-€1.659,84`
  - `1,234,567.89`
  - `1.234.567,89`
- Keeps simple decimal entry working for both `1.23` and `1,23`
- Applies the same normalization to amount, original amount, conversion rate, and split-by-amount fields
- Does not add settings, migrations, or UI changes

## Testing

- `npm test`
- `npm run check-types`
- `npm run lint`
- Targeted Prettier check on touched files

## Transparency Note

This is my second small request using Codex for implementation help. I’m trying it out to see whether it improves my workflow, and I want to be transparent so reviewers can flag anything that feels off or low-quality.