### PR TITLE
Add monthly category spending visuals

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -318,11 +318,26 @@
       "description": "Spending by month and category.",
       "rangeLabel": "Range",
       "groupingLabel": "Category grouping",
+      "chartTypeLabel": "Chart type",
       "stackedTitle": "Monthly categories",
-      "breakdownTitle": "{month} category breakdown",
-      "trendTitle": "Monthly total",
+      "breakdownTitle": "{range} category breakdown",
+      "balanceTimelineTitle": "Balance timeline",
+      "categoryMarkers": "Category markers",
+      "isOwedMoney": "Is owed money",
+      "owesMoney": "Owes money",
+      "payment": "Reimbursement",
+      "roundAmountsLabel": "Round amounts",
+      "stackOrderLabel": "Stack order",
       "income": "Income",
       "noData": "No spending data yet.",
+      "ChartTypes": {
+        "bars": "Stacked bars",
+        "columns": "Stacked columns"
+      },
+      "StackOrders": {
+        "smallInside": "Smaller debt inside",
+        "smallOutside": "Smaller debt outside"
+      },
       "RangeOptions": {
         "three": "3 months",
         "six": "6 months",
@@ -330,8 +345,8 @@
         "all": "All"
       },
       "GroupingOptions": {
-        "categoryGroup": "Category groups",
-        "category": "Detailed categories"
+        "categoryGroup": "Categories",
+        "category": "Detailed"
       }
     }
   },

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -312,6 +312,27 @@
       "yourSpendings": "Your total spendings",
       "yourEarnings": "Your total earnings",
       "yourShare": "Your total share"
+    },
+    "MonthlySpending": {
+      "title": "Monthly spending",
+      "description": "Spending by month and category.",
+      "rangeLabel": "Range",
+      "groupingLabel": "Category grouping",
+      "stackedTitle": "Monthly categories",
+      "breakdownTitle": "{month} category breakdown",
+      "trendTitle": "Monthly total",
+      "income": "Income",
+      "noData": "No spending data yet.",
+      "RangeOptions": {
+        "three": "3 months",
+        "six": "6 months",
+        "twelve": "12 months",
+        "all": "All"
+      },
+      "GroupingOptions": {
+        "categoryGroup": "Category groups",
+        "category": "Detailed categories"
+      }
     }
   },
   "Activity": {

--- a/src/app/groups/[groupId]/expenses/create-expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/create-expense-form.tsx
@@ -37,6 +37,7 @@ export function CreateExpenseForm({
           participantId,
         })
         utils.groups.expenses.invalidate()
+        utils.groups.stats.invalidate()
         router.push(`/groups/${group.id}`)
       }}
       runtimeFeatureFlags={runtimeFeatureFlags}

--- a/src/app/groups/[groupId]/expenses/edit-expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/edit-expense-form.tsx
@@ -48,6 +48,7 @@ export function EditExpenseForm({
           participantId,
         })
         utils.groups.expenses.invalidate()
+        utils.groups.stats.invalidate()
         router.push(`/groups/${group.id}`)
       }}
       onDelete={async (participantId) => {
@@ -57,6 +58,7 @@ export function EditExpenseForm({
           participantId,
         })
         utils.groups.expenses.invalidate()
+        utils.groups.stats.invalidate()
         router.push(`/groups/${group.id}`)
       }}
       runtimeFeatureFlags={runtimeFeatureFlags}

--- a/src/app/groups/[groupId]/stats/balance-timeline-chart.tsx
+++ b/src/app/groups/[groupId]/stats/balance-timeline-chart.tsx
@@ -1,0 +1,1474 @@
+'use client'
+
+import { CategoryIcon } from '@/app/groups/[groupId]/expenses/category-icon'
+import { Button } from '@/components/ui/button'
+import { formatChartCurrency } from '@/lib/chart-currency'
+import { cn, formatCurrency } from '@/lib/utils'
+import { AppRouterOutput } from '@/trpc/routers/_app'
+import { Category } from '@prisma/client'
+import { Banknote } from 'lucide-react'
+import { useState, type PointerEvent } from 'react'
+
+type BalanceTimeline =
+  AppRouterOutput['groups']['stats']['get']['balanceTimeline']
+type BalanceTimelineParticipant = BalanceTimeline['participants'][number]
+type BalanceTimelinePoint = BalanceTimeline['points'][number]
+type BalanceTimelineEvent = BalanceTimelinePoint['events'][number]
+
+type BalanceTimelineColor = {
+  legendClassName: string
+  lineClassName: string
+}
+
+type TimelineCoordinate = {
+  balance: number
+  baseStackedBalance: number
+  baseY: number
+  delta: number
+  point: BalanceTimelinePoint
+  stackedBalance: number
+  x: number
+  y: number
+}
+
+type TimelineMonthTick = {
+  day: number
+  index: number
+  key: string
+  month: number
+  year: number
+}
+
+type TimelineYAxisTick = {
+  key: string
+  label: string
+  value: number
+  y: number
+}
+
+type BalanceTimelineParticipantSeries = {
+  color: BalanceTimelineColor
+  coordinates: TimelineCoordinate[]
+  participant: BalanceTimelineParticipant
+}
+
+type TimelineParticipantCoordinate = {
+  color: BalanceTimelineColor
+  coordinate: TimelineCoordinate
+  participant: BalanceTimelineParticipant
+}
+
+type TimelineEventMarker = {
+  color: BalanceTimelineColor
+  coordinate: TimelineCoordinate
+  event: BalanceTimelineEvent
+  guideY: number
+  key: string
+  railX: number
+  title: string
+}
+
+type TimelineInterval = {
+  centerX: number
+  coordinate: TimelineCoordinate
+  endX: number
+  width: number
+  x: number
+}
+
+type TimelineStackOrder = 'smallInside' | 'smallOutside'
+
+const BALANCE_TIMELINE_COLORS: BalanceTimelineColor[] = [
+  {
+    legendClassName: 'bg-blue-500 dark:bg-blue-400',
+    lineClassName: 'text-blue-600 dark:text-blue-400',
+  },
+  {
+    legendClassName: 'bg-purple-500 dark:bg-purple-400',
+    lineClassName: 'text-purple-600 dark:text-purple-400',
+  },
+  {
+    legendClassName: 'bg-yellow-500 dark:bg-yellow-400',
+    lineClassName: 'text-yellow-600 dark:text-yellow-400',
+  },
+  {
+    legendClassName: 'bg-slate-500 dark:bg-slate-400',
+    lineClassName: 'text-slate-600 dark:text-slate-400',
+  },
+  {
+    legendClassName: 'bg-cyan-500 dark:bg-cyan-400',
+    lineClassName: 'text-cyan-600 dark:text-cyan-400',
+  },
+  {
+    legendClassName: 'bg-indigo-500 dark:bg-indigo-400',
+    lineClassName: 'text-indigo-600 dark:text-indigo-400',
+  },
+]
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000
+const TIMELINE_CHART_WIDTH = 1000
+const TIMELINE_CHART_HEIGHT = 260
+const TIMELINE_CHART_PADDING_X = 18
+const TIMELINE_Y_AXIS_GUTTER_WIDTH = 62
+const TIMELINE_PLOT_LEFT_X =
+  TIMELINE_CHART_PADDING_X + TIMELINE_Y_AXIS_GUTTER_WIDTH
+const TIMELINE_PLOT_RIGHT_X = TIMELINE_CHART_WIDTH - TIMELINE_CHART_PADDING_X
+const TIMELINE_PLOT_WIDTH = TIMELINE_PLOT_RIGHT_X - TIMELINE_PLOT_LEFT_X
+const TIMELINE_Y_AXIS_LABEL_X = TIMELINE_PLOT_LEFT_X - 8
+const TIMELINE_CHART_CENTER_Y = 130
+const TIMELINE_CHART_HALF_HEIGHT = 84
+const TIMELINE_PLOT_TOP_Y = TIMELINE_CHART_CENTER_Y - TIMELINE_CHART_HALF_HEIGHT
+const TIMELINE_PLOT_BOTTOM_Y =
+  TIMELINE_CHART_CENTER_Y + TIMELINE_CHART_HALF_HEIGHT
+const TIMELINE_AREA_LABEL_X = TIMELINE_PLOT_LEFT_X + 8
+const TIMELINE_OWES_AREA_LABEL_Y = TIMELINE_PLOT_TOP_Y + 14
+const TIMELINE_IS_OWED_AREA_LABEL_Y = TIMELINE_PLOT_BOTTOM_Y - 10
+const TIMELINE_EVENT_MARKER_RAIL_Y = TIMELINE_PLOT_TOP_Y - 14
+const TIMELINE_EVENT_MARKER_SIZE = 20
+const TIMELINE_EVENT_MARKER_GAP = 24
+const TIMELINE_HOVER_TOOLTIP_WIDTH = 244
+const TIMELINE_INTERVAL_GAP = 1
+const TIMELINE_INTERVAL_PARTICIPANT_WIDTH_RATIO = 0.62
+const TIMELINE_IS_OWED_AREA_CLASS_NAME = 'fill-green-200 dark:fill-green-800'
+const TIMELINE_OWES_AREA_CLASS_NAME = 'fill-red-500 dark:fill-red-400'
+
+export function BalanceTimelineChart({
+  balanceTimeline,
+  currency,
+  locale,
+  roundAmounts,
+  t,
+}: {
+  balanceTimeline: BalanceTimeline
+  currency: Parameters<typeof formatCurrency>[0]
+  locale: string
+  roundAmounts: boolean
+  t: (key: string) => string
+}) {
+  const [showCategoryMarkers, setShowCategoryMarkers] = useState(false)
+  const [stackOrder, setStackOrder] =
+    useState<TimelineStackOrder>('smallOutside')
+
+  if (
+    balanceTimeline.points.length === 0 ||
+    balanceTimeline.participants.length === 0
+  ) {
+    return null
+  }
+
+  const monthTicks = getTimelineMonthTicks(
+    balanceTimeline.rangeStart,
+    balanceTimeline.rangeEnd,
+  )
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <h3 className="text-sm font-semibold">{t('balanceTimelineTitle')}</h3>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-muted-foreground">
+          {balanceTimeline.participants.map((participant, participantIndex) => {
+            const color = getBalanceTimelineColor(participantIndex)
+
+            return (
+              <span
+                className="flex min-w-0 items-center gap-1.5"
+                key={participant.id}
+              >
+                <span
+                  className={cn(
+                    'h-3.5 w-2.5 shrink-0 rounded-[2px]',
+                    color.legendClassName,
+                  )}
+                />
+                <span className="truncate">{participant.name}</span>
+              </span>
+            )
+          })}
+          <span className="flex items-center gap-1.5">
+            <Banknote className="h-3.5 w-3.5 text-lime-400 drop-shadow-[0_0_3px_rgba(163,230,53,0.9)]" />
+            {t('payment')}
+          </span>
+        </div>
+      </div>
+      <div className="space-y-1 pb-1">
+        <BalanceTimelineLinesChart
+          balanceTimeline={balanceTimeline}
+          currency={currency}
+          locale={locale}
+          monthTicks={monthTicks}
+          roundAmounts={roundAmounts}
+          showCategoryMarkers={showCategoryMarkers}
+          stackOrder={stackOrder}
+          t={t}
+        />
+        <TimelineMonthAxis
+          locale={locale}
+          rangeEnd={balanceTimeline.rangeEnd}
+          rangeStart={balanceTimeline.rangeStart}
+          ticks={monthTicks}
+        />
+        <div className="flex flex-wrap justify-end gap-1.5 pt-1">
+          <Button
+            aria-pressed={showCategoryMarkers}
+            className="h-6 px-1.5 text-[10px]"
+            onClick={() => setShowCategoryMarkers((value) => !value)}
+            type="button"
+            variant={showCategoryMarkers ? 'secondary' : 'outline'}
+          >
+            {t('categoryMarkers')}
+          </Button>
+          <StackOrderToggle
+            onStackOrderChange={setStackOrder}
+            stackOrder={stackOrder}
+            t={t}
+          />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function StackOrderToggle({
+  onStackOrderChange,
+  stackOrder,
+  t,
+}: {
+  onStackOrderChange: (stackOrder: TimelineStackOrder) => void
+  stackOrder: TimelineStackOrder
+  t: (key: string) => string
+}) {
+  const isSmallOutside = stackOrder === 'smallOutside'
+
+  return (
+    <Button
+      aria-label={t('stackOrderLabel')}
+      aria-pressed={isSmallOutside}
+      className="h-6 px-1.5 text-[10px]"
+      onClick={() =>
+        onStackOrderChange(isSmallOutside ? 'smallInside' : 'smallOutside')
+      }
+      title={t('stackOrderLabel')}
+      type="button"
+      variant={isSmallOutside ? 'secondary' : 'outline'}
+    >
+      {t(
+        isSmallOutside ? 'StackOrders.smallOutside' : 'StackOrders.smallInside',
+      )}
+    </Button>
+  )
+}
+
+function BalanceTimelineLinesChart({
+  balanceTimeline,
+  currency,
+  locale,
+  monthTicks,
+  roundAmounts,
+  showCategoryMarkers,
+  stackOrder,
+  t,
+}: {
+  balanceTimeline: BalanceTimeline
+  currency: Parameters<typeof formatCurrency>[0]
+  locale: string
+  monthTicks: TimelineMonthTick[]
+  roundAmounts: boolean
+  showCategoryMarkers: boolean
+  stackOrder: TimelineStackOrder
+  t: (key: string) => string
+}) {
+  const [hoveredPointIndex, setHoveredPointIndex] = useState<number | null>(
+    null,
+  )
+  const maxStackedAbsBalance = getMaxStackedAbsBalance(balanceTimeline.points)
+  const yAxisMaxBalance = getBalanceTimelineYAxisMax(
+    maxStackedAbsBalance,
+    currency,
+  )
+  const yAxisTicks = getBalanceTimelineYAxisTicks({
+    currency,
+    locale,
+    yAxisMaxBalance,
+  })
+  const participantIds = balanceTimeline.participants.map(
+    (participant) => participant.id,
+  )
+  const participantSeries: BalanceTimelineParticipantSeries[] =
+    balanceTimeline.participants.map((participant, participantIndex) => ({
+      color: getBalanceTimelineColor(participantIndex),
+      coordinates: getTimelineCoordinates({
+        participantId: participant.id,
+        participantIds,
+        points: balanceTimeline.points,
+        rangeEnd: balanceTimeline.rangeEnd,
+        rangeStart: balanceTimeline.rangeStart,
+        stackOrder,
+        yAxisMaxBalance,
+      }),
+      participant,
+    }))
+  const timelineCoordinates = participantSeries[0]?.coordinates ?? []
+  const timelineIntervals = getTimelineIntervals(timelineCoordinates)
+  const hoveredParticipantCoordinates =
+    hoveredPointIndex === null
+      ? []
+      : participantSeries.flatMap(({ color, coordinates, participant }) => {
+          const coordinate = coordinates[hoveredPointIndex]
+
+          if (!coordinate) return []
+
+          return [{ color, coordinate, participant }]
+        })
+
+  function handlePointerMove(event: PointerEvent<HTMLDivElement>) {
+    if (timelineCoordinates.length === 0) return
+
+    const rect = event.currentTarget.getBoundingClientRect()
+    const rawX =
+      ((event.clientX - rect.left) / rect.width) * TIMELINE_CHART_WIDTH
+    const x = clamp(rawX, TIMELINE_PLOT_LEFT_X, TIMELINE_PLOT_RIGHT_X)
+    const nextPointIndex = getTimelineIntervalIndex(timelineIntervals, x)
+
+    setHoveredPointIndex((currentPointIndex) =>
+      currentPointIndex === nextPointIndex ? currentPointIndex : nextPointIndex,
+    )
+  }
+
+  return (
+    <div
+      className="relative h-72 w-full"
+      onPointerLeave={() => setHoveredPointIndex(null)}
+      onPointerMove={handlePointerMove}
+    >
+      <svg
+        aria-label={t('balanceTimelineTitle')}
+        className="absolute inset-0 h-full w-full overflow-visible rounded-sm bg-white"
+        preserveAspectRatio="none"
+        role="img"
+        viewBox={`0 0 ${TIMELINE_CHART_WIDTH} ${TIMELINE_CHART_HEIGHT}`}
+      >
+        <TimelineYAxisGrid ticks={yAxisTicks} />
+        {monthTicks.map((tick) => {
+          const x = getTimelineXCoordinate(tick, {
+            rangeEnd: balanceTimeline.rangeEnd,
+            rangeStart: balanceTimeline.rangeStart,
+          })
+
+          return (
+            <line
+              className="stroke-border"
+              key={tick.key}
+              opacity="0.42"
+              strokeWidth="1"
+              vectorEffect="non-scaling-stroke"
+              x1={x}
+              x2={x}
+              y1={TIMELINE_PLOT_TOP_Y}
+              y2={TIMELINE_PLOT_BOTTOM_Y}
+            />
+          )
+        })}
+        <TimelineBalanceColumns
+          currency={currency}
+          locale={locale}
+          participantSeries={participantSeries}
+          roundAmounts={roundAmounts}
+          yAxisMaxBalance={yAxisMaxBalance}
+        />
+        <line
+          className="stroke-foreground"
+          opacity="0.65"
+          strokeWidth="2.5"
+          vectorEffect="non-scaling-stroke"
+          x1={TIMELINE_PLOT_LEFT_X}
+          x2={TIMELINE_PLOT_RIGHT_X}
+          y1={TIMELINE_CHART_CENTER_Y}
+          y2={TIMELINE_CHART_CENTER_Y}
+        />
+        <TimelineBalanceAreaLabels t={t} />
+        <TimelineHoverGuide
+          hoveredInterval={
+            hoveredPointIndex === null
+              ? undefined
+              : timelineIntervals[hoveredPointIndex]
+          }
+          hoveredParticipantCoordinates={hoveredParticipantCoordinates}
+        />
+      </svg>
+      <TimelineEventMarkerLayer
+        currency={currency}
+        locale={locale}
+        participantSeries={participantSeries}
+        roundAmounts={roundAmounts}
+        showCategoryMarkers={showCategoryMarkers}
+      />
+      <TimelineHoverTooltip
+        currency={currency}
+        hoveredParticipantCoordinates={hoveredParticipantCoordinates}
+        locale={locale}
+        roundAmounts={roundAmounts}
+        t={t}
+      />
+    </div>
+  )
+}
+
+function TimelineYAxisGrid({ ticks }: { ticks: TimelineYAxisTick[] }) {
+  return (
+    <g aria-hidden="true" pointerEvents="none">
+      {ticks.map((tick) => (
+        <g key={tick.key}>
+          {tick.value !== 0 && (
+            <line
+              className="stroke-border"
+              opacity="0.42"
+              strokeWidth="1"
+              vectorEffect="non-scaling-stroke"
+              x1={TIMELINE_PLOT_LEFT_X}
+              x2={TIMELINE_PLOT_RIGHT_X}
+              y1={tick.y}
+              y2={tick.y}
+            />
+          )}
+          <text
+            className="fill-muted-foreground text-[11px] tabular-nums"
+            dominantBaseline="middle"
+            textAnchor="end"
+            x={TIMELINE_Y_AXIS_LABEL_X}
+            y={tick.y}
+          >
+            {tick.label}
+          </text>
+        </g>
+      ))}
+    </g>
+  )
+}
+
+function TimelineBalanceAreaLabels({ t }: { t: (key: string) => string }) {
+  const labels = [
+    {
+      className: 'fill-red-700 dark:fill-red-200',
+      key: 'owes',
+      text: t('owesMoney'),
+      y: TIMELINE_OWES_AREA_LABEL_Y,
+    },
+    {
+      className: 'fill-green-700 dark:fill-green-200',
+      key: 'is-owed',
+      text: t('isOwedMoney'),
+      y: TIMELINE_IS_OWED_AREA_LABEL_Y,
+    },
+  ]
+
+  return (
+    <g pointerEvents="none">
+      {labels.map((label) => {
+        const labelWidth = getTimelineTextLabelWidth(label.text)
+
+        return (
+          <g key={label.key}>
+            <rect
+              className="fill-white"
+              height="18"
+              opacity="0.86"
+              rx="4"
+              width={labelWidth}
+              x={TIMELINE_AREA_LABEL_X - 6}
+              y={label.y - 12}
+            />
+            <text
+              className={cn('text-[12px] font-semibold', label.className)}
+              dominantBaseline="middle"
+              textAnchor="start"
+              x={TIMELINE_AREA_LABEL_X}
+              y={label.y}
+            >
+              {label.text}
+            </text>
+          </g>
+        )
+      })}
+    </g>
+  )
+}
+
+function TimelineBalanceColumns({
+  currency,
+  locale,
+  participantSeries,
+  roundAmounts,
+  yAxisMaxBalance,
+}: {
+  currency: Parameters<typeof formatCurrency>[0]
+  locale: string
+  participantSeries: BalanceTimelineParticipantSeries[]
+  roundAmounts: boolean
+  yAxisMaxBalance: number
+}) {
+  const timelineCoordinates = participantSeries[0]?.coordinates ?? []
+  const timelineIntervals = getTimelineIntervals(timelineCoordinates)
+
+  return (
+    <g>
+      <g aria-hidden="true">
+        {timelineIntervals.map((interval) => {
+          const { negativeTotal, positiveTotal } = getPointBalanceTotals(
+            interval.coordinate.point,
+          )
+          const negativeY = getTimelineStackY(negativeTotal, yAxisMaxBalance)
+          const positiveY = getTimelineStackY(positiveTotal, yAxisMaxBalance)
+
+          if (interval.width <= 0) return null
+
+          return (
+            <g key={`${interval.coordinate.point.key}-polarity-column`}>
+              {negativeTotal < 0 && (
+                <rect
+                  className={TIMELINE_OWES_AREA_CLASS_NAME}
+                  fillOpacity="0.3"
+                  height={TIMELINE_CHART_CENTER_Y - negativeY}
+                  width={interval.width}
+                  x={interval.x}
+                  y={negativeY}
+                />
+              )}
+              {positiveTotal > 0 && (
+                <rect
+                  className={TIMELINE_IS_OWED_AREA_CLASS_NAME}
+                  fillOpacity="0.8"
+                  height={positiveY - TIMELINE_CHART_CENTER_Y}
+                  width={interval.width}
+                  x={interval.x}
+                  y={TIMELINE_CHART_CENTER_Y}
+                />
+              )}
+            </g>
+          )
+        })}
+      </g>
+      {participantSeries.map(({ color, coordinates, participant }) => (
+        <g key={`${participant.id}-columns`}>
+          {getTimelineIntervals(coordinates).map((interval) => {
+            const coordinate = interval.coordinate
+            const height = Math.abs(coordinate.y - coordinate.baseY)
+            const participantColumnWidth =
+              getTimelineParticipantColumnWidth(interval)
+
+            if (height < 0.8 || interval.width <= 0) return null
+
+            return (
+              <rect
+                className={cn('fill-current', color.lineClassName)}
+                height={height}
+                key={`${participant.id}-${coordinate.point.key}-column`}
+                opacity="0.92"
+                shapeRendering="crispEdges"
+                width={participantColumnWidth}
+                x={interval.centerX - participantColumnWidth / 2}
+                y={Math.min(coordinate.y, coordinate.baseY)}
+              >
+                <title>
+                  {getBalanceTimelinePointLabel({
+                    balance: coordinate.balance,
+                    currency,
+                    locale,
+                    participant,
+                    roundAmounts,
+                  })}
+                </title>
+              </rect>
+            )
+          })}
+        </g>
+      ))}
+    </g>
+  )
+}
+
+function TimelineHoverGuide({
+  hoveredInterval,
+  hoveredParticipantCoordinates,
+}: {
+  hoveredInterval?: TimelineInterval
+  hoveredParticipantCoordinates: TimelineParticipantCoordinate[]
+}) {
+  const x = hoveredParticipantCoordinates[0]?.coordinate.x
+
+  if (x === undefined) return null
+
+  return (
+    <g pointerEvents="none">
+      <rect
+        className="fill-foreground"
+        height={TIMELINE_PLOT_BOTTOM_Y - TIMELINE_PLOT_TOP_Y}
+        opacity="0.06"
+        width={hoveredInterval?.width ?? 0}
+        x={hoveredInterval?.x ?? x}
+        y={TIMELINE_PLOT_TOP_Y}
+      />
+      <line
+        className="stroke-foreground"
+        opacity="0.7"
+        strokeDasharray="4 3"
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+        x1={x}
+        x2={x}
+        y1={TIMELINE_PLOT_TOP_Y}
+        y2={TIMELINE_PLOT_BOTTOM_Y}
+      />
+    </g>
+  )
+}
+
+function TimelineHoverTooltip({
+  currency,
+  hoveredParticipantCoordinates,
+  locale,
+  roundAmounts,
+  t,
+}: {
+  currency: Parameters<typeof formatCurrency>[0]
+  hoveredParticipantCoordinates: TimelineParticipantCoordinate[]
+  locale: string
+  roundAmounts: boolean
+  t: (key: string) => string
+}) {
+  const point = hoveredParticipantCoordinates[0]?.coordinate.point
+
+  if (!point) return null
+
+  const x = hoveredParticipantCoordinates[0].coordinate.x
+  const sortedParticipantCoordinates = [...hoveredParticipantCoordinates].sort(
+    (participantA, participantB) =>
+      participantA.coordinate.y - participantB.coordinate.y,
+  )
+  const owingParticipantCoordinates = sortedParticipantCoordinates.filter(
+    ({ coordinate }) => coordinate.balance < 0,
+  )
+  const owedParticipantCoordinates = sortedParticipantCoordinates.filter(
+    ({ coordinate }) => coordinate.balance > 0,
+  )
+  const positiveTotal = sortedParticipantCoordinates.reduce(
+    (total, { coordinate }) =>
+      coordinate.balance > 0 ? total + coordinate.balance : total,
+    0,
+  )
+  const negativeTotal = Math.abs(
+    sortedParticipantCoordinates.reduce(
+      (total, { coordinate }) =>
+        coordinate.balance < 0 ? total + coordinate.balance : total,
+      0,
+    ),
+  )
+  const shouldPlaceLeft =
+    x > TIMELINE_PLOT_RIGHT_X - TIMELINE_HOVER_TOOLTIP_WIDTH
+
+  return (
+    <div
+      className="pointer-events-none absolute z-20 w-[244px] rounded-sm border bg-background/95 p-2 text-xs shadow-lg"
+      style={{
+        left: `${(x / TIMELINE_CHART_WIDTH) * 100}%`,
+        top: `${((TIMELINE_PLOT_TOP_Y + 8) / TIMELINE_CHART_HEIGHT) * 100}%`,
+        transform: shouldPlaceLeft
+          ? 'translateX(calc(-100% - 0.75rem))'
+          : 'translateX(0.75rem)',
+      }}
+    >
+      <div className="mb-1.5 font-medium text-foreground">
+        {formatTimelineDay(point, locale)}
+      </div>
+      <div className="space-y-2 border-t pt-1.5">
+        <TimelineHoverBalanceSection
+          amount={negativeTotal}
+          currency={currency}
+          locale={locale}
+          participantCoordinates={owingParticipantCoordinates}
+          roundAmounts={roundAmounts}
+          textClassName="text-red-700 dark:text-red-200"
+          title={t('owesMoney')}
+        />
+        <TimelineHoverBalanceSection
+          amount={positiveTotal}
+          currency={currency}
+          locale={locale}
+          participantCoordinates={owedParticipantCoordinates}
+          roundAmounts={roundAmounts}
+          textClassName="text-green-700 dark:text-green-200"
+          title={t('isOwedMoney')}
+        />
+      </div>
+    </div>
+  )
+}
+
+function TimelineHoverBalanceSection({
+  amount,
+  currency,
+  locale,
+  participantCoordinates,
+  roundAmounts,
+  textClassName,
+  title,
+}: {
+  amount: number
+  currency: Parameters<typeof formatCurrency>[0]
+  locale: string
+  participantCoordinates: TimelineParticipantCoordinate[]
+  roundAmounts: boolean
+  textClassName: string
+  title: string
+}) {
+  return (
+    <div className="space-y-1">
+      <div
+        className={cn(
+          'flex items-center justify-between gap-3 font-semibold',
+          textClassName,
+        )}
+      >
+        <span>{title}</span>
+        <span>
+          {formatChartCurrency({
+            amount,
+            currency,
+            locale,
+            roundAmounts,
+          })}
+        </span>
+      </div>
+      {participantCoordinates.map(({ color, coordinate, participant }) => (
+        <div
+          className="flex items-start gap-2"
+          key={`${participant.id}-${coordinate.point.key}-tooltip`}
+        >
+          <span
+            className={cn(
+              'mt-0.5 h-3.5 w-2.5 shrink-0 rounded-[2px]',
+              color.legendClassName,
+            )}
+          />
+          <span className="min-w-0 flex-1 text-muted-foreground">
+            {formatParticipantBalance({
+              amount: coordinate.balance,
+              currency,
+              includeCurrently: false,
+              locale,
+              participantName: participant.name,
+              roundAmounts,
+            })}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function TimelineEventMarkerLayer({
+  currency,
+  locale,
+  participantSeries,
+  roundAmounts,
+  showCategoryMarkers,
+}: {
+  currency: Parameters<typeof formatCurrency>[0]
+  locale: string
+  participantSeries: BalanceTimelineParticipantSeries[]
+  roundAmounts: boolean
+  showCategoryMarkers: boolean
+}) {
+  const markers = getTimelineEventMarkers({
+    currency,
+    locale,
+    participantSeries,
+    roundAmounts,
+    showCategoryMarkers,
+  })
+
+  return (
+    <>
+      <svg
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 h-full w-full overflow-visible"
+        preserveAspectRatio="none"
+        viewBox={`0 0 ${TIMELINE_CHART_WIDTH} ${TIMELINE_CHART_HEIGHT}`}
+      >
+        {markers.map(({ coordinate, event, guideY, key, railX }) => (
+          <line
+            className={
+              event.isReimbursement
+                ? 'stroke-lime-400'
+                : 'stroke-muted-foreground'
+            }
+            key={`${key}-guide`}
+            opacity={event.isReimbursement ? '0.95' : '0.58'}
+            strokeDasharray={event.isReimbursement ? undefined : '1 5'}
+            strokeLinecap="round"
+            strokeWidth="1.1"
+            vectorEffect="non-scaling-stroke"
+            x1={railX}
+            x2={coordinate.x}
+            y1={TIMELINE_EVENT_MARKER_RAIL_Y}
+            y2={guideY}
+          />
+        ))}
+      </svg>
+      <div className="pointer-events-none absolute inset-0">
+        {markers.map(({ color, coordinate, event, key, railX, title }) => (
+          <div
+            aria-label={title}
+            className={cn(
+              'pointer-events-auto absolute flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-[3px] border bg-background/95 shadow-sm',
+              event.isReimbursement ? 'border-lime-300' : 'border-border',
+            )}
+            key={key}
+            style={{
+              left: `${(railX / TIMELINE_CHART_WIDTH) * 100}%`,
+              top: `${(TIMELINE_EVENT_MARKER_RAIL_Y / TIMELINE_CHART_HEIGHT) * 100}%`,
+            }}
+            title={title}
+          >
+            {event.isReimbursement ? (
+              <Banknote className="h-3.5 w-3.5 text-lime-400 opacity-95 drop-shadow-[0_0_3px_rgba(163,230,53,0.9)]" />
+            ) : (
+              <CategoryIcon
+                category={event.category as Category | null}
+                className={cn('h-3.5 w-3.5 opacity-55', color.lineClassName)}
+              />
+            )}
+            <span className="sr-only">{title}</span>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}
+
+function getTimelineEventMarkers({
+  currency,
+  locale,
+  participantSeries,
+  roundAmounts,
+  showCategoryMarkers,
+}: {
+  currency: Parameters<typeof formatCurrency>[0]
+  locale: string
+  participantSeries: BalanceTimelineParticipantSeries[]
+  roundAmounts: boolean
+  showCategoryMarkers: boolean
+}): TimelineEventMarker[] {
+  const markers = participantSeries.flatMap(
+    ({ color, coordinates, participant }) =>
+      coordinates.flatMap((coordinate) => {
+        const events = getMarkerEvents({
+          coordinate,
+          participantId: participant.id,
+          showCategoryMarkers,
+        })
+
+        return events.map((event, eventIndex) => ({
+          color,
+          coordinate,
+          event,
+          guideY: event.isReimbursement
+            ? getTimelinePointTopY(coordinate, participantSeries)
+            : coordinate.y,
+          key: `${participant.id}-${coordinate.point.key}-${eventIndex}-event`,
+          railX: coordinate.x,
+          title: event.isReimbursement
+            ? getPaymentEventLabel({ currency, event, locale, roundAmounts })
+            : getExpenseEventLabel({ currency, event, locale, roundAmounts }),
+        }))
+      }),
+  )
+
+  const markerCountByPoint = new Map<string, number>()
+
+  return markers.map((marker) => {
+    const pointKey = marker.coordinate.point.key
+    const pointMarkerIndex = markerCountByPoint.get(pointKey) ?? 0
+    const pointMarkerCount = markers.filter(
+      (candidateMarker) => candidateMarker.coordinate.point.key === pointKey,
+    ).length
+
+    markerCountByPoint.set(pointKey, pointMarkerIndex + 1)
+
+    return {
+      ...marker,
+      railX: clamp(
+        marker.coordinate.x +
+          (pointMarkerIndex - (pointMarkerCount - 1) / 2) *
+            TIMELINE_EVENT_MARKER_GAP,
+        TIMELINE_PLOT_LEFT_X + TIMELINE_EVENT_MARKER_SIZE / 2,
+        TIMELINE_PLOT_RIGHT_X - TIMELINE_EVENT_MARKER_SIZE / 2,
+      ),
+    }
+  })
+}
+
+function getTimelinePointTopY(
+  coordinate: TimelineCoordinate,
+  participantSeries: BalanceTimelineParticipantSeries[],
+) {
+  const pointCoordinates = participantSeries.flatMap(({ coordinates }) =>
+    coordinates.filter(
+      (candidateCoordinate) =>
+        candidateCoordinate.point.key === coordinate.point.key,
+    ),
+  )
+
+  return Math.min(
+    TIMELINE_CHART_CENTER_Y,
+    ...pointCoordinates.map((pointCoordinate) =>
+      Math.min(pointCoordinate.y, pointCoordinate.baseY),
+    ),
+  )
+}
+
+function TimelineMonthAxis({
+  locale,
+  rangeEnd,
+  rangeStart,
+  ticks,
+}: {
+  locale: string
+  rangeEnd: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>
+  rangeStart: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>
+  ticks: TimelineMonthTick[]
+}) {
+  return (
+    <div className="relative h-3 text-[10px] leading-none text-muted-foreground">
+      {ticks.map((tick) => {
+        const left = getTimelineXPercent(tick, { rangeEnd, rangeStart })
+
+        return (
+          <span
+            className={cn(
+              'absolute top-0 max-w-12 truncate',
+              left <= 1
+                ? 'translate-x-0 text-left'
+                : left >= 99
+                  ? '-translate-x-full text-right'
+                  : '-translate-x-1/2 text-center',
+            )}
+            key={tick.key}
+            style={{ left: `${left}%` }}
+            title={formatTimelineMonth(tick, locale, 'long')}
+          >
+            {formatTimelineMonth(tick, locale, 'short')}
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+function getTimelineCoordinates({
+  participantId,
+  participantIds,
+  points,
+  rangeEnd,
+  rangeStart,
+  stackOrder,
+  yAxisMaxBalance,
+}: {
+  participantId: string
+  participantIds: string[]
+  points: BalanceTimelinePoint[]
+  rangeEnd: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>
+  rangeStart: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>
+  stackOrder: TimelineStackOrder
+  yAxisMaxBalance: number
+}): TimelineCoordinate[] {
+  return points.map((point) => {
+    const balance = point.balances[participantId] ?? 0
+    const delta = point.deltas[participantId] ?? 0
+    const baseStackedBalance = getBaseStackedBalance({
+      participantId,
+      participantIds,
+      point,
+      stackOrder,
+    })
+    const stackedBalance = getStackedBalance({
+      baseStackedBalance,
+      balance,
+    })
+
+    return {
+      balance,
+      baseStackedBalance,
+      baseY: getTimelineStackY(baseStackedBalance, yAxisMaxBalance),
+      delta,
+      point,
+      stackedBalance,
+      x: getTimelineXCoordinate(point, { rangeEnd, rangeStart }),
+      y: getTimelineStackY(stackedBalance, yAxisMaxBalance),
+    }
+  })
+}
+
+function getBaseStackedBalance({
+  participantId,
+  participantIds,
+  point,
+  stackOrder,
+}: {
+  participantId: string
+  participantIds: string[]
+  point: BalanceTimelinePoint
+  stackOrder: TimelineStackOrder
+}) {
+  const participantBalance = point.balances[participantId] ?? 0
+  if (participantBalance === 0) return 0
+
+  const stackedParticipantIds = getSortedStackParticipantIds({
+    participantBalance,
+    participantIds,
+    point,
+    stackOrder,
+  })
+  const participantIndex = stackedParticipantIds.indexOf(participantId)
+
+  return stackedParticipantIds
+    .slice(0, participantIndex)
+    .reduce(
+      (total, stackedParticipantId) =>
+        total + (point.balances[stackedParticipantId] ?? 0),
+      0,
+    )
+}
+
+function getSortedStackParticipantIds({
+  participantBalance,
+  participantIds,
+  point,
+  stackOrder,
+}: {
+  participantBalance: number
+  participantIds: string[]
+  point: BalanceTimelinePoint
+  stackOrder: TimelineStackOrder
+}) {
+  const participantSign = Math.sign(participantBalance)
+
+  return participantIds
+    .filter((stackedParticipantId) => {
+      const balance = point.balances[stackedParticipantId] ?? 0
+      return Math.sign(balance) === participantSign
+    })
+    .sort((participantIdA, participantIdB) => {
+      const balanceA = Math.abs(point.balances[participantIdA] ?? 0)
+      const balanceB = Math.abs(point.balances[participantIdB] ?? 0)
+      const amountDifference = balanceA - balanceB
+
+      if (amountDifference !== 0) {
+        return stackOrder === 'smallInside'
+          ? amountDifference
+          : -amountDifference
+      }
+
+      return (
+        participantIds.indexOf(participantIdA) -
+        participantIds.indexOf(participantIdB)
+      )
+    })
+}
+
+function getStackedBalance({
+  balance,
+  baseStackedBalance,
+}: {
+  balance: number
+  baseStackedBalance: number
+}) {
+  if (balance === 0) return 0
+  return baseStackedBalance + balance
+}
+
+function getMaxStackedAbsBalance(points: BalanceTimelinePoint[]) {
+  return points.reduce((maxStackedAbsBalance, point) => {
+    const { negativeTotal, positiveTotal } = getPointBalanceTotals(point)
+
+    return Math.max(
+      maxStackedAbsBalance,
+      positiveTotal,
+      Math.abs(negativeTotal),
+    )
+  }, 0)
+}
+
+function getBalanceTimelineYAxisMax(
+  maxStackedAbsBalance: number,
+  currency: Parameters<typeof formatCurrency>[0],
+) {
+  const maxMajorValue = maxStackedAbsBalance / 10 ** currency.decimal_digits
+  const tickMajorValue = getNiceTimelineAxisNumber(maxMajorValue / 2)
+
+  return Math.max(
+    1,
+    Math.round(tickMajorValue * 2 * 10 ** currency.decimal_digits),
+  )
+}
+
+function getBalanceTimelineYAxisTicks({
+  currency,
+  locale,
+  yAxisMaxBalance,
+}: {
+  currency: Parameters<typeof formatCurrency>[0]
+  locale: string
+  yAxisMaxBalance: number
+}): TimelineYAxisTick[] {
+  const tickStep = yAxisMaxBalance / 2
+
+  return [-yAxisMaxBalance, -tickStep, 0, tickStep, yAxisMaxBalance].map(
+    (value) => ({
+      key: String(value),
+      label: formatChartCurrency({
+        amount: value,
+        currency,
+        locale,
+        roundAmounts: true,
+      }),
+      value,
+      y: getTimelineStackY(value, yAxisMaxBalance),
+    }),
+  )
+}
+
+function getNiceTimelineAxisNumber(value: number) {
+  if (value <= 0) return 1
+
+  const exponent = Math.floor(Math.log10(value))
+  const magnitude = 10 ** exponent
+  const normalizedValue = value / magnitude
+
+  if (normalizedValue <= 1) return magnitude
+  if (normalizedValue <= 2) return 2 * magnitude
+  if (normalizedValue <= 5) return 5 * magnitude
+
+  return 10 * magnitude
+}
+
+function getPointBalanceTotals(point: BalanceTimelinePoint) {
+  return Object.values(point.balances).reduce(
+    (totals, balance) => {
+      if (balance > 0) totals.positiveTotal += balance
+      if (balance < 0) totals.negativeTotal += balance
+
+      return totals
+    },
+    { negativeTotal: 0, positiveTotal: 0 },
+  )
+}
+
+function getTimelineStackY(
+  stackedBalance: number,
+  maxStackedAbsBalance: number,
+) {
+  return (
+    TIMELINE_CHART_CENTER_Y +
+    (stackedBalance / Math.max(maxStackedAbsBalance, 1)) *
+      TIMELINE_CHART_HALF_HEIGHT
+  )
+}
+
+function getTimelineMonthTicks(
+  rangeStart: Pick<BalanceTimelinePoint, 'year' | 'month'>,
+  rangeEnd: Pick<BalanceTimelinePoint, 'year' | 'month'>,
+) {
+  const ticks: TimelineMonthTick[] = []
+  let current = { month: rangeStart.month, year: rangeStart.year }
+
+  while (getMonthKey(current) <= getMonthKey(rangeEnd)) {
+    ticks.push({
+      day: 1,
+      index: ticks.length,
+      key: getMonthKey(current),
+      month: current.month,
+      year: current.year,
+    })
+    current = addMonths(current.year, current.month, 1)
+  }
+
+  return ticks
+}
+
+function getTimelineXCoordinate(
+  point: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>,
+  {
+    rangeEnd,
+    rangeStart,
+  }: {
+    rangeEnd: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>
+    rangeStart: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>
+  },
+) {
+  const durationDays = getDayNumber(rangeEnd) - getDayNumber(rangeStart)
+  if (durationDays <= 0) {
+    return TIMELINE_PLOT_LEFT_X + TIMELINE_PLOT_WIDTH / 2
+  }
+
+  return (
+    TIMELINE_PLOT_LEFT_X +
+    ((getDayNumber(point) - getDayNumber(rangeStart)) / durationDays) *
+      TIMELINE_PLOT_WIDTH
+  )
+}
+
+function getTimelineXPercent(
+  point: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>,
+  {
+    rangeEnd,
+    rangeStart,
+  }: {
+    rangeEnd: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>
+    rangeStart: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>
+  },
+) {
+  const durationDays = getDayNumber(rangeEnd) - getDayNumber(rangeStart)
+  const plotStartPercent = (TIMELINE_PLOT_LEFT_X / TIMELINE_CHART_WIDTH) * 100
+  const plotWidthPercent = (TIMELINE_PLOT_WIDTH / TIMELINE_CHART_WIDTH) * 100
+
+  if (durationDays <= 0) return plotStartPercent + plotWidthPercent / 2
+
+  return (
+    plotStartPercent +
+    ((getDayNumber(point) - getDayNumber(rangeStart)) / durationDays) *
+      plotWidthPercent
+  )
+}
+
+function getTimelineIntervals(
+  coordinates: TimelineCoordinate[],
+): TimelineInterval[] {
+  return coordinates.map((coordinate, coordinateIndex) => {
+    const startX = clamp(
+      coordinate.x,
+      TIMELINE_PLOT_LEFT_X,
+      TIMELINE_PLOT_RIGHT_X,
+    )
+    const endX = clamp(
+      coordinates[coordinateIndex + 1]?.x ?? TIMELINE_PLOT_RIGHT_X,
+      TIMELINE_PLOT_LEFT_X,
+      TIMELINE_PLOT_RIGHT_X,
+    )
+    const rawWidth = Math.max(0, endX - startX)
+    const gap = rawWidth > TIMELINE_INTERVAL_GAP ? TIMELINE_INTERVAL_GAP : 0
+    const width = Math.max(0, rawWidth - gap)
+    const x = startX + gap / 2
+
+    return {
+      centerX: x + width / 2,
+      coordinate,
+      endX,
+      width,
+      x,
+    }
+  })
+}
+
+function getTimelineIntervalIndex(intervals: TimelineInterval[], x: number) {
+  if (intervals.length === 0) return 0
+
+  const intervalIndex = intervals.findIndex(
+    (interval) => x >= interval.x && x <= interval.endX,
+  )
+
+  if (intervalIndex !== -1) return intervalIndex
+
+  return intervals.reduce((nearestIndex, interval, candidateIndex) => {
+    const nearestInterval = intervals[nearestIndex]
+
+    return Math.abs(interval.coordinate.x - x) <
+      Math.abs(nearestInterval.coordinate.x - x)
+      ? candidateIndex
+      : nearestIndex
+  }, 0)
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value))
+}
+
+function getBalanceTimelineColor(index: number) {
+  return BALANCE_TIMELINE_COLORS[index % BALANCE_TIMELINE_COLORS.length]
+}
+
+function getTimelineTextLabelWidth(text: string) {
+  return Math.max(76, text.length * 6.8 + 12)
+}
+
+function getTimelineParticipantColumnWidth(interval: TimelineInterval) {
+  return Math.min(
+    interval.width,
+    Math.max(1.5, interval.width * TIMELINE_INTERVAL_PARTICIPANT_WIDTH_RATIO),
+  )
+}
+
+function getMarkerEvents({
+  coordinate,
+  participantId,
+  showCategoryMarkers,
+}: {
+  coordinate: TimelineCoordinate
+  participantId: string
+  showCategoryMarkers: boolean
+}) {
+  const paymentEvents = coordinate.point.events.filter(
+    (event) => event.isReimbursement && event.paidBy.id === participantId,
+  )
+
+  if (!showCategoryMarkers || coordinate.point.isStart) return paymentEvents
+
+  return [
+    ...paymentEvents,
+    ...coordinate.point.events.filter(
+      (event) => !event.isReimbursement && event.paidBy.id === participantId,
+    ),
+  ]
+}
+
+function formatParticipantBalance({
+  amount,
+  currency,
+  includeCurrently,
+  locale,
+  participantName,
+  roundAmounts,
+}: {
+  amount: number
+  currency: Parameters<typeof formatCurrency>[0]
+  includeCurrently: boolean
+  locale: string
+  participantName: string
+  roundAmounts: boolean
+}) {
+  const formattedAmount = formatChartCurrency({
+    amount: Math.abs(amount),
+    currency,
+    locale,
+    roundAmounts,
+  })
+  const currently = includeCurrently ? ' currently' : ''
+
+  if (amount < 0)
+    return `${participantName} owes ${formattedAmount}${currently}`
+  if (amount > 0) {
+    return `${participantName} is owed ${formattedAmount}${currently}`
+  }
+
+  return `${participantName} is settled${currently}`
+}
+
+function getPaymentEventLabel({
+  currency,
+  event,
+  locale,
+  roundAmounts,
+}: {
+  currency: Parameters<typeof formatCurrency>[0]
+  event: BalanceTimelineEvent
+  locale: string
+  roundAmounts: boolean
+}) {
+  const paidForNames = event.paidFor
+    .map((participant) => participant.name)
+    .join(', ')
+
+  return `${event.paidBy.name} paid ${formatChartCurrency({
+    amount: Math.abs(event.amount),
+    currency,
+    locale,
+    roundAmounts,
+  })} to ${paidForNames}`
+}
+
+function getExpenseEventLabel({
+  currency,
+  event,
+  locale,
+  roundAmounts,
+}: {
+  currency: Parameters<typeof formatCurrency>[0]
+  event: BalanceTimelineEvent
+  locale: string
+  roundAmounts: boolean
+}) {
+  const categoryLabel = event.category
+    ? `${event.category.grouping}: ${event.category.name}`
+    : 'Expense'
+  const eventLabel = event.title
+    ? `${event.title} (${categoryLabel})`
+    : categoryLabel
+
+  return `${eventLabel}: ${event.paidBy.name} paid ${formatChartCurrency({
+    amount: Math.abs(event.amount),
+    currency,
+    locale,
+    roundAmounts,
+  })}`
+}
+
+function getBalanceTimelinePointLabel({
+  balance,
+  currency,
+  locale,
+  participant,
+  roundAmounts,
+}: {
+  balance: number
+  currency: Parameters<typeof formatCurrency>[0]
+  locale: string
+  participant: BalanceTimelineParticipant
+  roundAmounts: boolean
+}) {
+  return formatParticipantBalance({
+    amount: balance,
+    currency,
+    includeCurrently: false,
+    locale,
+    participantName: participant.name,
+    roundAmounts,
+  })
+}
+
+function formatTimelineMonth(
+  tick: Pick<TimelineMonthTick, 'year' | 'month'>,
+  locale: string,
+  length: 'short' | 'long',
+) {
+  return new Intl.DateTimeFormat(locale, {
+    month: length,
+    timeZone: 'UTC',
+    year: length === 'long' ? 'numeric' : undefined,
+  }).format(new Date(Date.UTC(tick.year, tick.month, 1)))
+}
+
+function formatTimelineDay(
+  point: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>,
+  locale: string,
+) {
+  return new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'short',
+    timeZone: 'UTC',
+    year: 'numeric',
+  }).format(new Date(Date.UTC(point.year, point.month, point.day)))
+}
+
+function getDayNumber(
+  point: Pick<BalanceTimelinePoint, 'year' | 'month' | 'day'>,
+) {
+  return Date.UTC(point.year, point.month, point.day) / DAY_IN_MS
+}
+
+function getMonthKey(point: Pick<BalanceTimelinePoint, 'year' | 'month'>) {
+  return `${point.year}-${String(point.month + 1).padStart(2, '0')}`
+}
+
+function addMonths(year: number, month: number, monthsToAdd: number) {
+  const date = new Date(Date.UTC(year, month + monthsToAdd, 1))
+  return { year: date.getUTCFullYear(), month: date.getUTCMonth() }
+}

--- a/src/app/groups/[groupId]/stats/monthly-spending.tsx
+++ b/src/app/groups/[groupId]/stats/monthly-spending.tsx
@@ -1,0 +1,441 @@
+'use client'
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  MonthlySpendingGrouping,
+  MonthlySpendingRange,
+} from '@/lib/monthly-spending'
+import { formatCurrency, getCurrencyFromGroup } from '@/lib/utils'
+import { trpc } from '@/trpc/client'
+import { AppRouterOutput } from '@/trpc/routers/_app'
+import { useLocale, useTranslations } from 'next-intl'
+import { useMemo, useState } from 'react'
+import { useCurrentGroup } from '../current-group-context'
+
+type MonthlyCategorySpending =
+  AppRouterOutput['groups']['stats']['get']['monthlyCategorySpending']
+type MonthlySpendingCategory = MonthlyCategorySpending['categories'][number]
+type MonthlySpendingMonth = MonthlyCategorySpending['months'][number]
+
+const CATEGORY_COLORS = [
+  'bg-sky-500',
+  'bg-emerald-500',
+  'bg-amber-500',
+  'bg-rose-500',
+  'bg-violet-500',
+  'bg-cyan-500',
+  'bg-lime-500',
+  'bg-fuchsia-500',
+  'bg-orange-500',
+  'bg-teal-500',
+]
+
+export function MonthlySpending() {
+  const { groupId, group } = useCurrentGroup()
+  const t = useTranslations('Stats.MonthlySpending')
+  const tCategories = useTranslations('Categories')
+  const locale = useLocale()
+  const [range, setRange] = useState<MonthlySpendingRange>('6')
+  const [grouping, setGrouping] =
+    useState<MonthlySpendingGrouping>('categoryGroup')
+
+  const { data, isLoading } = trpc.groups.stats.get.useQuery({
+    groupId,
+    monthlySpendingGrouping: grouping,
+    monthlySpendingRange: range,
+  })
+
+  const monthlyCategorySpending = data?.monthlyCategorySpending
+  const currency = group ? getCurrencyFromGroup(group) : undefined
+  const colorByCategory = useMemo(
+    () => getColorByCategory(monthlyCategorySpending?.categories ?? []),
+    [monthlyCategorySpending?.categories],
+  )
+
+  return (
+    <Card className="mb-4">
+      <CardHeader>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle>{t('title')}</CardTitle>
+            <CardDescription>{t('description')}</CardDescription>
+          </div>
+          <div className="grid grid-cols-2 gap-2 sm:w-[22rem]">
+            <Select
+              value={range}
+              onValueChange={(value) => setRange(value as MonthlySpendingRange)}
+            >
+              <SelectTrigger aria-label={t('rangeLabel')}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="3">{t('RangeOptions.three')}</SelectItem>
+                <SelectItem value="6">{t('RangeOptions.six')}</SelectItem>
+                <SelectItem value="12">{t('RangeOptions.twelve')}</SelectItem>
+                <SelectItem value="all">{t('RangeOptions.all')}</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select
+              value={grouping}
+              onValueChange={(value) =>
+                setGrouping(value as MonthlySpendingGrouping)
+              }
+            >
+              <SelectTrigger aria-label={t('groupingLabel')}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="categoryGroup">
+                  {t('GroupingOptions.categoryGroup')}
+                </SelectItem>
+                <SelectItem value="category">
+                  {t('GroupingOptions.category')}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading || !monthlyCategorySpending || !currency ? (
+          <MonthlySpendingLoading />
+        ) : monthlyCategorySpending.months.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4">{t('noData')}</p>
+        ) : (
+          <div className="space-y-8">
+            <MonthlyCategoryStackedBars
+              colorByCategory={colorByCategory}
+              currency={currency}
+              grouping={grouping}
+              locale={locale}
+              monthlyCategorySpending={monthlyCategorySpending}
+              tCategories={tCategories}
+            />
+            <MonthlySpendingLegend
+              categories={monthlyCategorySpending.categories}
+              colorByCategory={colorByCategory}
+              grouping={grouping}
+              tCategories={tCategories}
+            />
+            <div className="grid gap-8 lg:grid-cols-2">
+              <MonthlyCategoryBreakdown
+                colorByCategory={colorByCategory}
+                currency={currency}
+                grouping={grouping}
+                locale={locale}
+                monthlyCategorySpending={monthlyCategorySpending}
+                t={t}
+                tCategories={tCategories}
+              />
+              <MonthlySpendingTrend
+                currency={currency}
+                locale={locale}
+                months={monthlyCategorySpending.months}
+                t={t}
+              />
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function MonthlyCategoryStackedBars({
+  colorByCategory,
+  currency,
+  grouping,
+  locale,
+  monthlyCategorySpending,
+  tCategories,
+}: {
+  colorByCategory: Map<string, string>
+  currency: Parameters<typeof formatCurrency>[0]
+  grouping: MonthlySpendingGrouping
+  locale: string
+  monthlyCategorySpending: MonthlyCategorySpending
+  tCategories: (key: string) => string
+}) {
+  const t = useTranslations('Stats.MonthlySpending')
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">{t('stackedTitle')}</h3>
+      <div className="space-y-2">
+        {monthlyCategorySpending.months.map((month) => (
+          <div
+            key={month.key}
+            className="grid gap-2 text-sm sm:grid-cols-[5rem_minmax(0,1fr)_7rem] sm:items-center"
+          >
+            <div className="text-muted-foreground">
+              {formatMonth(month, locale, 'short')}
+            </div>
+            <div className="h-7 overflow-hidden rounded-md bg-muted">
+              <div
+                className="flex h-full"
+                style={{
+                  width:
+                    monthlyCategorySpending.maxExpenseAmount > 0
+                      ? `${
+                          (month.expenseAmount /
+                            monthlyCategorySpending.maxExpenseAmount) *
+                          100
+                        }%`
+                      : '0%',
+                }}
+              >
+                {month.categories
+                  .filter((category) => category.expenseAmount > 0)
+                  .map((category) => (
+                    <div
+                      key={category.key}
+                      className={colorByCategory.get(category.key)}
+                      style={{
+                        width: `${
+                          (category.expenseAmount / month.expenseAmount) * 100
+                        }%`,
+                      }}
+                      title={`${getCategoryLabel(
+                        category,
+                        grouping,
+                        tCategories,
+                      )}: ${formatCurrency(
+                        currency,
+                        category.expenseAmount,
+                        locale,
+                      )}`}
+                    />
+                  ))}
+              </div>
+            </div>
+            <div className="text-muted-foreground sm:text-right">
+              {formatCurrency(currency, month.expenseAmount, locale)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export function MonthlyCategoryBreakdown({
+  colorByCategory,
+  currency,
+  grouping,
+  locale,
+  monthlyCategorySpending,
+  t,
+  tCategories,
+}: {
+  colorByCategory: Map<string, string>
+  currency: Parameters<typeof formatCurrency>[0]
+  grouping: MonthlySpendingGrouping
+  locale: string
+  monthlyCategorySpending: MonthlyCategorySpending
+  t: (key: string, values?: Record<string, string>) => string
+  tCategories: (key: string) => string
+}) {
+  const month =
+    monthlyCategorySpending.months.find(
+      (month) => month.key === monthlyCategorySpending.highlightedMonthKey,
+    ) ?? monthlyCategorySpending.months.at(-1)
+  const categories =
+    month?.categories.filter((category) => category.expenseAmount > 0) ?? []
+  const maxCategoryAmount = Math.max(
+    0,
+    ...categories.map((category) => category.expenseAmount),
+  )
+
+  if (!month || (categories.length === 0 && month.incomeAmount >= 0)) {
+    return null
+  }
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">
+        {t('breakdownTitle', { month: formatMonth(month, locale, 'long') })}
+      </h3>
+      {categories.length > 0 && (
+        <div className="space-y-2">
+          {categories.map((category) => (
+            <div key={category.key} className="space-y-1 text-sm">
+              <div className="flex justify-between gap-3">
+                <span className="truncate">
+                  {getCategoryLabel(category, grouping, tCategories)}
+                </span>
+                <span className="shrink-0 text-muted-foreground">
+                  {formatCurrency(currency, category.expenseAmount, locale)}
+                </span>
+              </div>
+              <div className="h-2 rounded-full bg-muted">
+                <div
+                  className={`h-2 rounded-full ${colorByCategory.get(
+                    category.key,
+                  )}`}
+                  style={{
+                    width: `${
+                      (category.expenseAmount / maxCategoryAmount) * 100
+                    }%`,
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {month.incomeAmount < 0 && (
+        <p className="text-xs text-muted-foreground">
+          {t('income')}: {formatCurrency(currency, month.incomeAmount, locale)}
+        </p>
+      )}
+    </section>
+  )
+}
+
+export function MonthlySpendingTrend({
+  currency,
+  locale,
+  months,
+  t,
+}: {
+  currency: Parameters<typeof formatCurrency>[0]
+  locale: string
+  months: MonthlySpendingMonth[]
+  t: (key: string) => string
+}) {
+  const maxExpenseAmount = Math.max(
+    0,
+    ...months.map((month) => month.expenseAmount),
+  )
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">{t('trendTitle')}</h3>
+      <div className="overflow-x-auto">
+        <div className="flex h-32 min-w-full items-end gap-2">
+          {months.map((month) => {
+            const height =
+              maxExpenseAmount > 0
+                ? (month.expenseAmount / maxExpenseAmount) * 100
+                : 0
+            return (
+              <div
+                key={month.key}
+                className="flex min-w-10 flex-1 flex-col items-center justify-end gap-1"
+                title={`${formatMonth(month, locale, 'long')}: ${formatCurrency(
+                  currency,
+                  month.expenseAmount,
+                  locale,
+                )}`}
+              >
+                <div
+                  className="w-full max-w-8 rounded-t-md bg-muted-foreground/60"
+                  style={{ height: `${height}%` }}
+                />
+                <div className="text-[10px] text-muted-foreground">
+                  {formatMonth(month, locale, 'narrow')}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function MonthlySpendingLegend({
+  categories,
+  colorByCategory,
+  grouping,
+  tCategories,
+}: {
+  categories: MonthlySpendingCategory[]
+  colorByCategory: Map<string, string>
+  grouping: MonthlySpendingGrouping
+  tCategories: (key: string) => string
+}) {
+  const visibleCategories = categories.filter(
+    (category) => category.expenseAmount > 0,
+  )
+
+  if (visibleCategories.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
+      {visibleCategories.map((category) => (
+        <div key={category.key} className="flex min-w-0 items-center gap-2">
+          <span
+            className={`h-2.5 w-2.5 shrink-0 rounded-full ${colorByCategory.get(
+              category.key,
+            )}`}
+          />
+          <span className="truncate">
+            {getCategoryLabel(category, grouping, tCategories)}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function MonthlySpendingLoading() {
+  return (
+    <div className="space-y-5">
+      {[0, 1, 2].map((index) => (
+        <div key={index} className="grid gap-2 sm:grid-cols-[5rem_1fr_7rem]">
+          <Skeleton className="h-4 w-14" />
+          <Skeleton className="h-7 w-full" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function getColorByCategory(categories: MonthlySpendingCategory[]) {
+  return new Map(
+    categories.map((category, index) => [
+      category.key,
+      CATEGORY_COLORS[index % CATEGORY_COLORS.length],
+    ]),
+  )
+}
+
+function getCategoryLabel(
+  category: Pick<MonthlySpendingCategory, 'grouping' | 'name'>,
+  grouping: MonthlySpendingGrouping,
+  tCategories: (key: string) => string,
+) {
+  if (grouping === 'categoryGroup') {
+    return tCategories(`${category.grouping}.heading`)
+  }
+
+  return tCategories(`${category.grouping}.${category.name}`)
+}
+
+function formatMonth(
+  month: Pick<MonthlySpendingMonth, 'year' | 'month'>,
+  locale: string,
+  length: 'short' | 'long' | 'narrow',
+) {
+  return new Intl.DateTimeFormat(locale, {
+    month: length === 'narrow' ? 'short' : length,
+    timeZone: 'UTC',
+    year: length === 'long' ? 'numeric' : undefined,
+  }).format(new Date(Date.UTC(month.year, month.month, 1)))
+}

--- a/src/app/groups/[groupId]/stats/monthly-spending.tsx
+++ b/src/app/groups/[groupId]/stats/monthly-spending.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import { CategoryIcon } from '@/app/groups/[groupId]/expenses/category-icon'
+import { BalanceTimelineChart } from '@/app/groups/[groupId]/stats/balance-timeline-chart'
+import { Button } from '@/components/ui/button'
 import {
   Card,
   CardContent,
@@ -7,6 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Select,
   SelectContent,
@@ -15,13 +19,25 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
+import { formatChartCurrency } from '@/lib/chart-currency'
 import {
   MonthlySpendingGrouping,
   MonthlySpendingRange,
 } from '@/lib/monthly-spending'
-import { formatCurrency, getCurrencyFromGroup } from '@/lib/utils'
+import { cn, formatCurrency, getCurrencyFromGroup } from '@/lib/utils'
 import { trpc } from '@/trpc/client'
 import { AppRouterOutput } from '@/trpc/routers/_app'
+import {
+  Banknote,
+  Bus,
+  ChartBarStacked,
+  ChartColumnStacked,
+  FerrisWheel,
+  HandHelping,
+  Home,
+  PlugZap,
+  Utensils,
+} from 'lucide-react'
 import { useLocale, useTranslations } from 'next-intl'
 import { useMemo, useState } from 'react'
 import { useCurrentGroup } from '../current-group-context'
@@ -30,18 +46,248 @@ type MonthlyCategorySpending =
   AppRouterOutput['groups']['stats']['get']['monthlyCategorySpending']
 type MonthlySpendingCategory = MonthlyCategorySpending['categories'][number]
 type MonthlySpendingMonth = MonthlyCategorySpending['months'][number]
+type MonthlySpendingChartType = 'bars' | 'columns'
 
-const CATEGORY_COLORS = [
-  'bg-sky-500',
-  'bg-emerald-500',
-  'bg-amber-500',
-  'bg-rose-500',
-  'bg-violet-500',
-  'bg-cyan-500',
-  'bg-lime-500',
-  'bg-fuchsia-500',
-  'bg-orange-500',
-  'bg-teal-500',
+type CategoryColor = {
+  backgroundClassName: string
+  borderClassName: string
+  foregroundClassName: string
+}
+
+const CATEGORY_COLORS_BY_GROUP: Record<string, CategoryColor[]> = {
+  Uncategorized: [
+    getCategoryColor(
+      'bg-slate-200 dark:bg-slate-800',
+      'border-slate-300 dark:border-slate-700',
+      'text-slate-950 dark:text-slate-50',
+    ),
+    getCategoryColor(
+      'bg-zinc-200 dark:bg-zinc-800',
+      'border-zinc-300 dark:border-zinc-700',
+      'text-zinc-950 dark:text-zinc-50',
+    ),
+  ],
+  Entertainment: [
+    getCategoryColor(
+      'bg-rose-200 dark:bg-rose-900',
+      'border-rose-300 dark:border-rose-800',
+      'text-rose-950 dark:text-rose-50',
+    ),
+    getCategoryColor(
+      'bg-pink-200 dark:bg-pink-900',
+      'border-pink-300 dark:border-pink-800',
+      'text-pink-950 dark:text-pink-50',
+    ),
+    getCategoryColor(
+      'bg-fuchsia-200 dark:bg-fuchsia-900',
+      'border-fuchsia-300 dark:border-fuchsia-800',
+      'text-fuchsia-950 dark:text-fuchsia-50',
+    ),
+  ],
+  'Food and Drink': [
+    getCategoryColor(
+      'bg-emerald-200 dark:bg-emerald-900',
+      'border-emerald-300 dark:border-emerald-800',
+      'text-emerald-950 dark:text-emerald-50',
+    ),
+    getCategoryColor(
+      'bg-green-200 dark:bg-green-900',
+      'border-green-300 dark:border-green-800',
+      'text-green-950 dark:text-green-50',
+    ),
+    getCategoryColor(
+      'bg-lime-200 dark:bg-lime-900',
+      'border-lime-300 dark:border-lime-800',
+      'text-lime-950 dark:text-lime-50',
+    ),
+    getCategoryColor(
+      'bg-teal-200 dark:bg-teal-900',
+      'border-teal-300 dark:border-teal-800',
+      'text-teal-950 dark:text-teal-50',
+    ),
+  ],
+  Home: [
+    getCategoryColor(
+      'bg-sky-200 dark:bg-sky-900',
+      'border-sky-300 dark:border-sky-800',
+      'text-sky-950 dark:text-sky-50',
+    ),
+    getCategoryColor(
+      'bg-blue-200 dark:bg-blue-900',
+      'border-blue-300 dark:border-blue-800',
+      'text-blue-950 dark:text-blue-50',
+    ),
+    getCategoryColor(
+      'bg-cyan-200 dark:bg-cyan-900',
+      'border-cyan-300 dark:border-cyan-800',
+      'text-cyan-950 dark:text-cyan-50',
+    ),
+  ],
+  Life: [
+    getCategoryColor(
+      'bg-violet-200 dark:bg-violet-900',
+      'border-violet-300 dark:border-violet-800',
+      'text-violet-950 dark:text-violet-50',
+    ),
+    getCategoryColor(
+      'bg-purple-200 dark:bg-purple-900',
+      'border-purple-300 dark:border-purple-800',
+      'text-purple-950 dark:text-purple-50',
+    ),
+    getCategoryColor(
+      'bg-fuchsia-200 dark:bg-fuchsia-900',
+      'border-fuchsia-300 dark:border-fuchsia-800',
+      'text-fuchsia-950 dark:text-fuchsia-50',
+    ),
+  ],
+  Transportation: [
+    getCategoryColor(
+      'bg-indigo-200 dark:bg-indigo-900',
+      'border-indigo-300 dark:border-indigo-800',
+      'text-indigo-950 dark:text-indigo-50',
+    ),
+    getCategoryColor(
+      'bg-cyan-200 dark:bg-cyan-900',
+      'border-cyan-300 dark:border-cyan-800',
+      'text-cyan-950 dark:text-cyan-50',
+    ),
+    getCategoryColor(
+      'bg-blue-200 dark:bg-blue-900',
+      'border-blue-300 dark:border-blue-800',
+      'text-blue-950 dark:text-blue-50',
+    ),
+  ],
+  Utilities: [
+    getCategoryColor(
+      'bg-amber-200 dark:bg-amber-900',
+      'border-amber-300 dark:border-amber-800',
+      'text-amber-950 dark:text-amber-50',
+    ),
+    getCategoryColor(
+      'bg-yellow-200 dark:bg-yellow-900',
+      'border-yellow-300 dark:border-yellow-800',
+      'text-yellow-950 dark:text-yellow-50',
+    ),
+    getCategoryColor(
+      'bg-orange-200 dark:bg-orange-900',
+      'border-orange-300 dark:border-orange-800',
+      'text-orange-950 dark:text-orange-50',
+    ),
+  ],
+}
+
+const FALLBACK_CATEGORY_COLORS = [
+  getCategoryColor(
+    'bg-slate-200 dark:bg-slate-800',
+    'border-slate-300 dark:border-slate-700',
+    'text-slate-950 dark:text-slate-50',
+  ),
+  getCategoryColor(
+    'bg-stone-200 dark:bg-stone-800',
+    'border-stone-300 dark:border-stone-700',
+    'text-stone-950 dark:text-stone-50',
+  ),
+  getCategoryColor(
+    'bg-neutral-200 dark:bg-neutral-800',
+    'border-neutral-300 dark:border-neutral-700',
+    'text-neutral-950 dark:text-neutral-50',
+  ),
+]
+
+const DETAILED_CATEGORY_COLORS_BY_KEY: Record<string, CategoryColor> = {
+  'Utilities:Cleaning': getCategoryColor(
+    'bg-teal-200 dark:bg-teal-900',
+    'border-teal-300 dark:border-teal-800',
+    'text-teal-950 dark:text-teal-50',
+  ),
+  'Utilities:Electricity': getCategoryColor(
+    'bg-yellow-200 dark:bg-yellow-900',
+    'border-yellow-300 dark:border-yellow-800',
+    'text-yellow-950 dark:text-yellow-50',
+  ),
+  'Utilities:Heat/Gas': getCategoryColor(
+    'bg-orange-200 dark:bg-orange-900',
+    'border-orange-300 dark:border-orange-800',
+    'text-orange-950 dark:text-orange-50',
+  ),
+  'Utilities:Trash': getCategoryColor(
+    'bg-slate-200 dark:bg-slate-800',
+    'border-slate-300 dark:border-slate-700',
+    'text-slate-950 dark:text-slate-50',
+  ),
+  'Utilities:TV/Phone/Internet': getCategoryColor(
+    'bg-sky-200 dark:bg-sky-900',
+    'border-sky-300 dark:border-sky-800',
+    'text-sky-950 dark:text-sky-50',
+  ),
+  'Utilities:Water': getCategoryColor(
+    'bg-blue-200 dark:bg-blue-900',
+    'border-blue-300 dark:border-blue-800',
+    'text-blue-950 dark:text-blue-50',
+  ),
+}
+
+const DETAILED_CATEGORY_COLOR_SPECTRUM = [
+  getCategoryColor(
+    'bg-emerald-200 dark:bg-emerald-900',
+    'border-emerald-300 dark:border-emerald-800',
+    'text-emerald-950 dark:text-emerald-50',
+  ),
+  getCategoryColor(
+    'bg-sky-200 dark:bg-sky-900',
+    'border-sky-300 dark:border-sky-800',
+    'text-sky-950 dark:text-sky-50',
+  ),
+  getCategoryColor(
+    'bg-amber-200 dark:bg-amber-900',
+    'border-amber-300 dark:border-amber-800',
+    'text-amber-950 dark:text-amber-50',
+  ),
+  getCategoryColor(
+    'bg-violet-200 dark:bg-violet-900',
+    'border-violet-300 dark:border-violet-800',
+    'text-violet-950 dark:text-violet-50',
+  ),
+  getCategoryColor(
+    'bg-rose-200 dark:bg-rose-900',
+    'border-rose-300 dark:border-rose-800',
+    'text-rose-950 dark:text-rose-50',
+  ),
+  getCategoryColor(
+    'bg-teal-200 dark:bg-teal-900',
+    'border-teal-300 dark:border-teal-800',
+    'text-teal-950 dark:text-teal-50',
+  ),
+  getCategoryColor(
+    'bg-indigo-200 dark:bg-indigo-900',
+    'border-indigo-300 dark:border-indigo-800',
+    'text-indigo-950 dark:text-indigo-50',
+  ),
+  getCategoryColor(
+    'bg-lime-200 dark:bg-lime-900',
+    'border-lime-300 dark:border-lime-800',
+    'text-lime-950 dark:text-lime-50',
+  ),
+  getCategoryColor(
+    'bg-orange-200 dark:bg-orange-900',
+    'border-orange-300 dark:border-orange-800',
+    'text-orange-950 dark:text-orange-50',
+  ),
+  getCategoryColor(
+    'bg-cyan-200 dark:bg-cyan-900',
+    'border-cyan-300 dark:border-cyan-800',
+    'text-cyan-950 dark:text-cyan-50',
+  ),
+  getCategoryColor(
+    'bg-fuchsia-200 dark:bg-fuchsia-900',
+    'border-fuchsia-300 dark:border-fuchsia-800',
+    'text-fuchsia-950 dark:text-fuchsia-50',
+  ),
+  getCategoryColor(
+    'bg-blue-200 dark:bg-blue-900',
+    'border-blue-300 dark:border-blue-800',
+    'text-blue-950 dark:text-blue-50',
+  ),
 ]
 
 export function MonthlySpending() {
@@ -52,6 +298,8 @@ export function MonthlySpending() {
   const [range, setRange] = useState<MonthlySpendingRange>('6')
   const [grouping, setGrouping] =
     useState<MonthlySpendingGrouping>('categoryGroup')
+  const [chartType, setChartType] = useState<MonthlySpendingChartType>('bars')
+  const [roundAmounts, setRoundAmounts] = useState(true)
 
   const { data, isLoading } = trpc.groups.stats.get.useQuery({
     groupId,
@@ -60,7 +308,12 @@ export function MonthlySpending() {
   })
 
   const monthlyCategorySpending = data?.monthlyCategorySpending
+  const balanceTimeline = data?.balanceTimeline
   const currency = group ? getCurrencyFromGroup(group) : undefined
+  const visibleCategories =
+    monthlyCategorySpending?.categories.filter(
+      (category) => category.expenseAmount > 0,
+    ) ?? []
   const colorByCategory = useMemo(
     () => getColorByCategory(monthlyCategorySpending?.categories ?? []),
     [monthlyCategorySpending?.categories],
@@ -70,16 +323,21 @@ export function MonthlySpending() {
     <Card className="mb-4">
       <CardHeader>
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div>
+          <div className="shrink-0">
             <CardTitle>{t('title')}</CardTitle>
             <CardDescription>{t('description')}</CardDescription>
           </div>
-          <div className="grid grid-cols-2 gap-2 sm:w-[22rem]">
+          <div className="flex flex-wrap items-center gap-2 sm:min-w-0 sm:justify-end">
+            <RoundAmountsToggle
+              checked={roundAmounts}
+              onCheckedChange={setRoundAmounts}
+              t={t}
+            />
             <Select
               value={range}
               onValueChange={(value) => setRange(value as MonthlySpendingRange)}
             >
-              <SelectTrigger aria-label={t('rangeLabel')}>
+              <SelectTrigger aria-label={t('rangeLabel')} className="h-8 w-28">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -95,7 +353,10 @@ export function MonthlySpending() {
                 setGrouping(value as MonthlySpendingGrouping)
               }
             >
-              <SelectTrigger aria-label={t('groupingLabel')}>
+              <SelectTrigger
+                aria-label={t('groupingLabel')}
+                className="h-8 w-28"
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -107,47 +368,72 @@ export function MonthlySpending() {
                 </SelectItem>
               </SelectContent>
             </Select>
+            <ChartTypeToggle
+              chartType={chartType}
+              onChartTypeChange={setChartType}
+              t={t}
+            />
           </div>
         </div>
       </CardHeader>
       <CardContent>
-        {isLoading || !monthlyCategorySpending || !currency ? (
+        {isLoading ||
+        !monthlyCategorySpending ||
+        !balanceTimeline ||
+        !currency ? (
           <MonthlySpendingLoading />
         ) : monthlyCategorySpending.months.length === 0 ? (
           <p className="text-sm text-muted-foreground py-4">{t('noData')}</p>
         ) : (
           <div className="space-y-8">
-            <MonthlyCategoryStackedBars
-              colorByCategory={colorByCategory}
-              currency={currency}
-              grouping={grouping}
-              locale={locale}
-              monthlyCategorySpending={monthlyCategorySpending}
-              tCategories={tCategories}
-            />
-            <MonthlySpendingLegend
-              categories={monthlyCategorySpending.categories}
-              colorByCategory={colorByCategory}
-              grouping={grouping}
-              tCategories={tCategories}
-            />
-            <div className="grid gap-8 lg:grid-cols-2">
-              <MonthlyCategoryBreakdown
+            <div
+              className={cn(
+                'gap-4',
+                chartType === 'columns' &&
+                  'grid lg:grid-cols-[minmax(0,1fr)_13rem] lg:items-end',
+              )}
+            >
+              <MonthlyCategoryStackedChart
+                chartType={chartType}
                 colorByCategory={colorByCategory}
                 currency={currency}
                 grouping={grouping}
                 locale={locale}
                 monthlyCategorySpending={monthlyCategorySpending}
-                t={t}
+                roundAmounts={roundAmounts}
+                visibleCategories={visibleCategories}
                 tCategories={tCategories}
               />
-              <MonthlySpendingTrend
-                currency={currency}
-                locale={locale}
-                months={monthlyCategorySpending.months}
-                t={t}
+              <MonthlySpendingLegend
+                categories={visibleCategories}
+                className={cn(
+                  chartType === 'bars' && 'mt-3',
+                  chartType === 'columns' && 'mt-4 lg:mb-7 lg:mt-0',
+                )}
+                colorByCategory={colorByCategory}
+                grouping={grouping}
+                isVertical={chartType === 'columns'}
+                tCategories={tCategories}
               />
             </div>
+            <MonthlyCategoryBreakdown
+              colorByCategory={colorByCategory}
+              currency={currency}
+              grouping={grouping}
+              locale={locale}
+              monthlyCategorySpending={monthlyCategorySpending}
+              range={range}
+              roundAmounts={roundAmounts}
+              t={t}
+              tCategories={tCategories}
+            />
+            <BalanceTimelineChart
+              balanceTimeline={balanceTimeline}
+              currency={currency}
+              locale={locale}
+              roundAmounts={roundAmounts}
+              t={t}
+            />
           </div>
         )}
       </CardContent>
@@ -155,80 +441,391 @@ export function MonthlySpending() {
   )
 }
 
-export function MonthlyCategoryStackedBars({
+function ChartTypeToggle({
+  chartType,
+  onChartTypeChange,
+  t,
+}: {
+  chartType: MonthlySpendingChartType
+  onChartTypeChange: (chartType: MonthlySpendingChartType) => void
+  t: (key: string) => string
+}) {
+  return (
+    <div
+      aria-label={t('chartTypeLabel')}
+      className="inline-flex h-8 shrink-0 rounded-md border border-input bg-background"
+      role="group"
+    >
+      <Button
+        aria-label={t('ChartTypes.bars')}
+        aria-pressed={chartType === 'bars'}
+        className={cn(
+          'h-7 w-8 rounded-r-none border-0 px-2',
+          chartType === 'bars' && 'bg-accent text-accent-foreground',
+        )}
+        onClick={() => onChartTypeChange('bars')}
+        title={t('ChartTypes.bars')}
+        type="button"
+        variant="ghost"
+      >
+        <ChartBarStacked className="h-4 w-4" />
+      </Button>
+      <Button
+        aria-label={t('ChartTypes.columns')}
+        aria-pressed={chartType === 'columns'}
+        className={cn(
+          'h-7 w-8 rounded-l-none border-0 px-2',
+          chartType === 'columns' && 'bg-accent text-accent-foreground',
+        )}
+        onClick={() => onChartTypeChange('columns')}
+        title={t('ChartTypes.columns')}
+        type="button"
+        variant="ghost"
+      >
+        <ChartColumnStacked className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}
+
+function RoundAmountsToggle({
+  checked,
+  onCheckedChange,
+  t,
+}: {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+  t: (key: string) => string
+}) {
+  return (
+    <label className="flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-input px-2 text-xs text-muted-foreground">
+      <Checkbox
+        className="h-3.5 w-3.5"
+        checked={checked}
+        onCheckedChange={(value) => onCheckedChange(value === true)}
+      />
+      <span>{t('roundAmountsLabel')}</span>
+    </label>
+  )
+}
+
+export function MonthlyCategoryStackedChart({
+  chartType,
   colorByCategory,
   currency,
   grouping,
   locale,
   monthlyCategorySpending,
+  roundAmounts,
   tCategories,
+  visibleCategories,
 }: {
-  colorByCategory: Map<string, string>
+  chartType: MonthlySpendingChartType
+  colorByCategory: Map<string, CategoryColor>
   currency: Parameters<typeof formatCurrency>[0]
   grouping: MonthlySpendingGrouping
   locale: string
   monthlyCategorySpending: MonthlyCategorySpending
+  roundAmounts: boolean
   tCategories: (key: string) => string
+  visibleCategories: MonthlySpendingCategory[]
 }) {
   const t = useTranslations('Stats.MonthlySpending')
 
   return (
     <section className="space-y-3">
       <h3 className="text-sm font-semibold">{t('stackedTitle')}</h3>
-      <div className="space-y-2">
-        {monthlyCategorySpending.months.map((month) => (
+      {chartType === 'columns' ? (
+        <MonthlyCategoryStackedColumns
+          colorByCategory={colorByCategory}
+          currency={currency}
+          grouping={grouping}
+          locale={locale}
+          monthlyCategorySpending={monthlyCategorySpending}
+          roundAmounts={roundAmounts}
+          tCategories={tCategories}
+          visibleCategories={visibleCategories}
+        />
+      ) : (
+        <MonthlyCategoryStackedBars
+          colorByCategory={colorByCategory}
+          currency={currency}
+          grouping={grouping}
+          locale={locale}
+          monthlyCategorySpending={monthlyCategorySpending}
+          roundAmounts={roundAmounts}
+          tCategories={tCategories}
+          visibleCategories={visibleCategories}
+        />
+      )}
+    </section>
+  )
+}
+
+function MonthlyCategoryStackedBars({
+  colorByCategory,
+  currency,
+  grouping,
+  locale,
+  monthlyCategorySpending,
+  roundAmounts,
+  tCategories,
+  visibleCategories,
+}: {
+  colorByCategory: Map<string, CategoryColor>
+  currency: Parameters<typeof formatCurrency>[0]
+  grouping: MonthlySpendingGrouping
+  locale: string
+  monthlyCategorySpending: MonthlyCategorySpending
+  roundAmounts: boolean
+  tCategories: (key: string) => string
+  visibleCategories: MonthlySpendingCategory[]
+}) {
+  return (
+    <div className="space-y-2">
+      {monthlyCategorySpending.months.map((month) => {
+        const monthCategories = getMonthCategoriesInDisplayOrder(
+          month,
+          visibleCategories,
+        )
+        const barShare = getShare(
+          month.expenseAmount,
+          monthlyCategorySpending.maxExpenseAmount,
+        )
+        const barUnits = month.expenseAmount > 0 ? Math.max(barShare, 0.03) : 0
+        const remainderUnits = Math.max(0, 1 - barUnits)
+
+        return (
           <div
             key={month.key}
-            className="grid gap-2 text-sm sm:grid-cols-[5rem_minmax(0,1fr)_7rem] sm:items-center"
+            className="grid grid-cols-[4rem_minmax(0,1fr)] items-center gap-2 text-sm sm:grid-cols-[5rem_minmax(0,1fr)]"
           >
             <div className="text-muted-foreground">
               {formatMonth(month, locale, 'short')}
             </div>
-            <div className="h-7 overflow-hidden rounded-md bg-muted">
-              <div
-                className="flex h-full"
-                style={{
-                  width:
-                    monthlyCategorySpending.maxExpenseAmount > 0
-                      ? `${
-                          (month.expenseAmount /
-                            monthlyCategorySpending.maxExpenseAmount) *
-                          100
-                        }%`
-                      : '0%',
-                }}
-              >
-                {month.categories
-                  .filter((category) => category.expenseAmount > 0)
-                  .map((category) => (
-                    <div
-                      key={category.key}
-                      className={colorByCategory.get(category.key)}
-                      style={{
-                        width: `${
-                          (category.expenseAmount / month.expenseAmount) * 100
-                        }%`,
-                      }}
-                      title={`${getCategoryLabel(
+            <div
+              className="grid items-center gap-2"
+              style={{
+                gridTemplateColumns: `${barUnits}fr max-content ${remainderUnits}fr`,
+              }}
+            >
+              <div className="h-7 min-w-0 overflow-hidden rounded-md bg-muted">
+                <div className="flex h-full">
+                  {monthCategories.map((category) => {
+                    const share = getShare(
+                      category.expenseAmount,
+                      month.expenseAmount,
+                    )
+                    const categoryLabel = getCategoryLabel(
+                      category,
+                      grouping,
+                      tCategories,
+                    )
+                    const color = colorByCategory.get(category.key)
+
+                    return (
+                      <div
+                        aria-label={getCategoryHoverLabel({
+                          amount: category.expenseAmount,
+                          categoryLabel,
+                          currency,
+                          locale,
+                          month,
+                          roundAmounts,
+                          share,
+                        })}
+                        className={cn(
+                          'flex h-full min-w-[2px] items-center justify-start gap-1 overflow-hidden border-y px-1.5 text-[11px] font-medium',
+                          color?.backgroundClassName,
+                          color?.borderClassName,
+                          color?.foregroundClassName,
+                        )}
+                        key={category.key}
+                        style={{ width: `${share * 100}%` }}
+                        title={getCategoryHoverLabel({
+                          amount: category.expenseAmount,
+                          categoryLabel,
+                          currency,
+                          locale,
+                          month,
+                          roundAmounts,
+                          share,
+                        })}
+                      >
+                        {share >= 0.06 && (
+                          <GraphCategoryIcon
+                            category={category}
+                            className="h-3.5 w-3.5 shrink-0 opacity-50"
+                            grouping={grouping}
+                          />
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+              <div className="text-left text-xs text-muted-foreground">
+                {formatChartCurrency({
+                  amount: month.expenseAmount,
+                  currency,
+                  locale,
+                  roundAmounts,
+                })}
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function MonthlyCategoryStackedColumns({
+  colorByCategory,
+  currency,
+  grouping,
+  locale,
+  monthlyCategorySpending,
+  roundAmounts,
+  tCategories,
+  visibleCategories,
+}: {
+  colorByCategory: Map<string, CategoryColor>
+  currency: Parameters<typeof formatCurrency>[0]
+  grouping: MonthlySpendingGrouping
+  locale: string
+  monthlyCategorySpending: MonthlyCategorySpending
+  roundAmounts: boolean
+  tCategories: (key: string) => string
+  visibleCategories: MonthlySpendingCategory[]
+}) {
+  const gridTemplateColumns = `repeat(${monthlyCategorySpending.months.length}, minmax(0, 1fr))`
+
+  return (
+    <div className="pb-1">
+      <div
+        className="grid h-56 items-end gap-1 sm:gap-2"
+        style={{ gridTemplateColumns }}
+      >
+        {monthlyCategorySpending.months.map((month) => {
+          const columnHeight = getShare(
+            month.expenseAmount,
+            monthlyCategorySpending.maxExpenseAmount,
+          )
+          const columnHeightPercent =
+            columnHeight > 0 ? Math.max(columnHeight * 100, 3) : 0
+          const monthCategories = getMonthCategoriesInDisplayOrder(
+            month,
+            visibleCategories,
+          )
+
+          return (
+            <div
+              className="flex min-w-0 flex-col items-center gap-2"
+              key={month.key}
+            >
+              <div className="relative h-48 w-full">
+                <div
+                  className="absolute max-w-full truncate text-left text-[10px] leading-none text-muted-foreground"
+                  style={{
+                    bottom:
+                      columnHeightPercent > 0
+                        ? `calc(${columnHeightPercent}% + 0.25rem)`
+                        : '0.25rem',
+                    left: '50%',
+                    width: '3.75rem',
+                    transform: 'translateX(-50%)',
+                  }}
+                >
+                  {formatChartCurrency({
+                    amount: month.expenseAmount,
+                    currency,
+                    locale,
+                    roundAmounts,
+                  })}
+                </div>
+                <div
+                  className="absolute bottom-0 left-1/2 flex w-full max-w-14 -translate-x-1/2 items-end rounded-md bg-muted"
+                  style={{
+                    height:
+                      columnHeightPercent > 0
+                        ? `${columnHeightPercent}%`
+                        : '0%',
+                  }}
+                  title={`${formatMonth(
+                    month,
+                    locale,
+                    'long',
+                  )}: ${formatChartCurrency({
+                    amount: month.expenseAmount,
+                    currency,
+                    locale,
+                    roundAmounts,
+                  })}`}
+                >
+                  <div className="flex h-full w-full flex-col-reverse overflow-hidden rounded-md">
+                    {monthCategories.map((category) => {
+                      const share = getShare(
+                        category.expenseAmount,
+                        month.expenseAmount,
+                      )
+                      const categoryLabel = getCategoryLabel(
                         category,
                         grouping,
                         tCategories,
-                      )}: ${formatCurrency(
-                        currency,
-                        category.expenseAmount,
-                        locale,
-                      )}`}
-                    />
-                  ))}
+                      )
+                      const color = colorByCategory.get(category.key)
+
+                      return (
+                        <div
+                          aria-label={getCategoryHoverLabel({
+                            amount: category.expenseAmount,
+                            categoryLabel,
+                            currency,
+                            locale,
+                            month,
+                            roundAmounts,
+                            share,
+                          })}
+                          className={cn(
+                            'flex min-h-[3px] items-center justify-center overflow-hidden border-x px-0.5',
+                            color?.backgroundClassName,
+                            color?.borderClassName,
+                            color?.foregroundClassName,
+                          )}
+                          key={category.key}
+                          style={{ height: `${share * 100}%` }}
+                          title={getCategoryHoverLabel({
+                            amount: category.expenseAmount,
+                            categoryLabel,
+                            currency,
+                            locale,
+                            month,
+                            roundAmounts,
+                            share,
+                          })}
+                        >
+                          {share >= 0.08 && (
+                            <GraphCategoryIcon
+                              category={category}
+                              className="h-3.5 w-3.5 shrink-0 opacity-50"
+                              grouping={grouping}
+                            />
+                          )}
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              </div>
+              <div className="w-full min-w-0 truncate text-center text-[10px] text-muted-foreground">
+                {formatMonth(month, locale, 'narrow')}
               </div>
             </div>
-            <div className="text-muted-foreground sm:text-right">
-              {formatCurrency(currency, month.expenseAmount, locale)}
-            </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
-    </section>
+    </div>
   )
 }
 
@@ -238,135 +835,124 @@ export function MonthlyCategoryBreakdown({
   grouping,
   locale,
   monthlyCategorySpending,
+  range,
+  roundAmounts,
   t,
   tCategories,
 }: {
-  colorByCategory: Map<string, string>
+  colorByCategory: Map<string, CategoryColor>
   currency: Parameters<typeof formatCurrency>[0]
   grouping: MonthlySpendingGrouping
   locale: string
   monthlyCategorySpending: MonthlyCategorySpending
+  range: MonthlySpendingRange
+  roundAmounts: boolean
   t: (key: string, values?: Record<string, string>) => string
   tCategories: (key: string) => string
 }) {
-  const month =
-    monthlyCategorySpending.months.find(
-      (month) => month.key === monthlyCategorySpending.highlightedMonthKey,
-    ) ?? monthlyCategorySpending.months.at(-1)
-  const categories =
-    month?.categories.filter((category) => category.expenseAmount > 0) ?? []
+  const categories = monthlyCategorySpending.categories.filter(
+    (category) => category.expenseAmount > 0,
+  )
   const maxCategoryAmount = Math.max(
     0,
     ...categories.map((category) => category.expenseAmount),
   )
+  const totalExpenseAmount = monthlyCategorySpending.months.reduce(
+    (total, month) => total + month.expenseAmount,
+    0,
+  )
+  const incomeAmount = monthlyCategorySpending.months.reduce(
+    (total, month) => total + month.incomeAmount,
+    0,
+  )
 
-  if (!month || (categories.length === 0 && month.incomeAmount >= 0)) {
+  if (categories.length === 0 && incomeAmount >= 0) {
     return null
   }
 
   return (
     <section className="space-y-3">
       <h3 className="text-sm font-semibold">
-        {t('breakdownTitle', { month: formatMonth(month, locale, 'long') })}
+        {t('breakdownTitle', { range: getRangeLabel(range, t) })}
       </h3>
       {categories.length > 0 && (
         <div className="space-y-2">
-          {categories.map((category) => (
-            <div key={category.key} className="space-y-1 text-sm">
-              <div className="flex justify-between gap-3">
-                <span className="truncate">
-                  {getCategoryLabel(category, grouping, tCategories)}
-                </span>
-                <span className="shrink-0 text-muted-foreground">
-                  {formatCurrency(currency, category.expenseAmount, locale)}
-                </span>
+          {categories.map((category) => {
+            const share = getShare(category.expenseAmount, totalExpenseAmount)
+            const categoryLabel = getCategoryLabel(
+              category,
+              grouping,
+              tCategories,
+            )
+            const color = colorByCategory.get(category.key)
+
+            return (
+              <div
+                key={category.key}
+                className="space-y-1 text-sm"
+                title={`${categoryLabel}: ${formatChartCurrency({
+                  amount: category.expenseAmount,
+                  currency,
+                  locale,
+                  roundAmounts,
+                })} (${formatPercent(share, locale)})`}
+              >
+                <div>
+                  <span className="truncate">{categoryLabel}</span>
+                </div>
+                <div className="relative h-7 overflow-hidden rounded-md bg-muted">
+                  <div
+                    className={cn('h-7 rounded-md', color?.backgroundClassName)}
+                    style={{
+                      width: `${
+                        getShare(category.expenseAmount, maxCategoryAmount) *
+                        100
+                      }%`,
+                    }}
+                  />
+                  <div className="absolute inset-y-0 left-0 flex items-center px-2 text-xs font-medium text-foreground">
+                    {formatChartCurrency({
+                      amount: category.expenseAmount,
+                      currency,
+                      locale,
+                      roundAmounts,
+                    })}{' '}
+                    ({formatPercent(share, locale)})
+                  </div>
+                </div>
               </div>
-              <div className="h-2 rounded-full bg-muted">
-                <div
-                  className={`h-2 rounded-full ${colorByCategory.get(
-                    category.key,
-                  )}`}
-                  style={{
-                    width: `${
-                      (category.expenseAmount / maxCategoryAmount) * 100
-                    }%`,
-                  }}
-                />
-              </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
-      {month.incomeAmount < 0 && (
+      {incomeAmount < 0 && (
         <p className="text-xs text-muted-foreground">
-          {t('income')}: {formatCurrency(currency, month.incomeAmount, locale)}
+          {t('income')}:{' '}
+          {formatChartCurrency({
+            amount: incomeAmount,
+            currency,
+            locale,
+            roundAmounts,
+          })}
         </p>
       )}
     </section>
   )
 }
 
-export function MonthlySpendingTrend({
-  currency,
-  locale,
-  months,
-  t,
-}: {
-  currency: Parameters<typeof formatCurrency>[0]
-  locale: string
-  months: MonthlySpendingMonth[]
-  t: (key: string) => string
-}) {
-  const maxExpenseAmount = Math.max(
-    0,
-    ...months.map((month) => month.expenseAmount),
-  )
-
-  return (
-    <section className="space-y-3">
-      <h3 className="text-sm font-semibold">{t('trendTitle')}</h3>
-      <div className="overflow-x-auto">
-        <div className="flex h-32 min-w-full items-end gap-2">
-          {months.map((month) => {
-            const height =
-              maxExpenseAmount > 0
-                ? (month.expenseAmount / maxExpenseAmount) * 100
-                : 0
-            return (
-              <div
-                key={month.key}
-                className="flex min-w-10 flex-1 flex-col items-center justify-end gap-1"
-                title={`${formatMonth(month, locale, 'long')}: ${formatCurrency(
-                  currency,
-                  month.expenseAmount,
-                  locale,
-                )}`}
-              >
-                <div
-                  className="w-full max-w-8 rounded-t-md bg-muted-foreground/60"
-                  style={{ height: `${height}%` }}
-                />
-                <div className="text-[10px] text-muted-foreground">
-                  {formatMonth(month, locale, 'narrow')}
-                </div>
-              </div>
-            )
-          })}
-        </div>
-      </div>
-    </section>
-  )
-}
-
 function MonthlySpendingLegend({
   categories,
+  className,
   colorByCategory,
   grouping,
+  isVertical = false,
   tCategories,
 }: {
   categories: MonthlySpendingCategory[]
-  colorByCategory: Map<string, string>
+  className?: string
+  colorByCategory: Map<string, CategoryColor>
   grouping: MonthlySpendingGrouping
+  isVertical?: boolean
   tCategories: (key: string) => string
 }) {
   const visibleCategories = categories.filter(
@@ -376,14 +962,29 @@ function MonthlySpendingLegend({
   if (visibleCategories.length === 0) return null
 
   return (
-    <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
+    <div
+      className={cn(
+        'text-xs text-muted-foreground',
+        isVertical ? 'space-y-2' : 'flex flex-wrap gap-x-4 gap-y-2',
+        className,
+      )}
+    >
       {visibleCategories.map((category) => (
         <div key={category.key} className="flex min-w-0 items-center gap-2">
           <span
-            className={`h-2.5 w-2.5 shrink-0 rounded-full ${colorByCategory.get(
-              category.key,
-            )}`}
-          />
+            className={cn(
+              'flex h-6 w-6 shrink-0 items-center justify-center rounded-md border',
+              colorByCategory.get(category.key)?.backgroundClassName,
+              colorByCategory.get(category.key)?.borderClassName,
+              colorByCategory.get(category.key)?.foregroundClassName,
+            )}
+          >
+            <GraphCategoryIcon
+              category={category}
+              className="h-3.5 w-3.5"
+              grouping={grouping}
+            />
+          </span>
           <span className="truncate">
             {getCategoryLabel(category, grouping, tCategories)}
           </span>
@@ -407,13 +1008,92 @@ function MonthlySpendingLoading() {
   )
 }
 
+function GraphCategoryIcon({
+  category,
+  className,
+  grouping,
+}: {
+  category: Pick<MonthlySpendingCategory, 'categoryId' | 'grouping' | 'name'>
+  className?: string
+  grouping: MonthlySpendingGrouping
+}) {
+  if (grouping === 'categoryGroup') {
+    return (
+      <CategoryGroupIcon className={className} grouping={category.grouping} />
+    )
+  }
+
+  return (
+    <CategoryIcon
+      category={{
+        id: category.categoryId ?? 0,
+        grouping: category.grouping,
+        name: category.name,
+      }}
+      className={className}
+    />
+  )
+}
+
+function CategoryGroupIcon({
+  className,
+  grouping,
+}: {
+  className?: string
+  grouping: string
+}) {
+  switch (grouping) {
+    case 'Entertainment':
+      return <FerrisWheel className={className} />
+    case 'Food and Drink':
+      return <Utensils className={className} />
+    case 'Home':
+      return <Home className={className} />
+    case 'Life':
+      return <HandHelping className={className} />
+    case 'Transportation':
+      return <Bus className={className} />
+    case 'Utilities':
+      return <PlugZap className={className} />
+    default:
+      return <Banknote className={className} />
+  }
+}
+
 function getColorByCategory(categories: MonthlySpendingCategory[]) {
   return new Map(
-    categories.map((category, index) => [
-      category.key,
-      CATEGORY_COLORS[index % CATEGORY_COLORS.length],
-    ]),
+    categories.map((category) => [category.key, getCategoryColorFor(category)]),
   )
+}
+
+function getCategoryColorFor(category: MonthlySpendingCategory) {
+  if (category.categoryId !== null) {
+    const detailedColor =
+      DETAILED_CATEGORY_COLORS_BY_KEY[`${category.grouping}:${category.name}`]
+
+    if (detailedColor) return detailedColor
+
+    return DETAILED_CATEGORY_COLOR_SPECTRUM[
+      Math.abs(category.categoryId) % DETAILED_CATEGORY_COLOR_SPECTRUM.length
+    ]
+  }
+
+  const palette =
+    CATEGORY_COLORS_BY_GROUP[category.grouping] ?? FALLBACK_CATEGORY_COLORS
+
+  return palette[0]
+}
+
+function getCategoryColor(
+  backgroundClassName: string,
+  borderClassName: string,
+  foregroundClassName: string,
+): CategoryColor {
+  return {
+    backgroundClassName,
+    borderClassName,
+    foregroundClassName,
+  }
 }
 
 function getCategoryLabel(
@@ -426,6 +1106,73 @@ function getCategoryLabel(
   }
 
   return tCategories(`${category.grouping}.${category.name}`)
+}
+
+function getCategoryHoverLabel({
+  amount,
+  categoryLabel,
+  currency,
+  locale,
+  month,
+  roundAmounts,
+  share,
+}: {
+  amount: number
+  categoryLabel: string
+  currency: Parameters<typeof formatCurrency>[0]
+  locale: string
+  month: MonthlySpendingMonth
+  roundAmounts: boolean
+  share: number
+}) {
+  return `${formatMonth(
+    month,
+    locale,
+    'long',
+  )} - ${categoryLabel}: ${formatChartCurrency({
+    amount,
+    currency,
+    locale,
+    roundAmounts,
+  })} (${formatPercent(share, locale)})`
+}
+
+function getRangeLabel(
+  range: MonthlySpendingRange,
+  t: (key: string) => string,
+) {
+  if (range === '3') return t('RangeOptions.three')
+  if (range === '6') return t('RangeOptions.six')
+  if (range === '12') return t('RangeOptions.twelve')
+  return t('RangeOptions.all')
+}
+
+function getShare(amount: number, total: number) {
+  if (total <= 0) return 0
+  return amount / total
+}
+
+function getMonthCategoriesInDisplayOrder(
+  month: MonthlySpendingMonth,
+  visibleCategories: MonthlySpendingCategory[],
+) {
+  const categoriesByKey = new Map(
+    month.categories.map((category) => [category.key, category]),
+  )
+
+  return visibleCategories
+    .map((category) => categoriesByKey.get(category.key))
+    .filter(
+      (category): category is MonthlySpendingCategory =>
+        category !== undefined && category.expenseAmount > 0,
+    )
+}
+
+function formatPercent(value: number, locale: string) {
+  return new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 0,
+    style: 'percent',
+  }).format(value)
 }
 
 function formatMonth(

--- a/src/app/groups/[groupId]/stats/page.client.tsx
+++ b/src/app/groups/[groupId]/stats/page.client.tsx
@@ -1,3 +1,4 @@
+import { MonthlySpending } from '@/app/groups/[groupId]/stats/monthly-spending'
 import { Totals } from '@/app/groups/[groupId]/stats/totals'
 import {
   Card,
@@ -22,6 +23,7 @@ export function TotalsPageClient() {
           <Totals />
         </CardContent>
       </Card>
+      <MonthlySpending />
     </>
   )
 }

--- a/src/lib/balance-timeline.test.ts
+++ b/src/lib/balance-timeline.test.ts
@@ -1,0 +1,198 @@
+import { BalanceTimelineExpense, getBalanceTimeline } from './balance-timeline'
+
+const participants = {
+  alex: { id: 'alex', name: 'Alex' },
+  blair: { id: 'blair', name: 'Blair' },
+  casey: { id: 'casey', name: 'Casey' },
+}
+
+const categories = {
+  payment: { id: 1, grouping: 'Uncategorized', name: 'Payment' },
+  rent: { id: 18, grouping: 'Home', name: 'Rent' },
+}
+
+function expense({
+  amount,
+  category = categories.rent,
+  createdAt,
+  date,
+  isReimbursement = false,
+  paidBy = participants.alex,
+  paidFor = [
+    { participant: participants.alex, shares: 1 },
+    { participant: participants.blair, shares: 1 },
+  ],
+  splitMode = 'EVENLY',
+}: {
+  amount: number
+  category?: BalanceTimelineExpense['category']
+  createdAt?: string
+  date: string
+  isReimbursement?: boolean
+  paidBy?: BalanceTimelineExpense['paidBy']
+  paidFor?: BalanceTimelineExpense['paidFor']
+  splitMode?: BalanceTimelineExpense['splitMode']
+}): BalanceTimelineExpense {
+  return {
+    amount,
+    category,
+    createdAt: createdAt ? new Date(createdAt) : undefined,
+    expenseDate: new Date(date),
+    isReimbursement,
+    paidBy,
+    paidFor,
+    splitMode,
+  }
+}
+
+describe('getBalanceTimeline', () => {
+  it('groups balance changes into sorted daily event points', () => {
+    const timeline = getBalanceTimeline(
+      [
+        expense({ amount: 3000, date: '2026-06-03T00:00:00.000Z' }),
+        expense({ amount: 12000, date: '2026-06-01T00:00:00.000Z' }),
+        expense({ amount: 6000, date: '2026-06-01T00:00:00.000Z' }),
+      ],
+      { range: 'all' },
+    )
+
+    expect(timeline.points.map((point) => point.key)).toEqual([
+      '2026-06-01-start',
+      '2026-06-01',
+      '2026-06-03',
+    ])
+    expect(timeline.points[0]).toMatchObject({
+      balances: {
+        alex: 0,
+        blair: 0,
+      },
+      isStart: true,
+    })
+    expect(timeline.points[1]?.balances).toMatchObject({
+      alex: 9000,
+      blair: -9000,
+    })
+  })
+
+  it('marks reimbursement days and updates balances toward zero', () => {
+    const timeline = getBalanceTimeline(
+      [
+        expense({ amount: 12000, date: '2026-06-01T00:00:00.000Z' }),
+        expense({
+          amount: 4000,
+          category: categories.payment,
+          date: '2026-06-15T00:00:00.000Z',
+          isReimbursement: true,
+          paidBy: participants.blair,
+          paidFor: [{ participant: participants.alex, shares: 1 }],
+        }),
+      ],
+      { range: 'all' },
+    )
+
+    expect(timeline.points[2]).toMatchObject({
+      hasRepayment: true,
+      balances: {
+        alex: 2000,
+        blair: -2000,
+      },
+      deltas: {
+        alex: -4000,
+        blair: 4000,
+      },
+      events: [
+        {
+          isReimbursement: true,
+          paidBy: participants.blair,
+          paidFor: [participants.alex],
+        },
+      ],
+    })
+  })
+
+  it('uses UTC date parts for day grouping', () => {
+    const timeline = getBalanceTimeline(
+      [expense({ amount: 12000, date: '2026-06-01T00:00:00.000Z' })],
+      { range: 'all' },
+    )
+
+    expect(timeline.points[1]).toMatchObject({
+      key: '2026-06-01',
+      year: 2026,
+      month: 5,
+      day: 1,
+    })
+  })
+
+  it('filters visible event days by range while preserving opening balances', () => {
+    const timeline = getBalanceTimeline(
+      [
+        expense({ amount: 12000, date: '2026-01-15T00:00:00.000Z' }),
+        expense({
+          amount: 2000,
+          date: '2026-06-15T00:00:00.000Z',
+          isReimbursement: true,
+          paidBy: participants.blair,
+          paidFor: [{ participant: participants.alex, shares: 1 }],
+        }),
+      ],
+      { range: '3' },
+    )
+
+    expect(timeline.points.map((point) => point.key)).toEqual([
+      '2026-04-01-start',
+      '2026-06-15',
+    ])
+    expect(timeline.points[0]?.balances).toMatchObject({
+      alex: 6000,
+      blair: -6000,
+    })
+    expect(timeline.points[1]?.balances).toMatchObject({
+      alex: 4000,
+      blair: -4000,
+    })
+  })
+
+  it('summarizes peak balances and reimbursement activity by participant', () => {
+    const timeline = getBalanceTimeline(
+      [
+        expense({
+          amount: 9000,
+          date: '2026-06-01T00:00:00.000Z',
+          paidFor: [
+            { participant: participants.alex, shares: 1 },
+            { participant: participants.blair, shares: 1 },
+            { participant: participants.casey, shares: 1 },
+          ],
+        }),
+        expense({
+          amount: 3000,
+          category: categories.payment,
+          date: '2026-06-10T00:00:00.000Z',
+          isReimbursement: true,
+          paidBy: participants.blair,
+          paidFor: [{ participant: participants.alex, shares: 1 }],
+        }),
+      ],
+      { range: 'all' },
+    )
+
+    expect(
+      timeline.participants.find((participant) => participant.id === 'alex'),
+    ).toMatchObject({
+      maxPositiveBalance: 6000,
+      peakBalance: 6000,
+      peakAbsBalance: 6000,
+      repaymentCount: 1,
+      currentBalance: 3000,
+    })
+    expect(
+      timeline.participants.find((participant) => participant.id === 'casey'),
+    ).toMatchObject({
+      maxNegativeBalance: -3000,
+      peakBalance: -3000,
+      peakAbsBalance: 3000,
+      repaymentCount: 0,
+    })
+  })
+})

--- a/src/lib/balance-timeline.ts
+++ b/src/lib/balance-timeline.ts
@@ -1,0 +1,485 @@
+import { MonthlySpendingRange } from './monthly-spending'
+
+type BalanceTimelineParticipant = {
+  id: string
+  name: string
+}
+
+type BalanceTimelineCategory = {
+  id: number
+  grouping: string
+  name: string
+}
+
+type BalanceTimelineSplitMode =
+  | 'EVENLY'
+  | 'BY_AMOUNT'
+  | 'BY_PERCENTAGE'
+  | 'BY_SHARES'
+
+export type BalanceTimelineExpense = {
+  amount: number
+  category: BalanceTimelineCategory | null
+  createdAt?: Date
+  expenseDate: Date
+  id?: string
+  isReimbursement: boolean
+  paidBy: BalanceTimelineParticipant
+  paidFor: {
+    participant: BalanceTimelineParticipant
+    shares: number
+  }[]
+  splitMode: BalanceTimelineSplitMode
+  title?: string
+}
+
+export type BalanceTimelineEvent = {
+  amount: number
+  category: BalanceTimelineCategory | null
+  isReimbursement: boolean
+  paidBy: BalanceTimelineParticipant
+  paidFor: BalanceTimelineParticipant[]
+  title?: string
+}
+
+export type BalanceTimelinePoint = {
+  key: string
+  year: number
+  month: number
+  day: number
+  balances: Record<string, number>
+  deltas: Record<string, number>
+  events: BalanceTimelineEvent[]
+  hasRepayment: boolean
+  isStart: boolean
+}
+
+export type BalanceTimelineParticipantSummary = BalanceTimelineParticipant & {
+  currentBalance: number
+  maxPositiveBalance: number
+  maxNegativeBalance: number
+  peakBalance: number
+  peakAbsBalance: number
+  repaymentCount: number
+}
+
+export type BalanceTimeline = {
+  points: BalanceTimelinePoint[]
+  participants: BalanceTimelineParticipantSummary[]
+  maxAbsBalance: number
+  rangeEnd: { year: number; month: number; day: number }
+  rangeStart: { year: number; month: number; day: number }
+}
+
+type MutableBalanceTimelineDay = {
+  key: string
+  year: number
+  month: number
+  day: number
+  deltas: Map<string, number>
+  events: BalanceTimelineEvent[]
+  hasRepayment: boolean
+}
+
+export function getBalanceTimeline(
+  expenses: BalanceTimelineExpense[],
+  options: { range?: MonthlySpendingRange } = {},
+): BalanceTimeline {
+  if (expenses.length === 0) {
+    return emptyBalanceTimeline()
+  }
+
+  const range = options.range ?? '6'
+  const participants = getParticipants(expenses)
+  const balances = new Map(
+    participants.map((participant) => [participant.id, 0]),
+  )
+  const sortedExpenses = [...expenses].sort(compareExpensesAscending)
+  const timelineRange = getTimelineRange(sortedExpenses, range)
+  const days = new Map<string, MutableBalanceTimelineDay>()
+
+  for (const expense of sortedExpenses) {
+    const expenseDeltas = getExpenseDeltas(expense)
+
+    if (getMonthKeyFromDate(expense.expenseDate) < timelineRange.startKey) {
+      addDeltasToBalances(balances, expenseDeltas)
+      continue
+    }
+
+    const day = getOrCreateDay(days, expense.expenseDate)
+    addDeltasToDay(day, expenseDeltas)
+    day.events.push(getTimelineEvent(expense))
+
+    if (expense.isReimbursement) {
+      day.hasRepayment = true
+    }
+  }
+
+  const participantSummaries = new Map(
+    participants.map((participant) => [
+      participant.id,
+      {
+        ...participant,
+        currentBalance: 0,
+        maxNegativeBalance: 0,
+        maxPositiveBalance: 0,
+        peakBalance: 0,
+        peakAbsBalance: 0,
+        repaymentCount: 0,
+      },
+    ]),
+  )
+  const points: BalanceTimelinePoint[] = []
+  let maxAbsBalance = 0
+
+  if (days.size > 0) {
+    const startBalances = mapToRoundedRecord(balances)
+    const startDeltas = Object.fromEntries(
+      participants.map((participant) => [participant.id, 0]),
+    )
+
+    updateParticipantSummaries({
+      balances: startBalances,
+      participantSummaries,
+      participants,
+    })
+    maxAbsBalance = getMaxAbsBalance(startBalances, maxAbsBalance)
+
+    points.push({
+      ...timelineRange.start,
+      key: `${getDayKey(timelineRange.start)}-start`,
+      balances: startBalances,
+      deltas: startDeltas,
+      events: [],
+      hasRepayment: false,
+      isStart: true,
+    })
+  }
+
+  for (const day of Array.from(days.values()).sort((dayA, dayB) =>
+    dayA.key.localeCompare(dayB.key),
+  )) {
+    addDeltasToBalances(balances, day.deltas)
+
+    const pointBalances = mapToRoundedRecord(balances)
+    const pointDeltas = mapToRoundedRecord(day.deltas)
+
+    updateParticipantSummaries({
+      balances: pointBalances,
+      deltas: pointDeltas,
+      hasRepayment: day.hasRepayment,
+      participantSummaries,
+      participants,
+    })
+    maxAbsBalance = getMaxAbsBalance(pointBalances, maxAbsBalance)
+
+    points.push({
+      key: day.key,
+      year: day.year,
+      month: day.month,
+      day: day.day,
+      balances: pointBalances,
+      deltas: pointDeltas,
+      events: day.events,
+      hasRepayment: day.hasRepayment,
+      isStart: false,
+    })
+  }
+
+  const currentBalances = points.at(-1)?.balances ?? {}
+  for (const participant of participants) {
+    const summary = participantSummaries.get(participant.id)
+    if (summary) summary.currentBalance = currentBalances[participant.id] ?? 0
+  }
+
+  return {
+    points,
+    participants: Array.from(participantSummaries.values()),
+    maxAbsBalance,
+    rangeEnd: timelineRange.end,
+    rangeStart: timelineRange.start,
+  }
+}
+
+function emptyBalanceTimeline(): BalanceTimeline {
+  return {
+    points: [],
+    participants: [],
+    maxAbsBalance: 0,
+    rangeEnd: { year: 0, month: 0, day: 1 },
+    rangeStart: { year: 0, month: 0, day: 1 },
+  }
+}
+
+function getParticipants(expenses: BalanceTimelineExpense[]) {
+  const participants = new Map<string, BalanceTimelineParticipant>()
+
+  for (const expense of expenses) {
+    participants.set(expense.paidBy.id, expense.paidBy)
+
+    for (const paidFor of expense.paidFor) {
+      participants.set(paidFor.participant.id, paidFor.participant)
+    }
+  }
+
+  return Array.from(participants.values()).sort((participantA, participantB) =>
+    participantA.name.localeCompare(participantB.name),
+  )
+}
+
+function compareExpensesAscending(
+  expenseA: BalanceTimelineExpense,
+  expenseB: BalanceTimelineExpense,
+) {
+  const dateDifference =
+    expenseA.expenseDate.getTime() - expenseB.expenseDate.getTime()
+  if (dateDifference !== 0) return dateDifference
+
+  return (
+    (expenseA.createdAt?.getTime() ?? 0) - (expenseB.createdAt?.getTime() ?? 0)
+  )
+}
+
+function getTimelineRange(
+  expenses: BalanceTimelineExpense[],
+  range: MonthlySpendingRange,
+) {
+  const monthKeys = expenses.map((expense) =>
+    getMonthKeyFromDate(expense.expenseDate),
+  )
+  const firstMonthKey = monthKeys.reduce((first, monthKey) =>
+    monthKey < first ? monthKey : first,
+  )
+  const lastMonthKey = monthKeys.reduce((last, monthKey) =>
+    monthKey > last ? monthKey : last,
+  )
+
+  const lastMonth = getMonthPartsFromKey(lastMonthKey)
+  const startMonth =
+    range === 'all'
+      ? getMonthPartsFromKey(firstMonthKey)
+      : addMonths(lastMonth.year, lastMonth.month, -Number(range) + 1)
+  const endMonth = getMonthPartsFromKey(lastMonthKey)
+
+  return {
+    end: {
+      ...endMonth,
+      day: getDaysInMonth(endMonth.year, endMonth.month),
+    },
+    start: {
+      ...startMonth,
+      day: 1,
+    },
+    startKey: getMonthKeyFromParts(startMonth),
+  }
+}
+
+function getTimelineEvent(expense: BalanceTimelineExpense) {
+  return {
+    amount: expense.amount,
+    category: expense.category,
+    isReimbursement: expense.isReimbursement,
+    paidBy: expense.paidBy,
+    paidFor: expense.paidFor.map((paidFor) => paidFor.participant),
+    title: expense.title,
+  }
+}
+
+function getExpenseDeltas(expense: BalanceTimelineExpense) {
+  const deltas = new Map<string, number>()
+  const totalPaidForShares = expense.paidFor.reduce(
+    (sum, paidFor) => sum + paidFor.shares,
+    0,
+  )
+  let remainingAmount = expense.amount
+
+  addDelta(deltas, expense.paidBy.id, expense.amount)
+
+  expense.paidFor.forEach((paidFor, index) => {
+    const isLast = index === expense.paidFor.length - 1
+    const dividedAmount = isLast
+      ? remainingAmount
+      : (expense.amount *
+          getPaidForShares({
+            paidForShares: paidFor.shares,
+            splitMode: expense.splitMode,
+          })) /
+        getTotalShares({
+          paidForCount: expense.paidFor.length,
+          splitMode: expense.splitMode,
+          totalPaidForShares,
+        })
+
+    remainingAmount -= dividedAmount
+    addDelta(deltas, paidFor.participant.id, -dividedAmount)
+  })
+
+  return deltas
+}
+
+function getPaidForShares({
+  paidForShares,
+  splitMode,
+}: {
+  paidForShares: number
+  splitMode: BalanceTimelineSplitMode
+}) {
+  if (splitMode === 'EVENLY') return 1
+  return paidForShares
+}
+
+function getTotalShares({
+  paidForCount,
+  splitMode,
+  totalPaidForShares,
+}: {
+  paidForCount: number
+  splitMode: BalanceTimelineSplitMode
+  totalPaidForShares: number
+}) {
+  if (splitMode === 'EVENLY') return paidForCount
+  return totalPaidForShares
+}
+
+function updateParticipantSummaries({
+  balances,
+  deltas = {},
+  hasRepayment = false,
+  participantSummaries,
+  participants,
+}: {
+  balances: Record<string, number>
+  deltas?: Record<string, number>
+  hasRepayment?: boolean
+  participantSummaries: Map<string, BalanceTimelineParticipantSummary>
+  participants: BalanceTimelineParticipant[]
+}) {
+  for (const participant of participants) {
+    const balance = balances[participant.id] ?? 0
+    const summary = participantSummaries.get(participant.id)
+    if (!summary) continue
+
+    summary.maxPositiveBalance = Math.max(summary.maxPositiveBalance, balance)
+    summary.maxNegativeBalance = Math.min(summary.maxNegativeBalance, balance)
+    summary.peakAbsBalance = Math.max(summary.peakAbsBalance, Math.abs(balance))
+    if (Math.abs(balance) > Math.abs(summary.peakBalance)) {
+      summary.peakBalance = balance
+    }
+    if (hasRepayment && (deltas[participant.id] ?? 0) !== 0) {
+      summary.repaymentCount += 1
+    }
+  }
+}
+
+function getMaxAbsBalance(
+  balances: Record<string, number>,
+  currentMaxAbsBalance: number,
+) {
+  return Object.values(balances).reduce(
+    (maxAbsBalance, balance) => Math.max(maxAbsBalance, Math.abs(balance)),
+    currentMaxAbsBalance,
+  )
+}
+
+function getOrCreateDay(
+  days: Map<string, MutableBalanceTimelineDay>,
+  date: Date,
+) {
+  const key = getDayKeyFromDate(date)
+  const existingDay = days.get(key)
+
+  if (existingDay) return existingDay
+
+  const day = {
+    key,
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth(),
+    day: date.getUTCDate(),
+    deltas: new Map<string, number>(),
+    events: [],
+    hasRepayment: false,
+  }
+
+  days.set(key, day)
+  return day
+}
+
+function addDeltasToDay(
+  day: MutableBalanceTimelineDay,
+  deltas: Map<string, number>,
+) {
+  deltas.forEach((delta, participantId) => {
+    addDelta(day.deltas, participantId, delta)
+  })
+}
+
+function addDeltasToBalances(
+  balances: Map<string, number>,
+  deltas: Map<string, number>,
+) {
+  deltas.forEach((delta, participantId) => {
+    addDelta(balances, participantId, delta)
+  })
+}
+
+function addDelta(
+  deltas: Map<string, number>,
+  participantId: string,
+  amount: number,
+) {
+  deltas.set(participantId, (deltas.get(participantId) ?? 0) + amount)
+}
+
+function mapToRoundedRecord(map: Map<string, number>) {
+  return Object.fromEntries(
+    Array.from(map.entries()).map(([participantId, amount]) => [
+      participantId,
+      roundCurrencyAmount(amount),
+    ]),
+  )
+}
+
+function roundCurrencyAmount(amount: number) {
+  return Math.round(amount) + 0
+}
+
+function getMonthKeyFromDate(date: Date) {
+  return getMonthKey(date.getUTCFullYear(), date.getUTCMonth())
+}
+
+function getDayKeyFromDate(date: Date) {
+  return getDayKey({
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth(),
+    day: date.getUTCDate(),
+  })
+}
+
+function getDayKey(parts: { year: number; month: number; day: number }) {
+  return `${getMonthKey(parts.year, parts.month)}-${String(parts.day).padStart(
+    2,
+    '0',
+  )}`
+}
+
+function getMonthKeyFromParts(parts: { year: number; month: number }) {
+  return getMonthKey(parts.year, parts.month)
+}
+
+function getMonthKey(year: number, month: number) {
+  return `${year}-${String(month + 1).padStart(2, '0')}`
+}
+
+function getMonthPartsFromKey(monthKey: string) {
+  const [year, month] = monthKey.split('-').map(Number)
+  return { year, month: month - 1 }
+}
+
+function addMonths(year: number, month: number, monthsToAdd: number) {
+  const date = new Date(Date.UTC(year, month + monthsToAdd, 1))
+  return { year: date.getUTCFullYear(), month: date.getUTCMonth() }
+}
+
+function getDaysInMonth(year: number, month: number) {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate()
+}

--- a/src/lib/chart-currency.ts
+++ b/src/lib/chart-currency.ts
@@ -1,0 +1,32 @@
+import { amountAsDecimal, formatCurrency } from './utils'
+
+type ChartCurrency = Parameters<typeof formatCurrency>[0]
+
+export function formatChartCurrency({
+  amount,
+  currency,
+  locale,
+  roundAmounts,
+}: {
+  amount: number
+  currency: ChartCurrency
+  locale: string
+  roundAmounts: boolean
+}) {
+  if (!roundAmounts) return formatCurrency(currency, amount, locale)
+
+  const formattedAmount = amountAsDecimal(amount, currency)
+  const format = new Intl.NumberFormat(locale, {
+    currency: currency.code.length ? currency.code : 'USD',
+    maximumFractionDigits: 0,
+    minimumFractionDigits: 0,
+    style: 'currency',
+  })
+
+  if (currency.code.length) return format.format(formattedAmount)
+
+  return format
+    .formatToParts(formattedAmount)
+    .map((part) => (part.type === 'currency' ? currency.symbol : part.value))
+    .join('')
+}

--- a/src/lib/monthly-spending.test.ts
+++ b/src/lib/monthly-spending.test.ts
@@ -1,0 +1,127 @@
+import {
+  MonthlySpendingExpense,
+  getMonthlyCategorySpending,
+} from './monthly-spending'
+
+const categories = {
+  diningOut: { id: 8, grouping: 'Food and Drink', name: 'Dining Out' },
+  groceries: { id: 9, grouping: 'Food and Drink', name: 'Groceries' },
+  rent: { id: 18, grouping: 'Home', name: 'Rent' },
+}
+
+function expense(
+  date: string,
+  amount: number,
+  category: MonthlySpendingExpense['category'] = categories.diningOut,
+  isReimbursement = false,
+): MonthlySpendingExpense {
+  return {
+    amount,
+    category,
+    expenseDate: new Date(date),
+    isReimbursement,
+  }
+}
+
+describe('getMonthlyCategorySpending', () => {
+  it('groups expenses by UTC calendar month', () => {
+    const stats = getMonthlyCategorySpending(
+      [expense('2026-06-01T00:00:00.000Z', 1200)],
+      { range: 'all' },
+    )
+
+    expect(stats.months).toHaveLength(1)
+    expect(stats.months[0]?.key).toBe('2026-06')
+    expect(stats.months[0]?.expenseAmount).toBe(1200)
+  })
+
+  it('excludes reimbursements from monthly spending', () => {
+    const stats = getMonthlyCategorySpending(
+      [
+        expense('2026-06-15T00:00:00.000Z', 1200),
+        expense('2026-06-15T00:00:00.000Z', 5000, categories.rent, true),
+      ],
+      { range: 'all' },
+    )
+
+    expect(stats.months[0]?.expenseAmount).toBe(1200)
+    expect(stats.categories).toHaveLength(1)
+  })
+
+  it('aggregates category totals correctly', () => {
+    const stats = getMonthlyCategorySpending(
+      [
+        expense('2026-06-01T00:00:00.000Z', 1200, categories.diningOut),
+        expense('2026-06-02T00:00:00.000Z', 800, categories.diningOut),
+        expense('2026-06-03T00:00:00.000Z', 3000, categories.rent),
+      ],
+      { grouping: 'category', range: 'all' },
+    )
+
+    expect(
+      stats.categories.find((category) => category.key === '8'),
+    ).toMatchObject({
+      amount: 2000,
+      expenseAmount: 2000,
+    })
+    expect(
+      stats.categories.find((category) => category.key === '18')?.expenseAmount,
+    ).toBe(3000)
+  })
+
+  it('sorts months chronologically and fills empty months in range', () => {
+    const stats = getMonthlyCategorySpending(
+      [
+        expense('2026-01-15T00:00:00.000Z', 1200),
+        expense('2026-03-15T00:00:00.000Z', 800),
+      ],
+      { range: 'all' },
+    )
+
+    expect(stats.months.map((month) => month.key)).toEqual([
+      '2026-01',
+      '2026-02',
+      '2026-03',
+    ])
+    expect(stats.months[1]?.expenseAmount).toBe(0)
+  })
+
+  it('uses the selected numeric range ending at the latest spending month', () => {
+    const stats = getMonthlyCategorySpending(
+      [
+        expense('2026-01-15T00:00:00.000Z', 1200),
+        expense('2026-06-15T00:00:00.000Z', 800),
+      ],
+      { range: '3' },
+    )
+
+    expect(stats.months.map((month) => month.key)).toEqual([
+      '2026-04',
+      '2026-05',
+      '2026-06',
+    ])
+  })
+
+  it('supports category group and detailed category modes', () => {
+    const expenses = [
+      expense('2026-06-01T00:00:00.000Z', 1200, categories.diningOut),
+      expense('2026-06-02T00:00:00.000Z', 800, categories.groceries),
+    ]
+
+    const groupedStats = getMonthlyCategorySpending(expenses, {
+      grouping: 'categoryGroup',
+      range: 'all',
+    })
+    const detailedStats = getMonthlyCategorySpending(expenses, {
+      grouping: 'category',
+      range: 'all',
+    })
+
+    expect(groupedStats.categories).toMatchObject([
+      { key: 'Food and Drink', expenseAmount: 2000 },
+    ])
+    expect(
+      detailedStats.categories.map((category) => category.key).sort(),
+    ).toEqual(['8', '9'])
+  })
+})

--- a/src/lib/monthly-spending.ts
+++ b/src/lib/monthly-spending.ts
@@ -45,7 +45,6 @@ export type MonthlyCategorySpending = {
   months: MonthlySpendingMonth[]
   categories: MonthlySpendingCategory[]
   maxExpenseAmount: number
-  highlightedMonthKey?: string
 }
 
 type MutableMonthlySpendingCategory = MonthlySpendingCategory
@@ -123,16 +122,10 @@ export function getMonthlyCategorySpending(
     0,
     ...sortedMonths.map((month) => month.expenseAmount),
   )
-  const currentMonthKey = getMonthKeyFromDate(new Date())
-  const highlightedMonthKey = months.has(currentMonthKey)
-    ? currentMonthKey
-    : sortedMonths.at(-1)?.key
-
   return {
     months: sortedMonths,
     categories: sortedCategories,
     maxExpenseAmount,
-    highlightedMonthKey,
   }
 }
 

--- a/src/lib/monthly-spending.ts
+++ b/src/lib/monthly-spending.ts
@@ -1,0 +1,254 @@
+export const monthlySpendingRangeOptions = ['3', '6', '12', 'all'] as const
+export const monthlySpendingGroupingOptions = [
+  'categoryGroup',
+  'category',
+] as const
+
+export type MonthlySpendingRange = (typeof monthlySpendingRangeOptions)[number]
+export type MonthlySpendingGrouping =
+  (typeof monthlySpendingGroupingOptions)[number]
+
+type ExpenseCategory = {
+  id: number
+  grouping: string
+  name: string
+}
+
+export type MonthlySpendingExpense = {
+  amount: number
+  category: ExpenseCategory | null
+  expenseDate: Date
+  isReimbursement: boolean
+}
+
+export type MonthlySpendingCategory = {
+  key: string
+  categoryId: number | null
+  grouping: string
+  name: string
+  amount: number
+  expenseAmount: number
+  incomeAmount: number
+}
+
+export type MonthlySpendingMonth = {
+  key: string
+  year: number
+  month: number
+  amount: number
+  expenseAmount: number
+  incomeAmount: number
+  categories: MonthlySpendingCategory[]
+}
+
+export type MonthlyCategorySpending = {
+  months: MonthlySpendingMonth[]
+  categories: MonthlySpendingCategory[]
+  maxExpenseAmount: number
+  highlightedMonthKey?: string
+}
+
+type MutableMonthlySpendingCategory = MonthlySpendingCategory
+
+type MutableMonthlySpendingMonth = Omit<MonthlySpendingMonth, 'categories'> & {
+  categories: Map<string, MutableMonthlySpendingCategory>
+}
+
+export function getMonthlyCategorySpending(
+  expenses: MonthlySpendingExpense[],
+  options: {
+    grouping?: MonthlySpendingGrouping
+    range?: MonthlySpendingRange
+  } = {},
+): MonthlyCategorySpending {
+  const grouping = options.grouping ?? 'categoryGroup'
+  const range = options.range ?? '6'
+  const expensesForStats = expenses.filter(
+    (expense) => !expense.isReimbursement,
+  )
+
+  if (expensesForStats.length === 0) {
+    return { months: [], categories: [], maxExpenseAmount: 0 }
+  }
+
+  const expenseMonthKeys = expensesForStats.map((expense) =>
+    getMonthKeyFromDate(expense.expenseDate),
+  )
+  const firstExpenseMonthKey = expenseMonthKeys.reduce((first, monthKey) =>
+    monthKey < first ? monthKey : first,
+  )
+  const lastExpenseMonthKey = expenseMonthKeys.reduce((last, monthKey) =>
+    monthKey > last ? monthKey : last,
+  )
+
+  const lastMonth = getMonthPartsFromKey(lastExpenseMonthKey)
+  const firstMonth =
+    range === 'all'
+      ? getMonthPartsFromKey(firstExpenseMonthKey)
+      : addMonths(lastMonth.year, lastMonth.month, -Number(range) + 1)
+  const monthKeys = getMonthKeysBetween(firstMonth, lastMonth)
+  const months = new Map<string, MutableMonthlySpendingMonth>()
+  const categoryTotals = new Map<string, MutableMonthlySpendingCategory>()
+
+  for (const monthKey of monthKeys) {
+    const { year, month } = getMonthPartsFromKey(monthKey)
+    months.set(monthKey, {
+      key: monthKey,
+      year,
+      month,
+      amount: 0,
+      expenseAmount: 0,
+      incomeAmount: 0,
+      categories: new Map(),
+    })
+  }
+
+  for (const expense of expensesForStats) {
+    const month = months.get(getMonthKeyFromDate(expense.expenseDate))
+    if (!month) continue
+
+    const category = getCategoryForGrouping(expense.category, grouping)
+    addAmount(month, category, expense.amount)
+    addAmountToCategoryTotals(categoryTotals, category, expense.amount)
+  }
+
+  const sortedMonths = Array.from(months.values()).map(
+    ({ categories, ...month }) => ({
+      ...month,
+      categories: sortCategories(Array.from(categories.values())),
+    }),
+  )
+  const sortedCategories = sortCategories(Array.from(categoryTotals.values()))
+  const maxExpenseAmount = Math.max(
+    0,
+    ...sortedMonths.map((month) => month.expenseAmount),
+  )
+  const currentMonthKey = getMonthKeyFromDate(new Date())
+  const highlightedMonthKey = months.has(currentMonthKey)
+    ? currentMonthKey
+    : sortedMonths.at(-1)?.key
+
+  return {
+    months: sortedMonths,
+    categories: sortedCategories,
+    maxExpenseAmount,
+    highlightedMonthKey,
+  }
+}
+
+function addAmount(
+  month: MutableMonthlySpendingMonth,
+  category: MonthlySpendingCategory,
+  amount: number,
+) {
+  month.amount += amount
+  month.expenseAmount += Math.max(amount, 0)
+  month.incomeAmount += Math.min(amount, 0)
+
+  const monthCategory = getOrCreateCategory(month.categories, category)
+  addAmountToCategory(monthCategory, amount)
+}
+
+function addAmountToCategoryTotals(
+  categoryTotals: Map<string, MutableMonthlySpendingCategory>,
+  category: MonthlySpendingCategory,
+  amount: number,
+) {
+  const categoryTotal = getOrCreateCategory(categoryTotals, category)
+  addAmountToCategory(categoryTotal, amount)
+}
+
+function getOrCreateCategory(
+  categories: Map<string, MutableMonthlySpendingCategory>,
+  category: MonthlySpendingCategory,
+) {
+  if (!categories.has(category.key)) {
+    categories.set(category.key, { ...category })
+  }
+  return categories.get(category.key) as MutableMonthlySpendingCategory
+}
+
+function addAmountToCategory(
+  category: MutableMonthlySpendingCategory,
+  amount: number,
+) {
+  category.amount += amount
+  category.expenseAmount += Math.max(amount, 0)
+  category.incomeAmount += Math.min(amount, 0)
+}
+
+function getCategoryForGrouping(
+  category: ExpenseCategory | null,
+  grouping: MonthlySpendingGrouping,
+): MonthlySpendingCategory {
+  const safeCategory = category ?? {
+    id: 0,
+    grouping: 'Uncategorized',
+    name: 'General',
+  }
+
+  if (grouping === 'categoryGroup') {
+    return {
+      key: safeCategory.grouping,
+      categoryId: null,
+      grouping: safeCategory.grouping,
+      name: safeCategory.grouping,
+      amount: 0,
+      expenseAmount: 0,
+      incomeAmount: 0,
+    }
+  }
+
+  return {
+    key: String(safeCategory.id),
+    categoryId: safeCategory.id,
+    grouping: safeCategory.grouping,
+    name: safeCategory.name,
+    amount: 0,
+    expenseAmount: 0,
+    incomeAmount: 0,
+  }
+}
+
+function sortCategories(categories: MonthlySpendingCategory[]) {
+  return categories.sort((categoryA, categoryB) => {
+    const amountDifference = categoryB.expenseAmount - categoryA.expenseAmount
+    if (amountDifference !== 0) return amountDifference
+    return categoryA.key.localeCompare(categoryB.key)
+  })
+}
+
+function getMonthKeyFromDate(date: Date) {
+  return getMonthKey(date.getUTCFullYear(), date.getUTCMonth())
+}
+
+function getMonthKey(year: number, month: number) {
+  return `${year}-${String(month + 1).padStart(2, '0')}`
+}
+
+function getMonthPartsFromKey(monthKey: string) {
+  const [year, month] = monthKey.split('-').map(Number)
+  return { year, month: month - 1 }
+}
+
+function addMonths(year: number, month: number, monthsToAdd: number) {
+  const date = new Date(Date.UTC(year, month + monthsToAdd, 1))
+  return { year: date.getUTCFullYear(), month: date.getUTCMonth() }
+}
+
+function getMonthKeysBetween(
+  start: { year: number; month: number },
+  end: { year: number; month: number },
+) {
+  const monthKeys: string[] = []
+  let current = start
+
+  while (
+    getMonthKey(current.year, current.month) <= getMonthKey(end.year, end.month)
+  ) {
+    monthKeys.push(getMonthKey(current.year, current.month))
+    current = addMonths(current.year, current.month, 1)
+  }
+
+  return monthKeys
+}

--- a/src/trpc/routers/groups/stats/get.procedure.ts
+++ b/src/trpc/routers/groups/stats/get.procedure.ts
@@ -1,4 +1,5 @@
 import { getGroupExpenses } from '@/lib/api'
+import { getBalanceTimeline } from '@/lib/balance-timeline'
 import {
   getMonthlyCategorySpending,
   monthlySpendingGroupingOptions,
@@ -38,6 +39,9 @@ export const getGroupStatsProcedure = baseProcedure
         grouping: monthlySpendingGrouping,
         range: monthlySpendingRange,
       })
+      const balanceTimeline = getBalanceTimeline(expenses, {
+        range: monthlySpendingRange,
+      })
 
       const totalParticipantSpendings =
         participantId !== undefined
@@ -53,6 +57,7 @@ export const getGroupStatsProcedure = baseProcedure
         totalParticipantSpendings,
         totalParticipantShare,
         monthlyCategorySpending,
+        balanceTimeline,
       }
     },
   )

--- a/src/trpc/routers/groups/stats/get.procedure.ts
+++ b/src/trpc/routers/groups/stats/get.procedure.ts
@@ -1,5 +1,10 @@
 import { getGroupExpenses } from '@/lib/api'
 import {
+  getMonthlyCategorySpending,
+  monthlySpendingGroupingOptions,
+  monthlySpendingRangeOptions,
+} from '@/lib/monthly-spending'
+import {
   getTotalActiveUserPaidFor,
   getTotalActiveUserShare,
   getTotalGroupSpending,
@@ -12,24 +17,42 @@ export const getGroupStatsProcedure = baseProcedure
     z.object({
       groupId: z.string().min(1),
       participantId: z.string().optional(),
+      monthlySpendingGrouping: z
+        .enum(monthlySpendingGroupingOptions)
+        .default('categoryGroup'),
+      monthlySpendingRange: z.enum(monthlySpendingRangeOptions).default('6'),
     }),
   )
-  .query(async ({ input: { groupId, participantId } }) => {
-    const expenses = await getGroupExpenses(groupId)
-    const totalGroupSpendings = getTotalGroupSpending(expenses)
+  .query(
+    async ({
+      input: {
+        groupId,
+        participantId,
+        monthlySpendingGrouping,
+        monthlySpendingRange,
+      },
+    }) => {
+      const expenses = await getGroupExpenses(groupId)
+      const totalGroupSpendings = getTotalGroupSpending(expenses)
+      const monthlyCategorySpending = getMonthlyCategorySpending(expenses, {
+        grouping: monthlySpendingGrouping,
+        range: monthlySpendingRange,
+      })
 
-    const totalParticipantSpendings =
-      participantId !== undefined
-        ? getTotalActiveUserPaidFor(participantId, expenses)
-        : undefined
-    const totalParticipantShare =
-      participantId !== undefined
-        ? getTotalActiveUserShare(participantId, expenses)
-        : undefined
+      const totalParticipantSpendings =
+        participantId !== undefined
+          ? getTotalActiveUserPaidFor(participantId, expenses)
+          : undefined
+      const totalParticipantShare =
+        participantId !== undefined
+          ? getTotalActiveUserShare(participantId, expenses)
+          : undefined
 
-    return {
-      totalGroupSpendings,
-      totalParticipantSpendings,
-      totalParticipantShare,
-    }
-  })
+      return {
+        totalGroupSpendings,
+        totalParticipantSpendings,
+        totalParticipantShare,
+        monthlyCategorySpending,
+      }
+    },
+  )


### PR DESCRIPTION

## Summary
Adds lightweight monthly spending visuals to the Stats page:
- Monthly stacked spending by category/category group
- Range category breakdown
- Balance timeline showing participant balances and reimbursements over time

The charts use existing expense/category data and custom HTML/CSS/SVG rendering. No chart dependency, persisted settings, Prisma fields, or migrations are added.

## Details
- Adds category/group filtering controls, range controls, chart orientation controls, and rounded amount display.
- Excludes reimbursements from category spending totals.
- Uses UTC date parts for month/day grouping to avoid DATE timezone shifts.
- Adds a balance timeline with reimbursement markers, optional category markers, and stack-order control.
- Keeps visuals live through the existing stats query refresh path.

## Testing
- `pnpm test`
- `pnpm run check-types`
- `pnpm run lint`
- targeted Prettier check on touched files



## Transparency note
This is my third request using Codex for this kind of contribution. Happy to iterate to make sure it's up to standards

## Reviewer Demo
Screenshots attached here. Any demo group/data should be fake and provided outside the deployed codebase.
- **Monthly Spending** is traditional stacked bar chart with expenses by category
- **Balance Timeline** is a stacked column chart showing outstanding balances ("Sam Owes" "Alex Is Owed") over the timeline of the group. I'm a data scientist (Masters in Statistics) so this is my best visual yet but I'm happy to iterate. I already went through hundreds of iterations to intuitively show the complexity of these interactions. 
 
<img width="759" height="680" alt="Monthly Spending" src="https://github.com/user-attachments/assets/45981652-f607-42b9-bb15-391c24a4a489" />
<img width="759" height="740" alt="Balance Timeline" src="https://github.com/user-attachments/assets/2057eef2-a506-46d1-9cec-e03f58458678" />

