### PR TITLE
fix: use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SPLIIT_APP_NAME=$(node -p -e "require('./package.json').name")
 SPLIIT_VERSION=$(node -p -e "require('./package.json').version")

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 


### PR DESCRIPTION
Improve compatibility by using /usr/bin/env bash instead of /bin/bash.