### PR TITLE
chore: reduce OpenAI vision costs for receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,14 @@ S3_UPLOAD_ENDPOINT=http://localhost:9000
 
 ### Create expense from receipt
 
-You can offer users to create expense by uploading a receipt. This feature relies on [OpenAI GPT-4 with Vision](https://platform.openai.com/docs/guides/vision) and a public S3 storage endpoint.
+You can offer users to create expense by uploading a receipt. This feature relies on an OpenAI vision-capable model ([GPT-5 nano](https://platform.openai.com/docs/models) by default) and a public S3 storage endpoint.
+
+To keep API costs low, receipt images are downscaled/compressed in the browser before upload, and the vision request uses `detail: "low"`.
 
 To enable the feature:
 
 - You must enable expense documents feature as well (see section above). That might change in the future, but for now we need to store images to make receipt scanning work.
-- Subscribe to OpenAI API and get access to GPT 4 with Vision (you might need to buy credits in advance).
+- Subscribe to the OpenAI API (you might need to buy credits in advance).
 - Update your environment variables with appropriate values:
 
 ```.env
@@ -115,7 +117,7 @@ OPENAI_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 ### Deduce category from title
 
-You can offer users to automatically deduce the expense category from the title. Since this feature relies on a OpenAI subscription, follow the signup instructions above and configure the following environment variables:
+You can offer users to automatically deduce the expense category from the title. This also uses OpenAI (GPT-5 nano by default). Configure:
 
 ```.env
 NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT=true

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
@@ -13,6 +13,8 @@ export async function extractExpenseInformationFromImage(imageUrl: string) {
 
   const body: ChatCompletionCreateParamsNonStreaming = {
     model: 'gpt-5-nano',
+    // Short CSV reply: amount,categoryId,date,title
+    max_tokens: 64,
     messages: [
       {
         role: 'user',
@@ -33,7 +35,13 @@ export async function extractExpenseInformationFromImage(imageUrl: string) {
       },
       {
         role: 'user',
-        content: [{ type: 'image_url', image_url: { url: imageUrl } }],
+        content: [
+          {
+            type: 'image_url',
+            // low detail ≈ fixed cheap token cost; enough for receipt OCR
+            image_url: { url: imageUrl, detail: 'low' },
+          },
+        ],
       },
     ],
   }

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
@@ -26,6 +26,7 @@ import {
 import { ToastAction } from '@/components/ui/toast'
 import { useToast } from '@/components/ui/use-toast'
 import { useMediaQuery } from '@/lib/hooks'
+import { compressReceiptImage } from '@/lib/compress-receipt-image'
 import {
   formatCurrency,
   formatDate,
@@ -109,12 +110,14 @@ function ReceiptDialogContent() {
     const upload = async () => {
       try {
         setPending(true)
+        console.log('Compressing image…')
+        const compressed = await compressReceiptImage(file)
         console.log('Uploading image…')
-        let { url } = await uploadToS3(file)
+        let { url } = await uploadToS3(compressed)
         console.log('Extracting information from receipt…')
         const { amount, categoryId, date, title } =
           await extractExpenseInformationFromImage(url)
-        const { width, height } = await getImageData(file)
+        const { width, height } = await getImageData(compressed)
         setReceiptInfo({ amount, categoryId, date, title, url, width, height })
       } catch (err) {
         console.error(err)

--- a/src/components/expense-form-actions.tsx
+++ b/src/components/expense-form-actions.tsx
@@ -19,9 +19,9 @@ export async function extractCategoryFromTitle(description: string) {
   const categories = await getCategories()
 
   const body: ChatCompletionCreateParamsNonStreaming = {
-    model: 'gpt-3.5-turbo',
+    model: 'gpt-5-nano',
     temperature: 0.1, // try to be highly deterministic so that each distinct title may lead to the same category every time
-    max_tokens: 1, // category ids are unlikely to go beyond ~4 digits so limit possible abuse
+    max_tokens: 4, // category ids are small integers; keep output cheap
     messages: [
       {
         role: 'system',

--- a/src/lib/compress-receipt-image.ts
+++ b/src/lib/compress-receipt-image.ts
@@ -1,0 +1,43 @@
+const MAX_DIMENSION = 1280
+const JPEG_QUALITY = 0.75
+
+/**
+ * Downscale and recompress a receipt image in the browser to reduce OpenAI
+ * vision token usage (and S3 upload size) without hurting OCR much.
+ */
+export async function compressReceiptImage(file: File): Promise<File> {
+  if (!file.type.startsWith('image/')) return file
+
+  const bitmap = await createImageBitmap(file)
+  try {
+    const scale = Math.min(
+      1,
+      MAX_DIMENSION / Math.max(bitmap.width, bitmap.height),
+    )
+    const width = Math.round(bitmap.width * scale)
+    const height = Math.round(bitmap.height * scale)
+
+    // Already small enough and not a huge PNG/JPEG — skip re-encode.
+    if (scale === 1 && file.size <= 400 * 1024) {
+      return file
+    }
+
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return file
+
+    ctx.drawImage(bitmap, 0, 0, width, height)
+
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, 'image/jpeg', JPEG_QUALITY),
+    )
+    if (!blob || blob.size >= file.size) return file
+
+    const baseName = file.name.replace(/\.[^.]+$/, '') || 'receipt'
+    return new File([blob], `${baseName}.jpg`, { type: 'image/jpeg' })
+  } finally {
+    bitmap.close()
+  }
+}


### PR DESCRIPTION
﻿## Summary
- Compress/downscale receipt images in the browser before S3 upload to cut vision tokens and bandwidth.
- Send receipt images with `detail: "low"` and cap `max_tokens` on extraction responses.
- Switch title→category extraction from `gpt-3.5-turbo` to `gpt-5-nano`.
- Update README: document GPT-5 nano (no longer GPT-4 Vision) and the cost-saving behavior.

## Test plan
- [ ] Enable `NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT` and upload a receipt photo; confirm amount/date/title/category still extract correctly.
- [ ] Upload a large photo (>2MB / high res) and confirm it is compressed before upload (smaller file / JPEG).
- [ ] Enable `NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT` and verify category suggestion from title still works.
- [ ] Confirm README describes GPT-5 nano and cost notes accurately.
