### PR TITLE
Include notes and history in JSON export

### DIFF
--- a/src/app/groups/[groupId]/expenses/export/json/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/json/route.ts
@@ -12,10 +12,12 @@ export async function GET(
     select: {
       id: true,
       name: true,
+      information: true,
       currency: true,
       currencyCode: true,
       expenses: {
         select: {
+          id: true,
           createdAt: true,
           expenseDate: true,
           title: true,
@@ -29,10 +31,22 @@ export async function GET(
           isReimbursement: true,
           splitMode: true,
           recurrenceRule: true,
+          notes: true,
         },
         orderBy: [{ expenseDate: 'asc' }, { createdAt: 'asc' }],
       },
       participants: { select: { id: true, name: true } },
+      activities: {
+        select: {
+          id: true,
+          time: true,
+          activityType: true,
+          participantId: true,
+          expenseId: true,
+          data: true,
+        },
+        orderBy: { time: 'asc' },
+      },
     },
   })
   if (!group)


### PR DESCRIPTION
## Summary
- Extends the JSON group export to include expense `notes` (and expense `id` for stable references), group `information`, and the full `activities` history.
- Addresses https://github.com/spliit-app/spliit/issues/545 (Notes + History). Attachments and recurring-expense links remain out of scope for this change.

## Test plan
- [x] Open a group with expense notes, group information text, and activity history
- [x] Use Export → JSON and confirm the file includes `information`, each expense’s `id`/`notes`, and an `activities` array ordered by `time`
- [x] Confirm existing fields (participants, amounts, paidFor, etc.) are unchanged
