### PR TITLE
Add pluggable analytics with console and Plausible providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@ POSTGRES_PRISMA_URL=postgresql://postgres:1234@localhost
 POSTGRES_URL_NON_POOLING=postgresql://postgres:1234@localhost
 
 NEXT_PUBLIC_DEFAULT_CURRENCY_CODE=""
+
+# Analytics is disabled unless a provider is selected. See the README.
+# ANALYTICS_PROVIDER=console
+# ANALYTICS_PROVIDER=plausible
+# PLAUSIBLE_DOMAIN=your-domain.com

--- a/README.md
+++ b/README.md
@@ -122,6 +122,58 @@ NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT=true
 OPENAI_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
+### Analytics
+
+Spliit can report anonymous usage events to an analytics service. **It is disabled by default**: nothing is loaded and nothing is sent unless you select a provider.
+
+Select one with `ANALYTICS_PROVIDER`. The variables are read on the server, so a single Docker image can be configured when the container starts.
+
+#### `console` — see what would be reported
+
+Logs every event to the browser console and sends nothing anywhere. Useful while developing, and the shortest example of what a provider looks like.
+
+```.env
+ANALYTICS_PROVIDER=console
+```
+
+#### `plausible`
+
+Reports to [Plausible](https://plausible.io), a privacy-friendly, cookie-free analytics service. No extra dependency is installed: the provider is a script tag and a function call.
+
+```.env
+ANALYTICS_PROVIDER=plausible
+PLAUSIBLE_DOMAIN=your-domain.com
+```
+
+For a self-hosted Plausible instance, point at it with `PLAUSIBLE_HOST`:
+
+```.env
+PLAUSIBLE_HOST=https://plausible.your-domain.com
+```
+
+Ad blockers drop requests to known analytics hosts. To avoid that, serve the script and the event endpoint from your own origin by adding [rewrites](https://nextjs.org/docs/app/api-reference/config/next-config-js/rewrites) in `next.config.mjs` and pointing the provider at them:
+
+```.env
+PLAUSIBLE_SCRIPT_URL=/js/script.manual.js
+PLAUSIBLE_API_URL=/proxy/api/event
+```
+
+#### What is reported
+
+Pageviews for a handful of pages, and one event per significant action: creating and updating a group, creating, updating and deleting an expense, attaching a document, scanning a receipt, and exporting expenses.
+
+**Group and expense IDs are never sent.** They are the capability to read someone's group, so `/groups/<id>/expenses` is reported as `/groups/[groupId]/expenses`. Anonymization happens in one place, `anonymizePath` in `src/lib/analytics/`, between the call sites and every provider, and the event types forbid properties that are not explicitly declared — so leaking an ID is a compile error rather than a review question.
+
+Pages are tracked explicitly, with `<TrackPage path="…" />`. A new route reports nothing until someone adds it, which keeps that a deliberate decision.
+
+This is unrelated to the group activity log (the _Activity_ tab), which is stored in your own database and is a product feature rather than analytics.
+
+#### Adding a provider
+
+Providers live in `src/lib/analytics/providers/`. Copy `console.tsx`, then register the new one in three places: `provider-ids.ts`, `registry.ts`, and `config.ts` (to map its environment variables to options). The last two are type-checked against the first, so `npm run check-types` tells you exactly what is missing.
+
+A provider supplies a transport — where events go — and optionally a `Script` component if it needs to load an SDK.
+
 ## License
 
 MIT, see [LICENSE](./LICENSE).

--- a/container.env.example
+++ b/container.env.example
@@ -4,3 +4,8 @@ POSTGRES_PASSWORD=1234
 # app
 POSTGRES_PRISMA_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db
 POSTGRES_URL_NON_POOLING=postgresql://postgres:${POSTGRES_PASSWORD}@db
+
+# analytics
+# Disabled unless a provider is selected. See the README.
+# ANALYTICS_PROVIDER=plausible
+# PLAUSIBLE_DOMAIN=your-domain.com

--- a/scripts/build.env
+++ b/scripts/build.env
@@ -20,3 +20,12 @@ S3_UPLOAD_ENDPOINT=s3://minio.example.com
 NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT=false
 OPENAI_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT=false
+
+# app-analytics
+# Left blank on purpose: analytics is disabled unless a provider is selected,
+# and it is configured at container start, not baked into the image.
+ANALYTICS_PROVIDER=
+PLAUSIBLE_DOMAIN=
+PLAUSIBLE_HOST=
+PLAUSIBLE_SCRIPT_URL=
+PLAUSIBLE_API_URL=

--- a/src/app/groups/[groupId]/balances/balances-and-reimbursements.tsx
+++ b/src/app/groups/[groupId]/balances/balances-and-reimbursements.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { TrackPage } from '@/lib/analytics/track-page'
 import { getCurrencyFromGroup } from '@/lib/utils'
 import { trpc } from '@/trpc/client'
 import { useTranslations } from 'next-intl'
@@ -36,6 +37,7 @@ export default function BalancesAndReimbursements() {
 
   return (
     <>
+      <TrackPage path={`/groups/${groupId}/balances`} />
       <Card className="mb-4">
         <CardHeader>
           <CardTitle>{t('title')}</CardTitle>

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/components/ui/drawer'
 import { ToastAction } from '@/components/ui/toast'
 import { useToast } from '@/components/ui/use-toast'
+import { useAnalytics } from '@/lib/analytics/context'
 import { useMediaQuery } from '@/lib/hooks'
 import {
   formatCurrency,
@@ -78,7 +79,8 @@ export function CreateFromReceiptButton() {
 }
 
 function ReceiptDialogContent() {
-  const { group } = useCurrentGroup()
+  const { groupId, group } = useCurrentGroup()
+  const sendEvent = useAnalytics()
   const { data: categoriesData } = trpc.categories.list.useQuery()
   const categories = categoriesData?.categories
 
@@ -107,6 +109,10 @@ function ReceiptDialogContent() {
     }
 
     const upload = async () => {
+      sendEvent(
+        { event: 'expense: scan receipt', props: {} },
+        `/groups/${groupId}/expenses`,
+      )
       try {
         setPending(true)
         console.log('Uploading image…')
@@ -247,6 +253,10 @@ function ReceiptDialogContent() {
           disabled={pending || !receiptInfo}
           onClick={() => {
             if (!receiptInfo || !group) return
+            sendEvent(
+              { event: 'expense: create from receipt', props: {} },
+              `/groups/${groupId}/expenses`,
+            )
             router.push(
               `/groups/${group.id}/expenses/create?amount=${
                 receiptInfo.amount

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -34,6 +34,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Locale } from '@/i18n/request'
+import { useAnalytics } from '@/lib/analytics/context'
 import { randomId } from '@/lib/api'
 import { defaultCurrencyList, getCurrency } from '@/lib/currency'
 import { RuntimeFeatureFlags } from '@/lib/featureFlags'
@@ -270,8 +271,14 @@ export function ExpenseForm({
   })
   const [isCategoryLoading, setCategoryLoading] = useState(false)
   const activeUserId = useActiveUser(group.id)
+  const sendEvent = useAnalytics()
 
   const submit = async (values: ExpenseFormValues) => {
+    sendEvent(
+      { event: expense ? 'expense: update' : 'expense: create', props: {} },
+      `/groups/${group.id}/expenses`,
+    )
+
     await persistDefaultSplittingOptions(group.id, values)
 
     // Store monetary amounts in minor units (cents)
@@ -1257,6 +1264,12 @@ export function ExpenseForm({
                   <ExpenseDocumentsInput
                     documents={field.value}
                     updateDocuments={field.onChange}
+                    onDocumentAttached={() =>
+                      sendEvent(
+                        { event: 'expense: attach document', props: {} },
+                        `/groups/${group.id}/expenses`,
+                      )
+                    }
                   />
                 )}
               />
@@ -1271,7 +1284,13 @@ export function ExpenseForm({
           </SubmitButton>
           {!isCreate && onDelete && (
             <DeletePopup
-              onDelete={() => onDelete(activeUserId ?? undefined)}
+              onDelete={async () => {
+                sendEvent(
+                  { event: 'expense: delete', props: {} },
+                  `/groups/${group.id}/expenses`,
+                )
+                await onDelete(activeUserId ?? undefined)
+              }}
             ></DeletePopup>
           )}
           <Button variant="ghost" asChild>

--- a/src/app/groups/[groupId]/expenses/page.client.tsx
+++ b/src/app/groups/[groupId]/expenses/page.client.tsx
@@ -12,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { TrackPage } from '@/lib/analytics/track-page'
 import { Plus } from 'lucide-react'
 import { Metadata } from 'next'
 import { useTranslations } from 'next-intl'
@@ -34,6 +35,7 @@ export default function GroupExpensesPageClient({
 
   return (
     <>
+      <TrackPage path={`/groups/${groupId}/expenses`} />
       <Card className="mb-4 rounded-none -mx-4 border-x-0 sm:border-x sm:rounded-lg sm:mx-0">
         <div className="flex flex-1">
           <CardHeader className="flex-1 p-4 sm:p-6">

--- a/src/app/groups/[groupId]/export-button.tsx
+++ b/src/app/groups/[groupId]/export-button.tsx
@@ -7,12 +7,19 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { useAnalytics } from '@/lib/analytics/context'
 import { Download, FileDown, FileJson } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 
 export default function ExportButton({ groupId }: { groupId: string }) {
   const t = useTranslations('Expenses')
+  const sendEvent = useAnalytics()
+  const trackExport = (format: 'csv' | 'json') =>
+    sendEvent(
+      { event: 'group: export expenses', props: { format } },
+      `/groups/${groupId}/expenses`,
+    )
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -27,6 +34,7 @@ export default function ExportButton({ groupId }: { groupId: string }) {
             href={`/groups/${groupId}/expenses/export/json`}
             target="_blank"
             title={t('exportJson')}
+            onClick={() => trackExport('json')}
           >
             <div className="flex items-center gap-2">
               <FileJson className="w-4 h-4" />
@@ -40,6 +48,7 @@ export default function ExportButton({ groupId }: { groupId: string }) {
             href={`/groups/${groupId}/expenses/export/csv`}
             target="_blank"
             title={t('exportCsv')}
+            onClick={() => trackExport('csv')}
           >
             <div className="flex items-center gap-2">
               <FileDown className="w-4 h-4" />

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -1,4 +1,5 @@
 import { RecentGroupList } from '@/app/groups/recent-group-list'
+import { TrackPage } from '@/lib/analytics/track-page'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -6,5 +7,10 @@ export const metadata: Metadata = {
 }
 
 export default async function GroupsPage() {
-  return <RecentGroupList />
+  return (
+    <>
+      <TrackPage path="/groups" />
+      <RecentGroupList />
+    </>
+  )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,8 @@ import { ThemeProvider } from '@/components/theme-provider'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { Button } from '@/components/ui/button'
 import { Toaster } from '@/components/ui/toaster'
+import { Analytics } from '@/lib/analytics/analytics'
+import { getAnalyticsConfig } from '@/lib/analytics/config'
 import { env } from '@/lib/env'
 import { TRPCProvider } from '@/trpc/client'
 import type { Metadata, Viewport } from 'next'
@@ -154,22 +156,25 @@ export default async function RootLayout({
 }) {
   const locale = await getLocale()
   const messages = await getMessages()
+  const analyticsConfig = await getAnalyticsConfig()
   return (
     <html lang={locale} suppressHydrationWarning>
       <ApplePwaSplash icon="/logo-with-text.png" color="#027756" />
       <body className="min-h-[100dvh] flex flex-col items-stretch bg-slate-50 bg-opacity-30 dark:bg-background">
         <NextIntlClientProvider messages={messages}>
-          <ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-            <Suspense>
-              <ProgressBar />
-            </Suspense>
-            <Content>{children}</Content>
-          </ThemeProvider>
+          <Analytics config={analyticsConfig}>
+            <ThemeProvider
+              attribute="class"
+              defaultTheme="system"
+              enableSystem
+              disableTransitionOnChange
+            >
+              <Suspense>
+                <ProgressBar />
+              </Suspense>
+              <Content>{children}</Content>
+            </ThemeProvider>
+          </Analytics>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { TrackPage } from '@/lib/analytics/track-page'
 import { Github } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
@@ -10,6 +11,7 @@ export default function HomePage() {
   const t = useTranslations()
   return (
     <main>
+      <TrackPage path="/" />
       <section className="py-16 md:py-24 lg:py-32">
         <div className="container flex max-w-screen-md flex-col items-center gap-4 text-center">
           <h1 className="!leading-none font-bold text-2xl sm:text-3xl md:text-4xl lg:text-5xl landing-header py-2">

--- a/src/components/expense-documents-input.tsx
+++ b/src/components/expense-documents-input.tsx
@@ -29,11 +29,17 @@ import { useEffect, useState } from 'react'
 type Props = {
   documents: ExpenseFormValues['documents']
   updateDocuments: (documents: ExpenseFormValues['documents']) => void
+  /** Called once per document successfully uploaded. */
+  onDocumentAttached?: () => void
 }
 
 const MAX_FILE_SIZE = 5 * 1024 ** 2
 
-export function ExpenseDocumentsInput({ documents, updateDocuments }: Props) {
+export function ExpenseDocumentsInput({
+  documents,
+  updateDocuments,
+  onDocumentAttached,
+}: Props) {
   const locale = useLocale()
   const t = useTranslations('ExpenseDocumentsInput')
   const [pending, setPending] = useState(false)
@@ -60,6 +66,7 @@ export function ExpenseDocumentsInput({ documents, updateDocuments }: Props) {
         if (!width || !height) throw new Error('Cannot get image dimensions')
         const { url } = await uploadToS3(file)
         updateDocuments([...documents, { id: randomId(), url, width, height }])
+        onDocumentAttached?.()
       } catch (err) {
         console.error(err)
         toast({

--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -31,6 +31,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Locale } from '@/i18n/request'
+import { useAnalytics } from '@/lib/analytics/context'
 import { getGroup } from '@/lib/api'
 import { defaultCurrencyList, getCurrency } from '@/lib/currency'
 import { GroupFormValues, groupFormSchema } from '@/lib/schemas'
@@ -86,6 +87,7 @@ export function GroupForm({
     name: 'participants',
     keyName: 'key',
   })
+  const sendEvent = useAnalytics()
 
   const [activeUser, setActiveUser] = useState<string | null>(null)
   useEffect(() => {
@@ -116,6 +118,14 @@ export function GroupForm({
     <Form {...form}>
       <form
         onSubmit={form.handleSubmit(async (values) => {
+          if (group) {
+            sendEvent(
+              { event: 'group: update', props: {} },
+              `/groups/${group.id}/edit`,
+            )
+          } else {
+            sendEvent({ event: 'group: create', props: {} }, `/groups`)
+          }
           await onSubmit(
             values,
             group?.participants.find((p) => p.name === activeUser)?.id ??

--- a/src/lib/analytics/analytics.tsx
+++ b/src/lib/analytics/analytics.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { analyticsProviders } from '@/lib/analytics/registry'
+import { AnalyticsConfig } from '@/lib/analytics/types'
+import { PropsWithChildren } from 'react'
+
+/**
+ * Mounts the configured analytics provider. Rendered by the root layout, which
+ * resolves the configuration on the server with `getAnalyticsConfig`.
+ *
+ * This component calls no hooks of its own, so the early return below is safe:
+ * each provider calls its own hooks unconditionally, inside a component whose
+ * identity never changes for the lifetime of the app.
+ */
+export function Analytics({
+  config,
+  children,
+}: PropsWithChildren<{ config: AnalyticsConfig }>) {
+  // Analytics is disabled unless a provider is selected. No context is
+  // installed, so `useAnalytics()` returns a no-op everywhere.
+  if (!config.provider) return <>{children}</>
+
+  const Provider = analyticsProviders[config.provider]
+  return <Provider options={config.options}>{children}</Provider>
+}

--- a/src/lib/analytics/anonymize-path.test.ts
+++ b/src/lib/analytics/anonymize-path.test.ts
@@ -1,0 +1,60 @@
+import { anonymizePath } from './anonymize-path'
+
+/**
+ * Made-up IDs, shaped like the real ones (21-character nanoid for groups, cuid
+ * for expenses). Never paste a real ID in here: this file is public.
+ */
+const GROUP_A = 'exampleGroupId0000000'
+const GROUP_B = 'anotherGroupId0000000'
+const GROUP_C = 'thirdGroupId000000000'
+const GROUP_D = 'fourthGroupId00000000'
+const EXPENSE = 'exampleExpenseId000000000'
+
+describe('anonymizePath', () => {
+  const cases: [path: string, expected: string][] = [
+    // Group IDs
+    [`/groups/${GROUP_A}`, '/groups/[groupId]'],
+    [`/groups/${GROUP_A}/expenses`, '/groups/[groupId]/expenses'],
+    [`/groups/${GROUP_B}/balances`, '/groups/[groupId]/balances'],
+    [`/groups/${GROUP_C}/edit`, '/groups/[groupId]/edit'],
+    [`/groups/${GROUP_D}/stats`, '/groups/[groupId]/stats'],
+
+    // Expense IDs
+    [
+      `/groups/${GROUP_A}/expenses/${EXPENSE}/edit`,
+      '/groups/[groupId]/expenses/[expenseId]/edit',
+    ],
+
+    // Static segments in an ID position are kept
+    ['/groups/create', '/groups/create'],
+    [`/groups/${GROUP_A}/expenses/create`, '/groups/[groupId]/expenses/create'],
+    [
+      `/groups/${GROUP_A}/expenses/export/csv`,
+      '/groups/[groupId]/expenses/export/csv',
+    ],
+    [
+      `/groups/${GROUP_A}/expenses/export/json`,
+      '/groups/[groupId]/expenses/export/json',
+    ],
+
+    // Query strings and hashes are preserved, and never scanned for IDs
+    [
+      `/groups/${GROUP_A}/expenses?ref=share`,
+      '/groups/[groupId]/expenses?ref=share',
+    ],
+    ['/groups/create?ref=share', '/groups/create?ref=share'],
+
+    // Paths without IDs are untouched
+    ['/', '/'],
+    ['/groups', '/groups'],
+  ]
+
+  test.each(cases)('%s → %s', (path, expected) => {
+    expect(anonymizePath(path)).toBe(expected)
+  })
+
+  it('is idempotent', () => {
+    const once = anonymizePath(`/groups/${GROUP_A}/expenses`)
+    expect(anonymizePath(once)).toBe(once)
+  })
+})

--- a/src/lib/analytics/anonymize-path.ts
+++ b/src/lib/analytics/anonymize-path.ts
@@ -1,0 +1,33 @@
+/**
+ * Segments that follow `/groups/` or `/expenses/` without being an identifier.
+ * Everything else in that position is a group or expense ID.
+ */
+const GROUP_ROUTES = new Set(['create'])
+const EXPENSE_ROUTES = new Set(['create', 'export'])
+
+/**
+ * Replaces group and expense IDs in a path with placeholders, so they are never
+ * sent to analytics. Those IDs are the capability to read someone's group, and
+ * they are unique per document, which also turns the pages report into thousands
+ * of one-visitor rows.
+ *
+ * `/groups/exampleGroupId0000000/expenses` → `/groups/[groupId]/expenses`
+ */
+export function anonymizePath(path: string): string {
+  const [pathname, ...rest] = path.split(/(?=[?#])/)
+  const segments = pathname.split('/')
+
+  return (
+    segments
+      .map((segment, index) => {
+        if (!segment) return segment
+        const parent = segments[index - 1]
+        if (parent === 'groups' && !GROUP_ROUTES.has(segment))
+          return '[groupId]'
+        if (parent === 'expenses' && !EXPENSE_ROUTES.has(segment))
+          return '[expenseId]'
+        return segment
+      })
+      .join('/') + rest.join('')
+  )
+}

--- a/src/lib/analytics/config.ts
+++ b/src/lib/analytics/config.ts
@@ -1,0 +1,31 @@
+'use server'
+
+import { AnalyticsConfig } from '@/lib/analytics/types'
+import { env } from '@/lib/env'
+import { match } from 'ts-pattern'
+
+/**
+ * Resolves the analytics configuration from the environment, on the server, and
+ * returns it as a plain object for the root layout to hand to `Analytics`.
+ *
+ * The layout is always rendered dynamically (next-intl reads cookies to pick a
+ * locale), so this runs per request: a single image can be configured when the
+ * container starts, rather than when it was built.
+ *
+ * Everything returned here is public — it is serialized into the HTML.
+ */
+export async function getAnalyticsConfig(): Promise<AnalyticsConfig> {
+  return match(env.ANALYTICS_PROVIDER)
+    .with(undefined, () => ({ provider: null, options: {} }))
+    .with('console', (provider) => ({ provider, options: {} }))
+    .with('plausible', (provider) => ({
+      provider,
+      options: {
+        domain: env.PLAUSIBLE_DOMAIN,
+        host: env.PLAUSIBLE_HOST,
+        scriptUrl: env.PLAUSIBLE_SCRIPT_URL,
+        apiUrl: env.PLAUSIBLE_API_URL,
+      },
+    }))
+    .exhaustive()
+}

--- a/src/lib/analytics/context.tsx
+++ b/src/lib/analytics/context.tsx
@@ -1,0 +1,70 @@
+import { anonymizePath } from '@/lib/analytics/anonymize-path'
+import {
+  AnalyticsProviderComponent,
+  AnalyticsProviderDefinition,
+  SendEvent,
+} from '@/lib/analytics/types'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+} from 'react'
+
+const AnalyticsContext = createContext<SendEvent | null>(null)
+
+/**
+ * Module-level constant, so that the disabled case is referentially stable too:
+ * see the comment about dependency arrays in `createAnalyticsProvider`.
+ */
+const noSendEvent: SendEvent = () => {}
+
+/**
+ * Unlike `useCurrentGroup`, this deliberately does not throw when there is no
+ * provider above it. Analytics is disabled by default, and call sites are
+ * expected to send events unconditionally; without a provider they no-op.
+ */
+export const useAnalytics = (): SendEvent =>
+  useContext(AnalyticsContext) ?? noSendEvent
+
+/**
+ * Builds the React component for a provider: injects its script, anonymizes and
+ * forwards events, and exposes `sendEvent` through the context.
+ */
+export function createAnalyticsProvider({
+  Script,
+  useTransport,
+}: AnalyticsProviderDefinition): AnalyticsProviderComponent {
+  return function AnalyticsProvider({ options, children }) {
+    const transport = useTransport(options)
+
+    // The transport is read through a ref so that `sendEvent` below can have an
+    // empty dependency array. `TrackPage` passes `sendEvent` to a `useEffect`
+    // dependency array, and group pages re-render on every tRPC refetch, so an
+    // identity that changed between renders would re-send the pageview every
+    // time. Keeping the indirection here means a provider cannot reintroduce
+    // that by returning a new function on each render.
+    const transportRef = useRef(transport)
+    useEffect(() => {
+      transportRef.current = transport
+    }, [transport])
+
+    const sendEvent = useCallback<SendEvent>(({ event, props }, path = '/') => {
+      // Anonymized here, once, between the call sites and every provider: no
+      // caller can leak an ID by passing a path built from `groupId`, and no
+      // provider has to remember to scrub it.
+      const url = `${window.location.origin}${anonymizePath(path)}`
+      transportRef.current(event, props, url)
+    }, [])
+
+    return (
+      <>
+        {Script && <Script options={options} />}
+        <AnalyticsContext.Provider value={sendEvent}>
+          {children}
+        </AnalyticsContext.Provider>
+      </>
+    )
+  }
+}

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,34 @@
+/**
+ * No properties at all. `{}` would not do: it accepts any object, so it would
+ * silently let a `groupId` through.
+ */
+export type NoProps = Record<string, never>
+
+// Group and expense IDs are deliberately absent from every event: they identify
+// a specific user's data, and they are unique per document, so they would only
+// ever produce single-visitor rows. Properties here must stay low-cardinality.
+type BaseAnalyticsEvent =
+  | { event: 'pageview'; props: NoProps }
+  | { event: 'group: create'; props: NoProps }
+  | { event: 'group: update'; props: NoProps }
+  | { event: 'group: export expenses'; props: { format: 'csv' | 'json' } }
+  | { event: 'expense: create'; props: NoProps }
+  | { event: 'expense: update'; props: NoProps }
+  | { event: 'expense: delete'; props: NoProps }
+  | { event: 'expense: attach document'; props: NoProps }
+  | { event: 'expense: scan receipt'; props: NoProps }
+  | { event: 'expense: create from receipt'; props: NoProps }
+
+/**
+ * Extension point for forks: replace `never` with your own events, e.g.
+ *
+ *     type CustomAnalyticsEvent =
+ *       | { event: 'news: open menu'; props: NoProps }
+ *       | { event: 'news: click news'; props: { news: string } }
+ *
+ * Keep it to this one declaration so rebases on upstream stay conflict-free:
+ * upstream only ever edits the union above.
+ */
+type CustomAnalyticsEvent = never
+
+export type AnalyticsEvent = BaseAnalyticsEvent | CustomAnalyticsEvent

--- a/src/lib/analytics/provider-ids.ts
+++ b/src/lib/analytics/provider-ids.ts
@@ -1,0 +1,12 @@
+/**
+ * The providers a deployment can select with the `ANALYTICS_PROVIDER` variable.
+ * Add yours here, then add the matching entry in `./registry` and the matching
+ * branch in `./config` — both are compiler-enforced, so `npm run check-types`
+ * will point at whatever is missing.
+ *
+ * This module is deliberately dependency-free: `src/lib/env.ts` imports it, and
+ * `env.ts` is pulled in by server-side scripts that must not load React.
+ */
+export const ANALYTICS_PROVIDER_IDS = ['console', 'plausible'] as const
+
+export type AnalyticsProviderId = (typeof ANALYTICS_PROVIDER_IDS)[number]

--- a/src/lib/analytics/providers/console.tsx
+++ b/src/lib/analytics/providers/console.tsx
@@ -1,0 +1,19 @@
+import { createAnalyticsProvider } from '@/lib/analytics/context'
+import { AnalyticsTransport } from '@/lib/analytics/types'
+
+/**
+ * Example provider: logs every event to the browser console and sends nothing
+ * anywhere. Select it with `ANALYTICS_PROVIDER=console` to check what the app
+ * would report — the logged URL is the anonymized one providers receive.
+ *
+ * It is also the shortest possible template for a real provider: implement a
+ * transport, and add a `Script` component if yours needs to load an SDK.
+ */
+const consoleTransport: AnalyticsTransport = (event, props, url) => {
+  console.info('[analytics]', event, props, url)
+}
+
+export const ConsoleAnalyticsProvider = createAnalyticsProvider({
+  // Nothing to load: this provider talks to the console only.
+  useTransport: () => consoleTransport,
+})

--- a/src/lib/analytics/providers/plausible.tsx
+++ b/src/lib/analytics/providers/plausible.tsx
@@ -1,0 +1,65 @@
+import { createAnalyticsProvider } from '@/lib/analytics/context'
+import { AnalyticsOptions, AnalyticsTransport } from '@/lib/analytics/types'
+import Script from 'next/script'
+
+declare global {
+  interface Window {
+    plausible?: (
+      event: string,
+      options?: { props?: Record<string, string>; u?: string },
+    ) => void
+  }
+}
+
+const DEFAULT_HOST = 'https://plausible.io'
+
+/**
+ * Queues events fired before the script has loaded; Plausible replays whatever
+ * it finds on `plausible.q` on startup. This is Plausible's own snippet.
+ */
+const QUEUE_STUB =
+  'window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }'
+
+/**
+ * Options, all set through environment variables:
+ *
+ * - `domain` (required): the site as registered in Plausible.
+ * - `host`: base URL of a self-hosted Plausible. Defaults to plausible.io.
+ * - `scriptUrl`: overrides the script URL entirely, to serve it from your own
+ *   origin through a rewrite so that ad blockers do not drop it.
+ * - `apiUrl`: the matching first-party endpoint events are posted to.
+ *
+ * The `manual` variant of the script is used on purpose: the standard one sends
+ * a pageview with `location.href` on every navigation, which on a group page
+ * carries the group ID. Pageviews are sent explicitly by `TrackPage` instead.
+ */
+function PlausibleScript({ options }: { options: AnalyticsOptions }) {
+  const scriptUrl =
+    options.scriptUrl ?? `${options.host ?? DEFAULT_HOST}/js/script.manual.js`
+
+  return (
+    <>
+      <Script
+        async
+        defer
+        data-api={options.apiUrl}
+        data-domain={options.domain}
+        src={scriptUrl}
+      />
+      <Script
+        id="analytics-plausible-init"
+        dangerouslySetInnerHTML={{ __html: QUEUE_STUB }}
+      />
+    </>
+  )
+}
+
+const plausibleTransport: AnalyticsTransport = (event, props, url) => {
+  // `u` overrides the URL Plausible would otherwise read from `location.href`.
+  window.plausible?.(event, { props, u: url })
+}
+
+export const PlausibleAnalyticsProvider = createAnalyticsProvider({
+  Script: PlausibleScript,
+  useTransport: () => plausibleTransport,
+})

--- a/src/lib/analytics/registry.ts
+++ b/src/lib/analytics/registry.ts
@@ -1,0 +1,21 @@
+import { AnalyticsProviderId } from '@/lib/analytics/provider-ids'
+import { ConsoleAnalyticsProvider } from '@/lib/analytics/providers/console'
+import { PlausibleAnalyticsProvider } from '@/lib/analytics/providers/plausible'
+import { AnalyticsProviderComponent } from '@/lib/analytics/types'
+
+/**
+ * Add your provider here. Because the map is typed by `AnalyticsProviderId`, an
+ * id without an entry — or an entry without an id — fails to compile.
+ *
+ * Every provider listed here is bundled for every client, whether or not it is
+ * selected. That is negligible for providers as small as these two; one that
+ * needs a heavy SDK should load it with `next/dynamic(…, { ssr: false })` inside
+ * its own file, so the cost stays with that provider.
+ */
+export const analyticsProviders: Record<
+  AnalyticsProviderId,
+  AnalyticsProviderComponent
+> = {
+  console: ConsoleAnalyticsProvider,
+  plausible: PlausibleAnalyticsProvider,
+}

--- a/src/lib/analytics/track-page.tsx
+++ b/src/lib/analytics/track-page.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useAnalytics } from '@/lib/analytics/context'
+import { useSearchParams } from 'next/navigation'
+import { Suspense, useEffect } from 'react'
+
+type Props = {
+  path: string
+}
+
+/**
+ * Sends a pageview for the page it is rendered in. Pages are tracked explicitly
+ * rather than automatically: a route sends nothing until someone adds this to
+ * it, which keeps a new route out of analytics until that is a deliberate,
+ * reviewable decision.
+ *
+ * `path` is anonymized before it is sent, so passing one built from a group ID
+ * is safe.
+ */
+export function TrackPage(props: Props) {
+  return (
+    // `useSearchParams` opts the whole route out of static rendering unless it
+    // is read inside a Suspense boundary.
+    <Suspense>
+      <TrackPage_ {...props} />
+    </Suspense>
+  )
+}
+
+function TrackPage_({ path }: Props) {
+  const sendEvent = useAnalytics()
+  const searchParams = useSearchParams()
+  // Kept so that campaign and share links stay attributable. Every other query
+  // parameter is dropped: the expense creation route carries the title and
+  // amount in its query string.
+  const ref = searchParams.get('ref')
+
+  useEffect(() => {
+    sendEvent(
+      { event: 'pageview', props: {} },
+      `${path}${ref ? `?ref=${ref}` : ''}`,
+    )
+  }, [path, ref, sendEvent])
+
+  return null
+}

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -1,0 +1,46 @@
+import { ComponentType, PropsWithChildren } from 'react'
+import { AnalyticsEvent } from './events'
+import { AnalyticsProviderId } from './provider-ids'
+
+/**
+ * Provider-specific settings, resolved from the environment on the server and
+ * serialized to the client. Never put a secret in here: it ends up in the HTML.
+ *
+ * Deliberately untyped per provider, so adding a provider never changes this
+ * file. Each provider documents the keys it reads; `src/lib/env.ts` enforces
+ * the ones it cannot work without.
+ */
+export type AnalyticsOptions = Record<string, string | undefined>
+
+/**
+ * What a provider implements: send one event somewhere. `url` is absolute and
+ * has already been anonymized — send it as given rather than letting an SDK
+ * fall back to `location.href`, which on a group page carries the group ID.
+ */
+export type AnalyticsTransport = (
+  event: string,
+  props: Record<string, string>,
+  url: string,
+) => void
+
+export type AnalyticsProviderDefinition = {
+  /** Optional script or SDK injection, rendered once near the root of the page. */
+  Script?: ComponentType<{ options: AnalyticsOptions }>
+  /** Returns the transport. Called as a hook, so it may use hooks itself. */
+  useTransport: (options: AnalyticsOptions) => AnalyticsTransport
+}
+
+export type AnalyticsProviderComponent = ComponentType<
+  PropsWithChildren<{ options: AnalyticsOptions }>
+>
+
+/**
+ * What call sites use. `path` is the page the event should be attributed to; it
+ * defaults to `/` and is anonymized before it reaches any provider.
+ */
+export type SendEvent = (event: AnalyticsEvent, path?: string) => void
+
+export type AnalyticsConfig = {
+  provider: AnalyticsProviderId | null
+  options: AnalyticsOptions
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,9 +1,18 @@
 import { ZodIssueCode, z } from 'zod'
+import { ANALYTICS_PROVIDER_IDS } from './analytics/provider-ids'
 
 const interpretEnvVarAsBool = (val: unknown): boolean => {
   if (typeof val !== 'string') return false
   return ['true', 'yes', '1', 'on'].includes(val.toLowerCase())
 }
+
+/**
+ * Treats a blank environment variable as unset, so that listing a variable
+ * without a value (as `scripts/build.env` does) is not the same as giving it an
+ * empty value — which would fail validations like `z.string().url()`.
+ */
+const interpretBlankEnvVarAsUndefined = (val: unknown): unknown =>
+  typeof val === 'string' && val.trim() === '' ? undefined : val
 
 const envSchema = z
   .object({
@@ -36,6 +45,31 @@ const envSchema = z
       z.boolean().default(false),
     ),
     OPENAI_API_KEY: z.string().optional(),
+    // Analytics is disabled unless a provider is selected. These are read on
+    // the server and passed to the client as props, so they are deliberately
+    // not `NEXT_PUBLIC_`: a single image stays configurable at container start.
+    ANALYTICS_PROVIDER: z.preprocess(
+      interpretBlankEnvVarAsUndefined,
+      z.enum(ANALYTICS_PROVIDER_IDS).optional(),
+    ),
+    PLAUSIBLE_DOMAIN: z.preprocess(
+      interpretBlankEnvVarAsUndefined,
+      z.string().optional(),
+    ),
+    PLAUSIBLE_HOST: z.preprocess(
+      interpretBlankEnvVarAsUndefined,
+      z.string().url().optional(),
+    ),
+    // Not a `z.string().url()`: both are usually relative paths, pointing at
+    // rewrites that serve Plausible first-party.
+    PLAUSIBLE_SCRIPT_URL: z.preprocess(
+      interpretBlankEnvVarAsUndefined,
+      z.string().optional(),
+    ),
+    PLAUSIBLE_API_URL: z.preprocess(
+      interpretBlankEnvVarAsUndefined,
+      z.string().optional(),
+    ),
   })
   .superRefine((env, ctx) => {
     if (
@@ -61,6 +95,13 @@ const envSchema = z
         code: ZodIssueCode.custom,
         message:
           'If NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT or NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT is specified, then OPENAI_API_KEY must be specified too',
+      })
+    }
+    if (env.ANALYTICS_PROVIDER === 'plausible' && !env.PLAUSIBLE_DOMAIN) {
+      ctx.addIssue({
+        code: ZodIssueCode.custom,
+        message:
+          'If ANALYTICS_PROVIDER is set to "plausible", then PLAUSIBLE_DOMAIN must be specified too',
       })
     }
   })


### PR DESCRIPTION
Analytics currently live only in the [spliit.app](https://spliit.app) fork, hardcoded to Plausible. The logic is reusable — a privacy-conscious event vocabulary, path anonymization, and two hard-won bug fixes — but self-hosters get none of it, and the fork carries a permanent diff across eight shared files.

This moves it here behind a provider abstraction.

## Disabled by default

Nothing is loaded and nothing is sent unless `ANALYTICS_PROVIDER` selects a provider. `useAnalytics()` returns a stable no-op, so call sites stay unconditional — no `if (enabled)` anywhere.

Two providers ship with the app:

- **`console`** — logs every event to the browser console and sends nothing anywhere. It's the tool for checking what the app would report, and the shortest template for writing a new provider.
- **`plausible`** — **no new dependency**: a script tag and a function call. `PLAUSIBLE_HOST` covers self-hosted instances; `PLAUSIBLE_SCRIPT_URL` / `PLAUSIBLE_API_URL` let you serve the script first-party through a rewrite so ad blockers don't drop it.

Configuration is read on the server and passed down as a prop, following the existing `getRuntimeFeatureFlags` idiom — so a single Docker image stays configurable at container start.

## Two invariants, made structural

The fork fixed both of these the hard way, in production. They're now enforced by construction rather than by discipline:

**`sendEvent` keeps a stable identity.** `TrackPage` puts it in a `useEffect` dependency array, and group pages re-render on every tRPC refetch — an unstable identity re-sends the pageview on every render. (The fork saw ~5.7 pageviews per visitor on `/groups/[id]/expenses` before fixing it.) The transport now sits behind a ref inside `createAnalyticsProvider`, so a provider can't reintroduce the bug by returning a new function each render.

**Group and expense IDs never leave the browser.** They're the capability to read someone's group, and they're unique per document. `anonymizePath` runs in exactly one place, between the call sites and every provider, so no caller can leak an ID by building a path from `groupId` and no provider can forget to scrub it. Event types reject undeclared properties (`Record<string, never>`, not `{}`), which makes a leak a compile error rather than a review question.

## Adding a provider

One new file under `src/lib/analytics/providers/`, plus three one-line registrations — two of which are type-checked against the first, so `npm run check-types` names whatever is missing.

## Also fixed

`group: export expenses` was declared in the fork but never fired: its `export-link.tsx` was never imported anywhere. It now hangs off the real export button, with the format (`csv` / `json`) as a property.

## Verification

Beyond `check-types` / `lint` / `jest` (27 tests, including the ported `anonymizePath` suite), this was driven through a real browser against a live database:

- On `/groups/cjTY_ZJgMIAT4S5GuIgIY/expenses`, Plausible received `u=/groups/[groupId]/expenses`.
- Eight events verified end to end: group create/update, expense create/update/delete, export, and pageviews on all four tracked pages.
- Six forced tRPC refetch cycles added **zero** pageviews (the pair per mount is React StrictMode's dev double-invoke).
- Disabled default: no script tag, `window.plausible` undefined, no output, and event call sites no-op cleanly.
- The Plausible script tags render identically to what spliit.app serves today, `data-domain` and `data-api` included.

Not exercised locally: `expense: attach document`, `scan receipt`, and `create from receipt`, which need S3 and OpenAI configured. Their code paths are wired identically to the verified ones.

## Note for the spliit.app fork

Dropping `next-plausible` also drops `withPlausibleProxy()`. The README documents the two-rewrite replacement plus the matching env vars, which reproduce today's URLs exactly — worth confirming before switching the deployment over, since it's the one part that can silently reduce measured traffic.

## Unrelated, but worth knowing

`main` currently fails `npm run check-formatting` on `src/components/money.tsx`, `expense-form.tsx`, and `create-from-receipt-button.tsx` — a pre-existing Prettier version drift. This PR deliberately leaves those files alone so the diff stays reviewable; the fix belongs in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqbXs6MPC1W1ABv71jNF7W
