### PR TITLE
fix: backfill Expense.originalAmount into minor units

### DIFF
--- a/prisma/migrations/20260812213708_backfill_original_amount_minor_units/migration.sql
+++ b/prisma/migrations/20260812213708_backfill_original_amount_minor_units/migration.sql
@@ -80,7 +80,11 @@ candidate AS (
         -- 10^od: the correction factor, and also the ratio between the two candidates
         power(10::numeric, COALESCE(original_currency."decimals", 2)) AS "originalFactor",
         expense."originalAmount"::numeric
-            * power(10::numeric, COALESCE(original_currency."decimals", 2)) AS "correctedOriginalAmount"
+            * power(10::numeric, COALESCE(original_currency."decimals", 2)) AS "correctedOriginalAmount",
+        -- The form only stores a conversion when the two currencies differ, so a row
+        -- where they match has been through a change the stored values do not reflect.
+        (expense."originalCurrency" IS NOT DISTINCT FROM "group"."currencyCode")
+            AS "sameCurrency"
     FROM "Expense" expense
     JOIN "Group" "group"
         ON "group"."id" = expense."groupId"
@@ -100,6 +104,14 @@ to_fix AS (
     FROM candidate
     -- 0-decimal original currencies: major units *are* minor units, nothing to do.
     WHERE "originalFactor" > 1
+      -- A row whose original currency equals its group's currency needs no
+      -- conversion, so the form never writes one: its group's currency was changed
+      -- afterwards (updateGroup in src/lib/api.ts lets that happen and does not
+      -- rescale existing amounts), leaving "amount", "conversionRate" and the two
+      -- currency codes describing different states of the world. On spliit.app such
+      -- rows are 2% of the conversion data but 86% of the rows whose "amount" cannot
+      -- be explained at all, so they are not classifiable and are left alone.
+      AND NOT "sameCurrency"
       -- nearest fit: closer to the pre-fix candidate than to the post-fix one
       AND abs("amount" - "preFixAmount")
           < abs("amount" - "preFixAmount" / "originalFactor")

--- a/prisma/migrations/20260812213708_backfill_original_amount_minor_units/migration.sql
+++ b/prisma/migrations/20260812213708_backfill_original_amount_minor_units/migration.sql
@@ -1,0 +1,116 @@
+-- Backfill "Expense"."originalAmount" into minor units.
+--
+-- WHAT WENT WRONG
+-- ---------------
+-- "Expense"."amount" has always been stored in minor units (cents) of the group
+-- currency. "Expense"."originalAmount" was written by the expense form in *major*
+-- units until PR #425 ("Store originalAmount in minor units to match amount"),
+-- and in minor units of the row's "originalCurrency" ever since. The column
+-- therefore holds a mix of both conventions, while every reader (the expense form
+-- and the CSV export) interprets it as minor units -- so rows written before the
+-- fix are displayed 100x too small. Balances are not affected: they are derived
+-- from "Expense"."amount" only.
+--
+-- HOW ROWS ARE CLASSIFIED (no timestamp predicate)
+-- ------------------------------------------------
+-- The cutover happens when each (self-hosted) instance deploys the fix, so no
+-- fixed timestamp is correct for everyone. Each row is classified by its own
+-- values instead.
+--
+-- When an amount is entered in another currency, the form derives
+--   amount(major, group currency) = originalAmount(major) * conversionRate
+-- and stores it as minor units of the *group* currency. So, writing
+-- `gd` = decimal digits of the group currency and `od` = decimal digits of the
+-- row's original currency:
+--
+--   pre-fix  row:  amount ~= "originalAmount" * "conversionRate" * 10^gd
+--   post-fix row:  amount ~= "originalAmount" * "conversionRate" * 10^gd / 10^od
+--
+-- The two candidates differ by exactly 10^od, so the candidate that "amount" is
+-- nearest to identifies which convention the row was written with. Note that both
+-- candidates carry the *group* currency's 10^gd factor: it does not cancel out
+-- unless the group and original currencies happen to have the same number of
+-- decimal digits, which is why "Group" is joined below (a group in JPY holding an
+-- expense in EUR is a real case).
+--
+-- Only rows whose original currency has decimal digits > 0 can need fixing: for a
+-- 0-decimal currency (JPY, HUF, ...) major and minor units are the same thing and
+-- the two candidates above are identical. Those rows are skipped explicitly by the
+-- `original_factor > 1` predicate rather than by relying on that coincidence.
+--
+-- WHY THE CURRENCY LIST IS HARDCODED (please do not "generalise" it)
+-- -----------------------------------------------------------------
+-- This is a point-in-time fixup: pre-existing rows can only hold currencies that
+-- were supported at the time it runs, i.e. the 30 codes of src/lib/currency-data.json
+-- listed below. Currencies added later are written in minor units by the fixed code
+-- and must never be touched by this migration. An unknown, empty or NULL
+-- "originalCurrency" (or group "currencyCode") falls back to 2 decimal digits,
+-- which is exactly what getCurrency() in src/lib/currency.ts does for the app.
+--
+-- WHAT CANNOT BE RECOVERED
+-- ------------------------
+-- Under the old code a fractional major-unit value was squeezed into an INTEGER
+-- column, so e.g. 12.34 was already stored as 12 (that data loss is the bug #425
+-- fixed). Those digits are gone; this migration restores the magnitude only, so
+-- such a row becomes 12.00 rather than 12.34. Values below 1 major unit collapsed
+-- to 0 and are indistinguishable from "not set" -- they are left alone.
+--
+-- SAFE TO RE-RUN: once a row has been scaled up, "amount" is nearest to the
+-- post-fix candidate, so a second execution matches nothing.
+
+WITH currency_decimals ("code", "decimals") AS (
+    VALUES
+        -- decimal_digits = 0 -> factor 1 -> never needs a backfill
+        ('HUF', 0), ('IDR', 0), ('ISK', 0), ('JPY', 0), ('KRW', 0),
+        -- decimal_digits = 2 -> factor 100
+        ('AUD', 2), ('BGN', 2), ('BRL', 2), ('CAD', 2), ('CHF', 2),
+        ('CNY', 2), ('CZK', 2), ('DKK', 2), ('EUR', 2), ('GBP', 2),
+        ('HKD', 2), ('ILS', 2), ('INR', 2), ('MXN', 2), ('NOK', 2),
+        ('NZD', 2), ('PHP', 2), ('PLN', 2), ('RON', 2), ('SEK', 2),
+        ('SGD', 2), ('THB', 2), ('TRY', 2), ('USD', 2), ('ZAR', 2)
+),
+candidate AS (
+    SELECT
+        expense."id" AS "expenseId",
+        expense."amount"::numeric AS "amount",
+        -- what "amount" would be if "originalAmount" is in major units (pre-fix)
+        expense."originalAmount"::numeric
+            * expense."conversionRate"
+            * power(10::numeric, COALESCE(group_currency."decimals", 2)) AS "preFixAmount",
+        -- 10^od: the correction factor, and also the ratio between the two candidates
+        power(10::numeric, COALESCE(original_currency."decimals", 2)) AS "originalFactor",
+        expense."originalAmount"::numeric
+            * power(10::numeric, COALESCE(original_currency."decimals", 2)) AS "correctedOriginalAmount"
+    FROM "Expense" expense
+    JOIN "Group" "group"
+        ON "group"."id" = expense."groupId"
+    LEFT JOIN currency_decimals original_currency
+        ON original_currency."code" = expense."originalCurrency"
+    LEFT JOIN currency_decimals group_currency
+        ON group_currency."code" = "group"."currencyCode"
+    -- Unclassifiable rows: no original amount to scale, a value that was already
+    -- truncated to 0, or no rate to relate it to "amount" with.
+    WHERE expense."originalAmount" IS NOT NULL
+      AND expense."originalAmount" <> 0
+      AND expense."conversionRate" IS NOT NULL
+      AND expense."conversionRate" <> 0
+),
+to_fix AS (
+    SELECT "expenseId", "correctedOriginalAmount"
+    FROM candidate
+    -- 0-decimal original currencies: major units *are* minor units, nothing to do.
+    WHERE "originalFactor" > 1
+      -- nearest fit: closer to the pre-fix candidate than to the post-fix one
+      AND abs("amount" - "preFixAmount")
+          < abs("amount" - "preFixAmount" / "originalFactor")
+      -- ...and not wildly off it either (e.g. an "amount" edited by hand afterwards
+      -- to something the stored original amount cannot explain). Such a row cannot
+      -- be classified with confidence, so leave it untouched.
+      AND abs("amount") <= abs("preFixAmount") * 10
+      -- never write a value the INTEGER column cannot hold
+      AND "correctedOriginalAmount" BETWEEN -2147483648 AND 2147483647
+)
+UPDATE "Expense" expense
+SET "originalAmount" = to_fix."correctedOriginalAmount"::int
+FROM to_fix
+WHERE expense."id" = to_fix."expenseId";


### PR DESCRIPTION
## The problem

`Expense.amount` has always been stored in minor units (cents). `Expense.originalAmount` was written by the expense form in **major** units until #425 (`7b5b3cc`), and in minor units of the row's `originalCurrency` ever since. The `Int?` column now holds a mix of both conventions, while every reader — the expense form (`expense-form.tsx:195`) and the CSV export (`export/csv/route.ts:111`) — interprets it as minor units. So rows written before #425 display **100× too small**.

Balances are unaffected: they are derived from `amount` only.

This migration is data-only; `prisma/schema.prisma` is unchanged and `prisma migrate diff --from-migrations --to-schema-datamodel` reports "No difference detected", so it introduces no drift. `postinstall` runs `prisma migrate deploy`, so self-hosted instances pick it up with no manual step.

## How rows are classified

No timestamp predicate: the cutover happens whenever each instance deploys the fix. Each row is classified by its own values.

When an amount is entered in another currency the form derives `amount(major) = originalAmount(major) × conversionRate` and stores `amount` in minor units of the **group** currency. With `gd` = decimal digits of the group currency and `od` = decimal digits of the row's original currency:

| convention | relationship |
| --- | --- |
| pre-fix | `amount ≈ originalAmount × conversionRate × 10^gd` |
| post-fix | `amount ≈ originalAmount × conversionRate × 10^gd ÷ 10^od` |

The candidates differ by exactly `10^od`, so whichever one `amount` is nearest to identifies the row's convention. A row classified as pre-fix is multiplied by `10^od`.

### ⚠️ Deviation from the plan this was written against

The brief specified the two candidates as `originalAmount × conversionRate × factor` and `originalAmount × conversionRate` — i.e. without the group currency's `10^gd`. That is only equivalent when the group and original currency have the same number of decimal digits. It misclassifies expenses in a **0-decimal group currency** (JPY, HUF, ISK, IDR, KRW) with a 2-decimal original currency: a pre-fix row there satisfies `amount = originalAmount × rate`, which matches the brief's *post-fix* candidate, so the row would be silently skipped and left broken. (It never corrupts a row — it only misses them.) Joining `Group` for `currencyCode` fixes this; seeded rows `e_jpy_pre_usd` and `e_jpy_pre_eur` below cover the case, and they are backfilled correctly.

A dry run on spliit.app confirms this is not hypothetical: **377 of the 10,229 rows to be fixed sit in 0-decimal group currencies** (HUF groups with USD expenses, JPY groups with INR expenses). Without the `Group` join, every one of them would have been silently skipped.

Everything else in the brief was verified and held: `amountAsMinorUnits`/`amountAsDecimal` use `10 ** decimal_digits` (`src/lib/utils.ts`), `currency-data.json` has exactly 5 zero-decimal currencies (HUF, IDR, ISK, JPY, KRW) and 25 two-decimal ones with consistent values across all 23 locales, and `getCurrency()` falls back to a 2-decimal default for NULL/empty/unknown codes — which the migration mirrors via `COALESCE(decimals, 2)`.

### Why the currency list is hardcoded

A migration is a point-in-time fixup: pre-existing rows can only hold currencies supported *before* it runs. Currencies added later are already written in minor units by the fixed code and must never be touched. The migration comment says so, to stop a future reader from "helpfully" generalising it. Zero-decimal currencies are skipped by an explicit `originalFactor > 1` predicate rather than by relying on the two candidates coinciding.

## Rows deliberately left alone

- `originalAmount IS NULL` — every expense without a currency conversion. Very common.
- `originalAmount = 0` — Prisma silently truncates when writing a float into an `Int` column (verified: `12.99 → 12`, `0.5 → 0`), so any original amount below 1 major unit collapsed to 0 pre-fix. Indistinguishable from "not set", unrecoverable.
- **`originalCurrency` equal to the group's `currencyCode`** — the form only stores a conversion when the two differ, so these rows come from a group whose currency was changed later (`updateGroup` allows it and never rescales existing amounts). Their stored `amount`, `conversionRate` and currency codes describe different states of the world: the dry run shows INR groups holding INR expenses at rates of 0.0091–0.0145, which are INR→USD rates from when the group was in USD. They are 2% of the conversion data but 86% of the rows whose `amount` cannot be explained by either convention.
- `conversionRate IS NULL` (or `0`) — reachable: `conversionRate` is optional in `expenseFormSchema`, so if the exchange-rate lookup fails the row can be saved with an original amount and no rate. Nothing relates `originalAmount` to `amount`, so it is unclassifiable.
- `amount` more than 10× away from the pre-fix candidate — e.g. an amount hand-edited after the fact. Not classifiable with confidence.
- rows whose corrected value would exceed `INT_MAX` — skipped rather than allowed to abort the migration for the whole instance.

## What cannot be recovered

Fractional major-unit values were truncated by the `Int` column under the old code (the data-loss bug #425 fixed). `12.34` was stored as `12`; the backfill restores the magnitude (`1200` = 12.00) but the cents are gone. Recomputing `originalAmount` from `amount ÷ conversionRate` would appear to recover them, but it would also silently overwrite user-entered original amounts with values derived from a possibly hand-edited `amount` — deliberately not done.

**Known limitation:** recurring expenses copy the previous row's stored fields verbatim (`api.ts`, `createRecurringExpenses`). A recurring chain seeded before #425 keeps generating major-unit rows after the deploy, until someone opens and saves the expense. This migration runs once and cannot cover those.

## Dry run against production

A read-only version of the classification was run against spliit.app before merging. Of ~1,272,581 expenses, 10,319 reach the nearest-fit test:

| verdict | rows |
| --- | --- |
| would change | 10,229 → **10,090** after excluding same-currency rows |
| untouched, already in minor units | 68 |
| untouched, 0-decimal original currency | 2,022 |
| ambiguous (`amount` unexplainable) | 22 → **3** |
| untouched, no conversion rate | 1,180 |
| untouched, original amount truncated to 0 | 14 |

Excluding same-currency rows takes the clean classification rate from 99.8% to **99.97%**. No row in production hits the INTEGER overflow guard or has a zero conversion rate.

**About 1,216 rows (9% of the conversion data) stay broken** — no conversion rate to classify them by, an original amount already truncated to 0, or an `amount` that matches neither convention. This is not a complete fix.

**#425 has not reached production yet** (confirmed by the maintainer, and visible in the data: the newest row classified "already in minor units" is from 2026-08-09, three days *before* #425 merged, while pre-fix rows run right up to the present).

That has a useful consequence for spliit.app: every row in the table was written by the old code, so **there is no already-correct row for this migration to damage**. The only way it can corrupt data is by mistaking a post-fix row for a pre-fix one, and none exist. Any classification error it makes here is a miss, not a corruption.

The protection for post-fix rows therefore rests on the seeded tests and on the 100× separation between the two candidates — which matters for self-hosted instances that deployed #425 before running this migration, not for spliit.app.

One footnote on ordering: the Docker entrypoint runs `prisma migrate deploy` immediately before `npm run start`, so migration and fixed code go live together. On a build-time deploy (`postinstall`), migrations run while the previous version is still serving, so a handful of major-unit rows can be written in the gap between the migration and the new code going live — a fraction of a row at the current rate of ~20–50 conversion expenses/day. Re-running the dry run afterwards will show any stragglers, and re-running the migration SQL by hand is safe (it is idempotent).

## Testing

Run against a real Postgres 18 (`scripts/start-local-db.sh`), on a database migrated to the *pre*-migration state, seeded with 28 expenses across three groups (EUR, JPY, and one with no `currencyCode`), then migrated with `prisma migrate deploy`:

- **Exactly the 8 expected rows changed**, 0 mismatches against the expected values, and `amount` / `originalCurrency` / `conversionRate` were untouched on every row.
- Coverage: 2-decimal pre-fix and post-fix rows; 0-decimal originals (JPY, HUF); NULL `originalCurrency`; unrecognised code (`XYZ`) both pre- and post-fix; NULL and zero `conversionRate`; `originalAmount = 0` and NULL; a row where truncation already happened (12.34 GBP → 12 → 1200); negative (income) rows pre- and post-fix; `amount = 0`; a sign-mismatched row; a hand-edited `amount`; an overflow case; pre-/post-fix rows in a **JPY group** (the case above); and same-currency rows including one that would otherwise have been a textbook change and one where both currency codes are NULL.
- The read-only dry-run script classifies the same seeded data identically to the migration (8 = 8).
- **Idempotent:** re-running the SQL twice more reports `UPDATE 0` and changes nothing.
- **Empty table:** `UPDATE 0`, no error — and a fresh `npm install` (`postinstall` → `prisma migrate deploy`) applies the whole chain including this migration on an empty database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cfMwoWST95Fn7XdqZ5zv3
