### PR TITLE
fix: install optional deps in Docker runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /usr/app
 COPY --from=base /usr/app/package.json /usr/app/package-lock.json /usr/app/next.config.mjs ./
 COPY --from=base /usr/app/prisma ./prisma
 
-RUN npm ci --omit=dev --omit=optional --ignore-scripts && \
+RUN npm ci --omit=dev --ignore-scripts && \
     npx prisma generate
 
 FROM node:24-alpine AS runner


### PR DESCRIPTION
## Problem

Deploying the Docker image fails at container startup:

My log :

```
2026-08-12T23:04:55.985Z at ignore-listed frames
2026-08-12T23:05:57.172Z + npx prisma migrate deploy
2026-08-12T23:06:01.838Z Prisma schema loaded from prisma/schema.prisma
2026-08-12T23:06:01.847Z Datasource "db": PostgreSQL database "spliit", schema "public" at "spliit-db:5432"
2026-08-12T23:06:01.992Z 24 migrations found in prisma/migrations
2026-08-12T23:06:02.155Z No pending migrations to apply.
2026-08-12T23:06:02.264Z + exec npm run start
2026-08-12T23:06:02.741Z > spliit2@0.1.0 start
2026-08-12T23:06:02.741Z > next start
2026-08-12T23:06:03.819Z ▲ Next.js 16.3.0
2026-08-12T23:06:03.820Z - Local:         http://localhost:3069
2026-08-12T23:06:03.820Z - Network:      
2026-08-12T23:06:03.822Z ✓ Ready in 643ms
2026-08-12T23:06:03.938Z ⨯ Failed to load next.config.mjs, see more info here https://nextjs.org/docs/messages/next-config-error
2026-08-12T23:06:03.950Z Error: No prebuild or local build of @parcel/watcher found. Tried @parcel/watcher-linux-x64-musl. Please ensure it is installed (don't use --no-optional when installing with npm). Otherwise it is possible we don't support your platform yet. If this is the case, please report an issue to https://github.com/parcel-bundler/watcher.
2026-08-12T23:06:03.950Z at ignore-listed frames
2026-08-12T23:07:05.090Z + npx prisma migrate deploy
2026-08-12T23:07:09.881Z Prisma schema loaded from prisma/schema.prisma
2026-08-12T23:07:09.893Z Datasource "db": PostgreSQL database "spliit", schema "public" at "spliit-db:5432"
2026-08-12T23:07:10.074Z 24 migrations found in prisma/migrations
2026-08-12T23:07:10.311Z No pending migrations to apply.
2026-08-12T23:07:10.395Z + exec npm run start
2026-08-12T23:07:10.891Z > spliit2@0.1.0 start
2026-08-12T23:07:10.891Z > next start
2026-08-12T23:07:11.983Z ▲ Next.js 16.3.0
2026-08-12T23:07:11.984Z - Local:         http://localhost:3069
2026-08-12T23:07:11.984Z - Network:      
2026-08-12T23:07:11.986Z ✓ Ready in 651ms
2026-08-12T23:07:12.107Z ⨯ Failed to load next.config.mjs, see more info here https://nextjs.org/docs/messages/next-config-error
2026-08-12T23:07:12.121Z Error: No prebuild or local build of @parcel/watcher found. Tried @parcel/watcher-linux-x64-musl. Please ensure it is installed (don't use --no-optional when installing with npm). Otherwise it is possible we don't support your platform yet. If this is the case, please report an issue to https://github.com/parcel-bundler/watcher.
2026-08-12T23:07:12.121Z at ignore-listed frames
```

### Root cause

`next start` evaluates `next.config.mjs` when the server boots, and our config
calls `createNextIntlPlugin()` from `next-intl/plugin` — build-time code that
ends up being loaded in production.

`next-intl@4.13.6` declares `@parcel/watcher` and `@swc/core` as **regular**
dependencies, but their platform-specific native bindings
(`@parcel/watcher-linux-x64-musl`, `@swc/core-linux-x64-musl`) ship as
**optionalDependencies**. The `runtime-deps` stage installed with
`npm ci --omit=dev --omit=optional`, which kept the JS but stripped the native
bindings it requires — so the container crashed on startup.

### Why this surfaced now

The `--omit=optional` flag has been in the Dockerfile since 2af0660 ("Optimize
docker image size") and was harmless for two years: no package in the runtime
graph shipped native code as an optional dependency. #543 bumped `next-intl`
from 4.5.8 to 4.13.6, which introduced the `@parcel/watcher` dependency —
before that commit, `@parcel/watcher` did not appear in `package-lock.json` at
all.

## Fix

Drop `--omit=optional` from the `runtime-deps` stage so npm installs the native
bindings matching the build platform. npm only installs the variants whose
`os`/`cpu`/`libc` fields match, so this stays correct for multi-arch builds.

A narrower fix (copying only `node_modules/@parcel` from the `base` stage) was
tried first and rejected: `@parcel/watcher` was merely the first missing
binding, and `@swc/core` failed right after it. As long as the build-time
plugin is loaded at runtime, its whole native tree has to be present.

## Testing

Image rebuilt and started:

▲ Next.js 16.3.0
✓ Ready in 205ms


`next.config.mjs` now loads inside the container, and there are no native
binding errors in the startup logs.
