### PR TITLE
fix: repair main after the MYR, MKD and COP merges

### DIFF
--- a/src/lib/currency-data.json
+++ b/src/lib/currency-data.json
@@ -217,11 +217,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Macedonian Denar",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "Denar Makedonia",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -525,11 +525,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Macedonian Denar",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "denar macedoni",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -833,11 +833,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Makedonský denár",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "makedonský denár",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -1141,11 +1141,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Nordmazedonischer Denar",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "Mazedonischer Denar",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -1449,11 +1449,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Macedonian denar",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "Macedonian Denar",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -1757,11 +1757,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Denar macedonio",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "dinar macedonio",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -2065,11 +2065,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Mazedoniako denarra",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "Mazedoniako dinarra",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -2373,11 +2373,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Denar macédonien",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "denar macédonien",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -2681,11 +2681,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Dinaro macedone",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "denar macedone",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -2990,10 +2990,10 @@
     },
     "MKD": {
       "name": "Macedonische denar",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -3297,11 +3297,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Macedonia Północna",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "denar macedoński",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -3605,11 +3605,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Dinar macedónio",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "Dinar macedônio",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -3913,11 +3913,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Dinar macedónio",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "Dinar macedônio",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -4221,11 +4221,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Denar macedonean",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "dinar macedonean",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -4530,10 +4530,10 @@
     },
     "MKD": {
       "name": "Makedonian denaari",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -4837,11 +4837,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Makedon dinarı",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "Makedonya Dinarı",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -5146,10 +5146,10 @@
     },
     "MKD": {
       "name": "Македонский денар",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -5453,11 +5453,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "Македонський денар",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "македонський денар",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -5762,10 +5762,10 @@
     },
     "MKD": {
       "name": "דינר מקדוני",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -6068,12 +6068,30 @@
       "rounding": 0,
       "decimal_digits": 0
     },
+    "MKD": {
+      "name": "دينار مقدوني",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
+      "code": "MKD",
+      "name_plural": "Macedonian denari",
+      "rounding": 0,
+      "decimal_digits": 2
+    },
     "MXN": {
       "name": "بيزو مكسيكي",
       "symbol_native": "$",
       "symbol": "MX$",
       "code": "MXN",
       "name_plural": "Mexican pesos",
+      "rounding": 0,
+      "decimal_digits": 2
+    },
+    "MYR": {
+      "name": "رينغيت ماليزي",
+      "symbol_native": "RM",
+      "symbol": "RM",
+      "code": "MYR",
+      "name_plural": "Malaysian ringgits",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -6130,6 +6148,15 @@
       "name_plural": "South African rand",
       "rounding": 0,
       "decimal_digits": 2
+    },
+    "COP": {
+      "name": "بيزو كولومبي",
+      "symbol_native": "$",
+      "symbol": "CO$",
+      "code": "COP",
+      "name_plural": "Colombian pesos",
+      "rounding": 0,
+      "decimal_digits": 0
     }
   },
   "ko": {
@@ -6351,10 +6378,10 @@
     },
     "MKD": {
       "name": "마케도니아 디나르",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -6658,11 +6685,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "マケドニア・デナール",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "マケドニア デナル",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -6967,10 +6994,10 @@
     },
     "MKD": {
       "name": "马其顿第纳尔",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },
@@ -7274,11 +7301,11 @@
       "decimal_digits": 0
     },
     "MKD": {
-      "name": "馬其頓第納爾",
-      "symbol_native": "ден",
-      "symbol": "den",
+      "name": "马其顿第纳尔",
+      "symbol_native": "MKD",
+      "symbol": "MKD",
       "code": "MKD",
-      "name_plural": "Macedonian denars",
+      "name_plural": "Macedonian denari",
       "rounding": 0,
       "decimal_digits": 2
     },

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -55,16 +55,16 @@ export function defaultCurrencyList(
 ) {
   const currencies = customChoice
     ? [
-      {
-        name: customChoice,
-        symbol_native: '',
-        symbol: '',
-        code: '',
-        name_plural: customChoice,
-        rounding: 0,
-        decimal_digits: 2,
-      },
-    ]
+        {
+          name: customChoice,
+          symbol_native: '',
+          symbol: '',
+          code: '',
+          name_plural: customChoice,
+          rounding: 0,
+          decimal_digits: 2,
+        },
+      ]
     : []
   const allCurrencies = currencyList[locale]
   return currencies.concat(Object.values(allCurrencies))

--- a/src/scripts/generateCurrencyData.ts
+++ b/src/scripts/generateCurrencyData.ts
@@ -37,4 +37,7 @@ const currencyList = locales.reduce((curList, locale) => {
   }
 }
 
-fs.writeFileSync('src/lib/currency-data.json', JSON.stringify(currencyList, null, 2))
+fs.writeFileSync(
+  'src/lib/currency-data.json',
+  JSON.stringify(currencyList, null, 2) + '\n',
+)


### PR DESCRIPTION
# fix: repair main after the MYR, MKD and COP merges

`main` is currently red. #486 (MYR), #507 (MKD) and #521 (COP) were each green on their own base, but none of them was rebased onto the branch that added the Arabic locale (#540). All three hand-edited `src/lib/currency-data.json` for the 23 locales their branch knew about, so after the merges `ar` has 31 currencies while every other locale has 34.

`getCurrency()` indexes the union of all locale objects with the union of all supported codes, so the missing keys break type checking:

```
$ npm run check-types
src/lib/currency.ts(90,5): error TS7053: Element implicitly has an 'any' type because
expression of type '"USD" | "EUR" | ... | "COP"' can't be used to index type '{ ... }'.
  Property 'MKD' does not exist on type '{ USD: {...}; EUR: {...}; ... }'.
```

`npm run check-formatting` fails too, on three files:

```
[warn] src/lib/currency-data.json
[warn] src/lib/currency.ts
[warn] src/scripts/generateCurrencyData.ts
```

## What this PR changes

**1. Regenerate `src/lib/currency-data.json`** with the existing `npm run generate-currency-data`, so every locale carries every supported code. Verified: 24 locales × 34 currencies, no gaps.

The only entries that differ from the current `main`:

| Change | Entries |
| --- | --- |
| **added** `MKD`, `MYR`, `COP` to the `ar` locale | 3 — this is the actual build fix |
| **changed** `MKD` in the other 23 locales | `symbol_native` `ден` → `MKD`, `symbol` `den` → `MKD`, and `name`/`name_plural` to the `currency-list` wording |

Worth flagging explicitly: #507 hand-wrote those MKD values rather than taking them from `currency-list`, so regenerating replaces them. That brings MKD in line with how every other currency in the file is produced — after this PR the file is exactly what the generator emits. If you'd rather keep `ден` as the native symbol, it should go through the generator (e.g. a small override map) so the file stays reproducible; happy to add that here if you prefer.

**2. `src/scripts/generateCurrencyData.ts`** — write a trailing newline. Without it, a freshly generated data file always fails `prettier -c src`; that missing newline was Prettier's only complaint about the JSON. The `writeFileSync` call is also wrapped, since #521 left it at 86 characters.

**3. `src/lib/currency.ts`** — restore the indentation of the `customChoice` ternary in `defaultCurrencyList`. #521 re-indented that block by two spaces as collateral damage; the contents are unchanged, so this is formatting only.

`supportedCurrencyCodes` is untouched — MYR, MKD and COP all stay.

## Verification

Full CI sequence from `.github/workflows/ci.yml`, on Node 24:

```
npm ci --ignore-scripts
npx prisma generate
npm run check-types        # silent
npm run lint               # 16 problems (0 errors, 16 warnings) — unchanged from before
npm run check-formatting   # All matched files use Prettier code style!
npx jest                   # 27 tests passed
```

Re-running `npm run generate-currency-data` after the commit leaves a clean working tree, which confirms the checked-in JSON is exactly the generator's output and that the trailing-newline fix holds.

## Suggestion

Enabling *Require branches to be up to date before merging* on `main` would make this class of merge skew fail on the PR rather than on `main` — all three PRs here passed individually and only conflicted semantically once combined.
