### PR TITLE
fix: honour locale week start when grouping expenses and activity

### DIFF
--- a/src/app/groups/[groupId]/activity/activity-list.tsx
+++ b/src/app/groups/[groupId]/activity/activity-list.tsx
@@ -4,9 +4,10 @@ import {
   ActivityItem,
 } from '@/app/groups/[groupId]/activity/activity-item'
 import { Skeleton } from '@/components/ui/skeleton'
+import { getWeekStartsOn, isSameWeek } from '@/lib/date-groups'
 import { trpc } from '@/trpc/client'
 import dayjs, { type Dayjs } from 'dayjs'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import { forwardRef, useEffect } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { useCurrentGroup } from '../current-group-context'
@@ -25,14 +26,14 @@ const DATE_GROUPS = {
   OLDER: 'older',
 }
 
-function getDateGroup(date: Dayjs, today: Dayjs) {
+function getDateGroup(date: Dayjs, today: Dayjs, weekStartsOn: number) {
   if (today.isSame(date, 'day')) {
     return DATE_GROUPS.TODAY
   } else if (today.subtract(1, 'day').isSame(date, 'day')) {
     return DATE_GROUPS.YESTERDAY
-  } else if (today.isSame(date, 'week')) {
+  } else if (isSameWeek(today, date, weekStartsOn)) {
     return DATE_GROUPS.EARLIER_THIS_WEEK
-  } else if (today.subtract(1, 'week').isSame(date, 'week')) {
+  } else if (isSameWeek(today.subtract(1, 'week'), date, weekStartsOn)) {
     return DATE_GROUPS.LAST_WEEK
   } else if (today.isSame(date, 'month')) {
     return DATE_GROUPS.EARLIER_THIS_MONTH
@@ -47,11 +48,18 @@ function getDateGroup(date: Dayjs, today: Dayjs) {
   }
 }
 
-function getGroupedActivitiesByDate(activities: Activity[]) {
+function getGroupedActivitiesByDate(
+  activities: Activity[],
+  weekStartsOn: number,
+) {
   const today = dayjs()
   return activities.reduce(
     (result, activity) => {
-      const activityGroup = getDateGroup(dayjs(activity.time), today)
+      const activityGroup = getDateGroup(
+        dayjs(activity.time),
+        today,
+        weekStartsOn,
+      )
       result[activityGroup] = result[activityGroup] ?? []
       result[activityGroup].push(activity)
       return result
@@ -85,6 +93,8 @@ ActivitiesLoading.displayName = 'ActivitiesLoading'
 
 export function ActivityList() {
   const t = useTranslations('Activity')
+  const locale = useLocale()
+  const weekStartsOn = getWeekStartsOn(locale)
   const { group, groupId } = useCurrentGroup()
 
   const {
@@ -106,7 +116,10 @@ export function ActivityList() {
 
   if (isLoading || !activities || !group) return <ActivitiesLoading />
 
-  const groupedActivitiesByDate = getGroupedActivitiesByDate(activities)
+  const groupedActivitiesByDate = getGroupedActivitiesByDate(
+    activities,
+    weekStartsOn,
+  )
 
   return activities.length > 0 ? (
     <>

--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -4,10 +4,11 @@ import { getGroupExpensesAction } from '@/app/groups/[groupId]/expenses/expense-
 import { Button } from '@/components/ui/button'
 import { SearchBar } from '@/components/ui/search-bar'
 import { Skeleton } from '@/components/ui/skeleton'
+import { getWeekStartsOn, isSameWeek } from '@/lib/date-groups'
 import { getCurrencyFromGroup } from '@/lib/utils'
 import { trpc } from '@/trpc/client'
 import dayjs, { type Dayjs } from 'dayjs'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { forwardRef, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
@@ -30,10 +31,10 @@ const EXPENSE_GROUPS = {
   OLDER: 'older',
 }
 
-function getExpenseGroup(date: Dayjs, today: Dayjs) {
+function getExpenseGroup(date: Dayjs, today: Dayjs, weekStartsOn: number) {
   if (today.isBefore(date)) {
     return EXPENSE_GROUPS.UPCOMING
-  } else if (today.isSame(date, 'week')) {
+  } else if (isSameWeek(today, date, weekStartsOn)) {
     return EXPENSE_GROUPS.THIS_WEEK
   } else if (today.isSame(date, 'month')) {
     return EXPENSE_GROUPS.EARLIER_THIS_MONTH
@@ -48,10 +49,17 @@ function getExpenseGroup(date: Dayjs, today: Dayjs) {
   }
 }
 
-function getGroupedExpensesByDate(expenses: ExpensesType) {
+function getGroupedExpensesByDate(
+  expenses: ExpensesType,
+  weekStartsOn: number,
+) {
   const today = dayjs()
   return expenses.reduce((result: { [key: string]: ExpensesType }, expense) => {
-    const expenseGroup = getExpenseGroup(dayjs(expense.expenseDate), today)
+    const expenseGroup = getExpenseGroup(
+      dayjs(expense.expenseDate),
+      today,
+      weekStartsOn,
+    )
     result[expenseGroup] = result[expenseGroup] ?? []
     result[expenseGroup].push(expense)
     return result
@@ -114,6 +122,8 @@ const ExpenseListForSearch = ({
   }, [utils])
 
   const t = useTranslations('Expenses')
+  const locale = useLocale()
+  const weekStartsOn = getWeekStartsOn(locale)
   const { ref: loadingRef, inView } = useInView()
 
   const {
@@ -134,8 +144,8 @@ const ExpenseListForSearch = ({
   }, [fetchNextPage, hasMore, inView, isLoading])
 
   const groupedExpensesByDate = useMemo(
-    () => (expenses ? getGroupedExpensesByDate(expenses) : {}),
-    [expenses],
+    () => (expenses ? getGroupedExpensesByDate(expenses, weekStartsOn) : {}),
+    [expenses, weekStartsOn],
   )
 
   if (isLoading) return <ExpensesLoading />

--- a/src/lib/date-groups.test.ts
+++ b/src/lib/date-groups.test.ts
@@ -1,0 +1,56 @@
+import dayjs from 'dayjs'
+import { getWeekStartsOn, isSameWeek } from './date-groups'
+
+describe('getWeekStartsOn', () => {
+  it('returns Monday (1) for German locale', () => {
+    expect(getWeekStartsOn('de-DE')).toBe(1)
+  })
+
+  it('returns Sunday (0) for US English locale', () => {
+    expect(getWeekStartsOn('en-US')).toBe(0)
+  })
+
+  it('falls back to Monday (1) when the locale cannot be parsed', () => {
+    // An empty/malformed locale makes `new Intl.Locale` throw, exercising the
+    // fallback path (also hit on engines without `Intl` week info).
+    expect(getWeekStartsOn('')).toBe(1)
+  })
+})
+
+describe('isSameWeek', () => {
+  // 2024-01-01 is a Monday, 2024-01-07 a Sunday, 2024-01-08 the next Monday.
+  const monday = dayjs('2024-01-01')
+  const sameSunday = dayjs('2024-01-07')
+  const nextMonday = dayjs('2024-01-08')
+  const previousSunday = dayjs('2023-12-31')
+
+  describe('with a Monday-based week (weekStartsOn = 1)', () => {
+    it('groups Monday through the following Sunday together', () => {
+      expect(isSameWeek(monday, sameSunday, 1)).toBe(true)
+    })
+
+    it('does not group the Sunday before Monday into the same week', () => {
+      expect(isSameWeek(monday, previousSunday, 1)).toBe(false)
+    })
+
+    it('starts a new week on the following Monday', () => {
+      expect(isSameWeek(monday, nextMonday, 1)).toBe(false)
+    })
+  })
+
+  describe('with a Sunday-based week (weekStartsOn = 0)', () => {
+    it('groups the Sunday before Monday into the same week', () => {
+      expect(isSameWeek(monday, previousSunday, 0)).toBe(true)
+    })
+
+    it('does not group Monday with the following Sunday', () => {
+      expect(isSameWeek(monday, sameSunday, 0)).toBe(false)
+    })
+  })
+
+  it('ignores the time of day', () => {
+    expect(
+      isSameWeek(dayjs('2024-01-01T23:59:59'), dayjs('2024-01-01T00:00:00'), 1),
+    ).toBe(true)
+  })
+})

--- a/src/lib/date-groups.ts
+++ b/src/lib/date-groups.ts
@@ -1,0 +1,47 @@
+import { Dayjs } from 'dayjs'
+
+/**
+ * Determine the first day of the week for a given locale, expressed using
+ * dayjs' day index convention (0 = Sunday, 1 = Monday, … 6 = Saturday).
+ *
+ * The value is derived from the platform `Intl.Locale` week information
+ * (e.g. Monday for `de-DE`, Sunday for `en-US`). When that information is
+ * unavailable, we fall back to Monday, which is the correct default for the
+ * large majority of the app's supported locales.
+ */
+export function getWeekStartsOn(locale: string): number {
+  try {
+    const intlLocale = new Intl.Locale(locale) as Intl.Locale & {
+      getWeekInfo?: () => { firstDay: number }
+      weekInfo?: { firstDay: number }
+    }
+    // `firstDay` is 1..7 (Monday..Sunday). Convert to dayjs' 0..6 (Sunday..Saturday).
+    const firstDay =
+      intlLocale.getWeekInfo?.().firstDay ?? intlLocale.weekInfo?.firstDay
+    if (firstDay) return firstDay % 7
+  } catch {
+    // Unsupported locale or missing Intl week info: fall through to the default.
+  }
+  return 1
+}
+
+/**
+ * Return the start of the week containing `date`, honouring the given
+ * first-day-of-week. Independent of dayjs' globally configured locale so the
+ * result is deterministic.
+ */
+function startOfWeek(date: Dayjs, weekStartsOn: number): Dayjs {
+  const diff = (date.day() - weekStartsOn + 7) % 7
+  return date.subtract(diff, 'day').startOf('day')
+}
+
+/**
+ * Whether `a` and `b` fall in the same week, where the week starts on
+ * `weekStartsOn` (0 = Sunday … 6 = Saturday).
+ */
+export function isSameWeek(a: Dayjs, b: Dayjs, weekStartsOn: number): boolean {
+  return startOfWeek(a, weekStartsOn).isSame(
+    startOfWeek(b, weekStartsOn),
+    'day',
+  )
+}


### PR DESCRIPTION
# fix: honour locale week start when grouping expenses and activity

First of the series in #553. Self-contained, ~100 lines, fully unit-tested — no
dependency on anything else queued there.

## The bug

The expenses and activity lists group entries under time-period headers ("This
week", "Earlier this week", "Last week", …). Week boundaries are computed with
dayjs' `isSame(date, 'week')`, which reads dayjs' **global** locale `weekStart`.
That global is never wired to the app's active next-intl locale, so it stays at
its default of Sunday for every user, in every locale.

The visible effect: a Sunday entry is grouped into the current week even for the
many supported locales whose week starts on Monday. On a Monday, a `de-DE` user
sees yesterday's expense filed under "This week" rather than "Last week" —
Sunday is last week for them.

Spliit ships far more Monday-first locales than Sunday-first ones, so the
default is wrong for most of the user base.

## The fix

A new `src/lib/date-groups.ts`:

- `getWeekStartsOn(locale)` reads the first day of the week from `Intl.Locale`
  week info (`getWeekInfo()`, falling back to the `weekInfo` property), and
  converts it from the ECMA-402 1..7 Monday-first convention to dayjs' 0..6
  Sunday-first one. Locales without week info, or an unparseable locale, fall
  back to Monday.
- `isSameWeek(a, b, weekStartsOn)` compares the two dates' week starts.

The helper takes the first day as an argument rather than reading dayjs' global,
which keeps it deterministic and testable. The two list components pass what
they get from next-intl's `useLocale()`.

## Notes for review

- **Nothing configures dayjs globally.** I deliberately did not call
  `dayjs.updateLocale()` — a global mutation would fix these two call sites and
  silently change every other date computation in the app.
- **Why Monday as the fallback**, not Sunday: it is correct for the majority of
  the locales Spliit ships. It only applies on engines without `Intl` week info,
  which in practice means very old runtimes.
- `activity-list.tsx` gains one extra call: the "Last week" bucket also had to
  move to `isSameWeek`, since `today.subtract(1, 'week').isSame(date, 'week')`
  has the same global-locale problem.

## Verification

`npm ci --ignore-scripts`, `npx prisma generate`, `check-types`, `lint`,
`check-formatting` all clean against current `main` (lint: 16 warnings, all
pre-existing). `date-groups.test.ts` covers `de-DE`, `en-US`, the unparseable
fallback, both week conventions across a Monday/Sunday boundary, and
time-of-day insensitivity.

`npm test` is not wired into CI yet — a later PR in the series adds that.
