### PR TITLE
security: harden AI extraction, CSV export, and the migration script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: ['main']
 
+# Least privilege: the checks only read the repository. Without an explicit
+# block, the workflow runs with the repository's default token scopes, which
+# for many repositories includes write access.
+permissions:
+  contents: read
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
@@ -1,6 +1,8 @@
 'use server'
 import { getCategories } from '@/lib/api'
 import { env } from '@/lib/env'
+import { getRuntimeFeatureFlags } from '@/lib/featureFlags'
+import { isAllowedUploadUrl } from '@/lib/uploaded-image-url'
 import { formatCategoryForAIPrompt } from '@/lib/utils'
 import OpenAI from 'openai'
 import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/index.mjs'
@@ -9,6 +11,21 @@ const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY })
 
 export async function extractExpenseInformationFromImage(imageUrl: string) {
   'use server'
+
+  // Enforce the feature flag server-side: the UI gate only hides the button, it
+  // does not prevent the action endpoint from being invoked directly.
+  const { enableReceiptExtract } = await getRuntimeFeatureFlags()
+  if (!enableReceiptExtract) {
+    throw new Error('Receipt extraction is not enabled.')
+  }
+
+  // Only extract from images the app itself uploaded. Without this, an arbitrary
+  // caller-supplied URL is forwarded to the model, enabling SSRF-via-OpenAI and
+  // unbounded API spend.
+  if (!isAllowedUploadUrl(imageUrl)) {
+    throw new Error('Invalid image URL.')
+  }
+
   const categories = await getCategories()
 
   const body: ChatCompletionCreateParamsNonStreaming = {
@@ -42,7 +59,15 @@ export async function extractExpenseInformationFromImage(imageUrl: string) {
   const [amountString, categoryId, date, title] = completion.choices
     .at(0)
     ?.message.content?.split(',') ?? [null, null, null, null]
-  return { amount: Number(amountString), categoryId, date, title }
+  // The model is asked for a plain number, but nothing guarantees it obliges.
+  // Report "not extracted" rather than passing NaN on to the expense form.
+  const amount = Number(amountString)
+  return {
+    amount: Number.isFinite(amount) ? amount : null,
+    categoryId,
+    date,
+    title,
+  }
 }
 
 export type ReceiptExtractedInfo = Awaited<

--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -1,7 +1,7 @@
 import { getCurrency } from '@/lib/currency'
+import { prisma } from '@/lib/prisma'
 import { formatAmountAsDecimal, getCurrencyFromGroup } from '@/lib/utils'
 import { Parser } from '@json2csv/plainjs'
-import { PrismaClient } from '@prisma/client'
 import contentDisposition from 'content-disposition'
 import { NextResponse } from 'next/server'
 
@@ -12,6 +12,17 @@ const splitModeLabel = {
   BY_AMOUNT: 'Unevenly – By amount',
 }
 
+/**
+ * Prevents CSV formula/command injection (CWE-1236): a cell beginning with
+ * =, +, -, @, tab or carriage return can be executed as a formula by spreadsheet
+ * applications (Excel, LibreOffice, Sheets). Expense titles, category and
+ * participant names are user-controlled, so prefix such text cells with a single
+ * quote to neutralize them.
+ */
+function escapeCsvFormula(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value
+}
+
 function formatDate(isoDateString: Date): string {
   const date = new Date(isoDateString)
   const year = date.getFullYear()
@@ -19,8 +30,6 @@ function formatDate(isoDateString: Date): string {
   const day = String(date.getDate()).padStart(2, '0')
   return `${year}-${month}-${day}` // YYYY-MM-DD format
 }
-
-const prisma = new PrismaClient()
 
 export async function GET(
   req: Request,
@@ -95,7 +104,7 @@ export async function GET(
     { label: 'Is Reimbursement', value: 'isReimbursement' },
     { label: 'Split mode', value: 'splitMode' },
     ...group.participants.map((participant) => ({
-      label: participant.name,
+      label: escapeCsvFormula(participant.name),
       value: participant.name,
     })),
   ]
@@ -104,8 +113,8 @@ export async function GET(
 
   const expenses = group.expenses.map((expense) => ({
     date: formatDate(expense.expenseDate),
-    title: expense.title,
-    categoryName: expense.category?.name || '',
+    title: escapeCsvFormula(expense.title),
+    categoryName: escapeCsvFormula(expense.category?.name || ''),
     currency: group.currencyCode ?? group.currency,
     amount: formatAmountAsDecimal(expense.amount, currency),
     originalAmount: expense.originalAmount

--- a/src/components/expense-form-actions.tsx
+++ b/src/components/expense-form-actions.tsx
@@ -1,6 +1,7 @@
 'use server'
 import { getCategories } from '@/lib/api'
 import { env } from '@/lib/env'
+import { getRuntimeFeatureFlags } from '@/lib/featureFlags'
 import { formatCategoryForAIPrompt } from '@/lib/utils'
 import OpenAI from 'openai'
 import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/index.mjs'
@@ -16,6 +17,14 @@ const limit = 40 // ~10 tokens
  */
 export async function extractCategoryFromTitle(description: string) {
   'use server'
+
+  // Enforce the feature flag server-side: the UI gate only hides the feature, it
+  // does not prevent the action endpoint from being invoked directly.
+  const { enableCategoryExtract } = await getRuntimeFeatureFlags()
+  if (!enableCategoryExtract) {
+    throw new Error('Category extraction is not enabled.')
+  }
+
   const categories = await getCategories()
 
   const body: ChatCompletionCreateParamsNonStreaming = {

--- a/src/lib/uploaded-image-url.test.ts
+++ b/src/lib/uploaded-image-url.test.ts
@@ -1,0 +1,153 @@
+import { env } from './env'
+import { isAllowedUploadUrl } from './uploaded-image-url'
+
+// The helper derives its allow-list from the S3 upload configuration in `env`.
+// Mock it with a mutable object so each test can set the relevant variables;
+// `getAllowedUploadHosts` reads these properties live on every call.
+jest.mock('./env', () => ({ env: {} }))
+
+const mockEnv = env as {
+  S3_UPLOAD_ENDPOINT?: string
+  S3_UPLOAD_BUCKET?: string
+  S3_UPLOAD_REGION?: string
+}
+
+describe('isAllowedUploadUrl', () => {
+  afterEach(() => {
+    delete mockEnv.S3_UPLOAD_ENDPOINT
+    delete mockEnv.S3_UPLOAD_BUCKET
+    delete mockEnv.S3_UPLOAD_REGION
+  })
+
+  describe('with a custom S3 endpoint configured', () => {
+    beforeEach(() => {
+      mockEnv.S3_UPLOAD_ENDPOINT = 'https://minio.example.com'
+    })
+
+    it('allows a URL on the configured endpoint host', () => {
+      expect(
+        isAllowedUploadUrl('https://minio.example.com/bucket/receipt.jpg'),
+      ).toBe(true)
+    })
+
+    it('allows the endpoint host regardless of port', () => {
+      mockEnv.S3_UPLOAD_ENDPOINT = 'https://minio.example.com:9000'
+      expect(
+        isAllowedUploadUrl('https://minio.example.com:9000/bucket/receipt.jpg'),
+      ).toBe(true)
+    })
+
+    it('rejects a different host (SSRF / denial-of-wallet attempt)', () => {
+      expect(isAllowedUploadUrl('https://evil.example.com/receipt.jpg')).toBe(
+        false,
+      )
+    })
+
+    it('rejects a subdomain of the allowed host', () => {
+      expect(
+        isAllowedUploadUrl('https://minio.example.com.evil.com/receipt.jpg'),
+      ).toBe(false)
+    })
+
+    it('allows http as well as https', () => {
+      expect(
+        isAllowedUploadUrl('http://minio.example.com/bucket/receipt.jpg'),
+      ).toBe(true)
+    })
+
+    it('rejects non-http(s) schemes even when the host matches', () => {
+      expect(isAllowedUploadUrl('ftp://minio.example.com/receipt.jpg')).toBe(
+        false,
+      )
+      expect(isAllowedUploadUrl('gopher://minio.example.com/x')).toBe(false)
+    })
+  })
+
+  describe('with the AWS bucket/region fallback', () => {
+    beforeEach(() => {
+      mockEnv.S3_UPLOAD_BUCKET = 'my-bucket'
+      mockEnv.S3_UPLOAD_REGION = 'eu-central-1'
+    })
+
+    it('allows the derived bucket.s3.region.amazonaws.com host', () => {
+      expect(
+        isAllowedUploadUrl(
+          'https://my-bucket.s3.eu-central-1.amazonaws.com/receipts/1.png',
+        ),
+      ).toBe(true)
+    })
+
+    it('rejects the same bucket in a different region', () => {
+      expect(
+        isAllowedUploadUrl(
+          'https://my-bucket.s3.us-east-1.amazonaws.com/receipts/1.png',
+        ),
+      ).toBe(false)
+    })
+
+    it('rejects an unrelated host', () => {
+      expect(isAllowedUploadUrl('https://attacker.com/receipts/1.png')).toBe(
+        false,
+      )
+    })
+  })
+
+  describe('precedence of endpoint over bucket/region', () => {
+    it('uses only the endpoint host when both are configured', () => {
+      mockEnv.S3_UPLOAD_ENDPOINT = 'https://minio.example.com'
+      mockEnv.S3_UPLOAD_BUCKET = 'my-bucket'
+      mockEnv.S3_UPLOAD_REGION = 'eu-central-1'
+
+      expect(
+        isAllowedUploadUrl('https://minio.example.com/bucket/receipt.jpg'),
+      ).toBe(true)
+      // The AWS-derived host is not trusted because the endpoint branch wins.
+      expect(
+        isAllowedUploadUrl(
+          'https://my-bucket.s3.eu-central-1.amazonaws.com/receipts/1.png',
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe('malformed input', () => {
+    beforeEach(() => {
+      mockEnv.S3_UPLOAD_ENDPOINT = 'https://minio.example.com'
+    })
+
+    it('rejects strings that are not URLs', () => {
+      expect(isAllowedUploadUrl('not a url')).toBe(false)
+      expect(isAllowedUploadUrl('')).toBe(false)
+      expect(isAllowedUploadUrl('/relative/path.jpg')).toBe(false)
+    })
+
+    it('rejects javascript: and data: URLs', () => {
+      expect(isAllowedUploadUrl('javascript:alert(1)')).toBe(false)
+      expect(isAllowedUploadUrl('data:image/png;base64,iVBORw0KGgo=')).toBe(
+        false,
+      )
+    })
+  })
+
+  describe('with no S3 configuration', () => {
+    it('rejects every URL because the allow-list is empty', () => {
+      expect(
+        isAllowedUploadUrl('https://minio.example.com/bucket/receipt.jpg'),
+      ).toBe(false)
+      expect(
+        isAllowedUploadUrl(
+          'https://my-bucket.s3.eu-central-1.amazonaws.com/receipts/1.png',
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe('with an unparseable endpoint', () => {
+    it('contributes no allowed host and rejects everything', () => {
+      mockEnv.S3_UPLOAD_ENDPOINT = 'http://[not a valid url'
+      expect(
+        isAllowedUploadUrl('https://minio.example.com/bucket/receipt.jpg'),
+      ).toBe(false)
+    })
+  })
+})

--- a/src/lib/uploaded-image-url.ts
+++ b/src/lib/uploaded-image-url.ts
@@ -1,0 +1,41 @@
+import { env } from './env'
+
+/**
+ * Hosts that uploaded receipt/document images can legitimately live on, derived
+ * from the configured S3 storage. Mirrors the image `remotePatterns` logic in
+ * next.config.mjs so that the set of trusted hosts stays consistent.
+ */
+function getAllowedUploadHosts(): string[] {
+  const hosts: string[] = []
+  if (env.S3_UPLOAD_ENDPOINT) {
+    // custom endpoint for providers other than AWS
+    try {
+      hosts.push(new URL(env.S3_UPLOAD_ENDPOINT).hostname)
+    } catch {
+      // ignore an unparseable endpoint; it simply contributes no allowed host
+    }
+  } else if (env.S3_UPLOAD_BUCKET && env.S3_UPLOAD_REGION) {
+    // default AWS provider
+    hosts.push(
+      `${env.S3_UPLOAD_BUCKET}.s3.${env.S3_UPLOAD_REGION}.amazonaws.com`,
+    )
+  }
+  return hosts
+}
+
+/**
+ * Returns true only for http(s) URLs whose host is one of the app's own
+ * configured upload hosts. Used to ensure AI extraction is performed against
+ * images the app itself produced, rather than an arbitrary attacker-supplied
+ * URL (which would otherwise enable SSRF-via-OpenAI and unbounded API spend).
+ */
+export function isAllowedUploadUrl(rawUrl: string): boolean {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return false
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return false
+  return getAllowedUploadHosts().includes(url.hostname)
+}

--- a/src/scripts/migrate.ts
+++ b/src/scripts/migrate.ts
@@ -4,8 +4,6 @@ import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { Client } from 'pg'
 
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-
 async function main() {
   withClient(async (client) => {
     // console.log('Deleting all groups…')
@@ -116,9 +114,15 @@ async function main() {
 }
 
 async function withClient(fn: (client: Client) => void | Promise<void>) {
+  // Connect over TLS with full certificate validation. If the legacy database
+  // presents a certificate signed by a private/self-signed CA, provide that CA
+  // via OLD_POSTGRES_CA_CERT instead of disabling validation (previously done
+  // globally with NODE_TLS_REJECT_UNAUTHORIZED='0', which turned off TLS
+  // verification for the entire process).
+  const caCert = process.env.OLD_POSTGRES_CA_CERT
   const client = new Client({
     connectionString: process.env.OLD_POSTGRES_URL,
-    ssl: true,
+    ssl: caCert ? { ca: caCert, rejectUnauthorized: true } : true,
   })
   await client.connect()
   console.log('Connected.')


### PR DESCRIPTION
# security: harden AI extraction, CSV export, and the migration script

Part of the series in #553. Five independent fixes, none of which changes
behaviour for a correctly-configured instance. Grouped into one PR because they
are all small and all fall out of the same audit; happy to split any of them out
if you'd rather review them separately.

Nothing here is being publicly disclosed anywhere; if you'd prefer to take any
of it privately instead, say so and I'll close this and re-send.

## 1. AI extraction was reachable with the feature flags off

`extractExpenseInformationFromImage` and `extractCategoryFromTitle` are server
actions, so each has its own callable endpoint. `ENABLE_RECEIPT_EXTRACT` and
`ENABLE_CATEGORY_EXTRACT` only ever hid the buttons that call them.

An instance that deliberately leaves the AI features off — because the operator
does not want to pay for them, or has no key configured — still had them
callable by anyone who can reach the app, spending the operator's OpenAI credit.
Both actions now check `getRuntimeFeatureFlags()` before doing any work.

## 2. Receipt extraction forwarded any caller-supplied URL to OpenAI

The image URL is a plain string parameter of the action. Since the action is
directly callable (see above), an arbitrary URL could be passed and OpenAI would
fetch it: an SSRF primitive using someone else's egress, plus unmetered API
spend on images the app never uploaded.

New `isAllowedUploadUrl` restricts extraction to `http(s)` URLs on the app's own
configured S3 host. It derives that host exactly the way `next.config.mjs`
derives the image `remotePatterns` — custom `S3_UPLOAD_ENDPOINT` if set,
otherwise the `bucket.s3.region.amazonaws.com` form — so the trusted-host set
stays consistent between the two. With no S3 configured the allow-list is empty
and nothing passes, which is the right answer: without uploads there are no
receipts to extract.

Unit-tested, including suffix look-alikes (`minio.example.com.evil.com`),
non-`http(s)` schemes, port insensitivity, and the unconfigured case.

## 3. The receipt action could return `NaN`

The model is asked for a plain number but nothing guarantees it obliges;
`Number()` on anything else yields `NaN`, which flowed into the expense form. It
now reports `null`, which the dialog already renders as "unknown" — the existing
truthiness check on `receiptInfo.amount` handles both, so this is a
tightening rather than a behaviour change.

## 4. CSV formula injection (CWE-1236)

Expense titles, category names and participant names are user-controlled and
were written to the export verbatim. A cell beginning with `=`, `+`, `-`, `@`,
tab or CR is executed as a formula by Excel, LibreOffice and Google Sheets when
the file is opened.

So a group member can title an expense `=HYPERLINK(...)` or a `WEBSERVICE` call
and have it execute in another member's spreadsheet — the export is the delivery
mechanism, and the person who opens it is not the person who wrote the text.
Such cells are now prefixed with a single quote, the standard neutralisation.

## 5. The CSV route created its own `PrismaClient`

Every other data path uses the `@/lib/prisma` singleton; this route constructed a
second client at module scope, opening a second connection pool. On a
long-running container that is a slow leak against the database's connection
limit. Now uses the singleton, matching the JSON export route right next to it.

## Two smaller items in the same spirit

- **`src/scripts/migrate.ts` disabled TLS verification process-wide.** It set
  `NODE_TLS_REJECT_UNAUTHORIZED='0'` at module scope, which turns off
  certificate validation for *every* outbound TLS connection the process makes,
  not just the legacy database one it was meant for. The script now connects
  with validated TLS; a self-signed legacy database can supply its CA through a
  new `OLD_POSTGRES_CA_CERT` env var. (This is the one-off v1→v2 import script,
  so the blast radius is small, but it is also the script most likely to be run
  with production credentials in the environment.)
- **`ci.yml` had no `permissions:` block**, so it ran with the repository's
  default token scopes. The checks only read the repository. `cd.yml` already
  declares per-job permissions, so this just brings CI in line.

## Verification

`npm ci --ignore-scripts`, `npx prisma generate`, `check-types`, `lint`,
`check-formatting` all clean against current `main` (lint: 16 warnings, all
pre-existing). `uploaded-image-url.test.ts` adds 14 cases.

## Not included

The regex-injection fix in `add-group-by-url-button.tsx` was part of the same
audit, but it already went upstream with #558 — it was needed there to keep the
QR scanner's relative-URL support from accepting any host.
