### PR TITLE
docs: add Open Collective as a way to support the project

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -10,4 +10,4 @@ liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
 lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-custom: ['https://donate.stripe.com/28o3eh96G7hH8k89Ba']
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,7 @@
 
 github: ['scastiel']
 patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
+open_collective: spliit
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry

--- a/README.md
+++ b/README.md
@@ -44,9 +44,8 @@ Spliit is free, open source, and has no ads. Hosting, database and API costs are
 paid for by donations. If you want to help keep it that way, you can:
 
 - 🧡 [Support us on Open Collective](https://opencollective.com/spliit) — recurring or one-time,
-  with a public and transparent ledger of what comes in and what it is spent on,
-- 💜 [Sponsor me (Sebastien)](https://github.com/sponsors/scastiel), or
-- 💙 [Make a small one-time donation](https://donate.stripe.com/28o3eh96G7hH8k89Ba).
+  with a public and transparent ledger of what comes in and what it is spent on, or
+- 💜 [Sponsor me (Sebastien)](https://github.com/sponsors/scastiel).
 
 Contributions of any size are appreciated, and so is simply telling people about
 the project.

--- a/README.md
+++ b/README.md
@@ -38,10 +38,18 @@ Spliit is a free and open source alternative to Splitwise. You can either use th
 The project is open to contributions. Feel free to open an issue or even a pull-request! 
 Join the discussion in [the Spliit Discord server](https://discord.gg/YSyVXbwvSY).
 
-If you want to contribute financially and help us keep the application free and without ads, you can also:
+### Contribute financially
 
+Spliit is free, open source, and has no ads. Hosting, database and API costs are
+paid for by donations. If you want to help keep it that way, you can:
+
+- 🧡 [Support us on Open Collective](https://opencollective.com/spliit) — recurring or one-time,
+  with a public and transparent ledger of what comes in and what it is spent on,
 - 💜 [Sponsor me (Sebastien)](https://github.com/sponsors/scastiel), or
 - 💙 [Make a small one-time donation](https://donate.stripe.com/28o3eh96G7hH8k89Ba).
+
+Contributions of any size are appreciated, and so is simply telling people about
+the project.
 
 ### Translation
 


### PR DESCRIPTION
## Summary

Adds Open Collective as the primary way to contribute financially to Spliit, and removes the Stripe payment link now that Open Collective covers one-time donations too.

## Changes

- **README** — the one-line "if you want to contribute financially" note becomes its own `### Contribute financially` subsection under _Contribute_ (alongside `### Translation`). It states that the project is free, ad-free and donation-funded, then lists Open Collective (recurring or one-time, with a public ledger) and GitHub Sponsors.
- **`.github/FUNDING.yml`** — sets `open_collective: spliit` so the GitHub Sponsor button offers the collective, and returns `custom:` to its commented placeholder.

The Stripe link had no other references anywhere in the repo.

## Note before merging

`opencollective.com/spliit` must exist and be approved by a fiscal host, otherwise the Sponsor button entry and the README link will 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtRWo2aURDBiBSh9hCkKo5