### PR TITLE
Shares

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -44,11 +44,13 @@ import {
   SplittingOptions,
   expenseFormSchema,
 } from '@/lib/schemas'
+import { distributeAmount } from '@/lib/shares'
 import { calculateShare } from '@/lib/totals'
 import {
   amountAsDecimal,
   amountAsMinorUnits,
   cn,
+  formatAmountAsDecimal,
   formatCurrency,
   getCurrencyFromGroup,
 } from '@/lib/utils'
@@ -370,17 +372,23 @@ export function ExpenseForm({
       })
 
       if (remainingParticipants > 0) {
-        let amountPerRemaining = 0
-        if (splitMode === 'BY_AMOUNT') {
-          amountPerRemaining = remainingAmount / remainingParticipants
-        }
+        // Apportion in minor units so the auto-filled amounts add up to the
+        // total exactly. Dividing and rounding each one independently makes
+        // 95 across three participants come out as 31.67 three times, which
+        // the "amounts must add up" validation then rejects.
+        const amountsPerRemaining = distributeAmount(
+          amountAsMinorUnits(remainingAmount, groupCurrency),
+          remainingParticipants,
+        )
 
+        let remainingIndex = 0
         newPaidFor = newPaidFor.map((participant) => {
           if (!editedParticipants.includes(participant.participant)) {
             return {
               ...participant,
-              shares: amountPerRemaining.toFixed(
-                groupCurrency.decimal_digits,
+              shares: formatAmountAsDecimal(
+                amountsPerRemaining[remainingIndex++],
+                groupCurrency,
               ) as any, // Keep as string for consistent schema handling
             }
           }
@@ -932,6 +940,14 @@ export function ExpenseForm({
                                       {formatCurrency(
                                         groupCurrency,
                                         calculateShare(id, {
+                                          // A new expense has no id yet — ids
+                                          // are minted server-side — so the
+                                          // leftover minor unit of an uneven
+                                          // split may land on a different
+                                          // participant once it is saved. When
+                                          // editing, this makes the amounts
+                                          // here match the balances tab.
+                                          id: expense?.id,
                                           amount: amountAsMinorUnits(
                                             Number(form.watch('amount')),
                                             groupCurrency,

--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -1,5 +1,6 @@
 import { getCurrency } from '@/lib/currency'
 import { prisma } from '@/lib/prisma'
+import { getExpenseShares } from '@/lib/shares'
 import { formatAmountAsDecimal, getCurrencyFromGroup } from '@/lib/utils'
 import { Parser } from '@json2csv/plainjs'
 import contentDisposition from 'content-disposition'
@@ -45,6 +46,9 @@ export async function GET(
       currencyCode: true,
       expenses: {
         select: {
+          // Seeds which participant is offered the leftover minor unit of an
+          // uneven split, so the export agrees with the balances tab.
+          id: true,
           expenseDate: true,
           title: true,
           category: { select: { name: true } },
@@ -111,50 +115,46 @@ export async function GET(
 
   const currency = getCurrencyFromGroup(group)
 
-  const expenses = group.expenses.map((expense) => ({
-    date: formatDate(expense.expenseDate),
-    title: escapeCsvFormula(expense.title),
-    categoryName: escapeCsvFormula(expense.category?.name || ''),
-    currency: group.currencyCode ?? group.currency,
-    amount: formatAmountAsDecimal(expense.amount, currency),
-    originalAmount: expense.originalAmount
-      ? formatAmountAsDecimal(
-          expense.originalAmount,
-          getCurrency(expense.originalCurrency),
-        )
-      : null,
-    originalCurrency: expense.originalCurrency,
-    conversionRate: expense.conversionRate
-      ? expense.conversionRate.toString()
-      : null,
-    isReimbursement: expense.isReimbursement ? 'Yes' : 'No',
-    splitMode: splitModeLabel[expense.splitMode],
-    ...Object.fromEntries(
-      group.participants.map((participant) => {
-        const { totalShares, participantShare } = expense.paidFor.reduce(
-          (acc, { participantId, shares }) => {
-            acc.totalShares += shares
-            if (participantId === participant.id) {
-              acc.participantShare = shares
-            }
-            return acc
-          },
-          { totalShares: 0, participantShare: 0 },
-        )
+  const expenses = group.expenses.map((expense) => {
+    const shares = getExpenseShares(expense)
 
-        const isPaidByParticipant = expense.paidById === participant.id
-        const participantAmountShare = +formatAmountAsDecimal(
-          (expense.amount / totalShares) * participantShare,
-          currency,
-        )
+    return {
+      date: formatDate(expense.expenseDate),
+      title: escapeCsvFormula(expense.title),
+      categoryName: escapeCsvFormula(expense.category?.name || ''),
+      currency: group.currencyCode ?? group.currency,
+      amount: formatAmountAsDecimal(expense.amount, currency),
+      originalAmount: expense.originalAmount
+        ? formatAmountAsDecimal(
+            expense.originalAmount,
+            getCurrency(expense.originalCurrency),
+          )
+        : null,
+      originalCurrency: expense.originalCurrency,
+      conversionRate: expense.conversionRate
+        ? expense.conversionRate.toString()
+        : null,
+      isReimbursement: expense.isReimbursement ? 'Yes' : 'No',
+      splitMode: splitModeLabel[expense.splitMode],
+      ...Object.fromEntries(
+        group.participants.map((participant) => {
+          const isPaidByParticipant = expense.paidById === participant.id
+          // The same apportionment the balances tab uses, so a participant's
+          // column here matches what they are actually charged: whole minor
+          // units, honouring the split mode, adding up to the expense amount.
+          const participantAmountShare = +formatAmountAsDecimal(
+            shares.get(participant.id) ?? 0,
+            currency,
+          )
 
-        return [
-          participant.name,
-          participantAmountShare * (isPaidByParticipant ? 1 : -1),
-        ]
-      }),
-    ),
-  }))
+          return [
+            participant.name,
+            participantAmountShare * (isPaidByParticipant ? 1 : -1),
+          ]
+        }),
+      ),
+    }
+  })
 
   const json2csvParser = new Parser({ fields })
   const csv = json2csvParser.parse(expenses)

--- a/src/lib/balances.test.ts
+++ b/src/lib/balances.test.ts
@@ -1,0 +1,399 @@
+import { getGroupExpenses } from '@/lib/api'
+import { getBalances, getSuggestedReimbursements } from './balances'
+
+type Expenses = NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>
+type Expense = Expenses[number]
+
+function expense(
+  paidBy: string,
+  amount: number,
+  paidFor: string[],
+  isReimbursement = false,
+): Expense {
+  return {
+    amount,
+    isReimbursement,
+    splitMode: 'EVENLY',
+    paidBy: { id: paidBy, name: paidBy },
+    paidFor: paidFor.map((id) => ({
+      participant: { id, name: id },
+      shares: 100,
+    })),
+  } as Expense
+}
+
+describe('getBalances', () => {
+  it('splits an expense evenly between the participants', () => {
+    const balances = getBalances([expense('alice', 3000, ['alice', 'bob'])])
+
+    expect(balances.alice).toEqual({ paid: 3000, paidFor: 1500, total: 1500 })
+    expect(balances.bob).toEqual({ paid: 0, paidFor: 1500, total: -1500 })
+  })
+
+  it('counts a reimbursement like any other expense', () => {
+    const balances = getBalances([
+      expense('alice', 3000, ['alice', 'bob']),
+      expense('bob', 1500, ['alice'], true),
+    ])
+
+    expect(balances.alice.total).toBe(0)
+    expect(balances.bob.total).toBe(0)
+  })
+})
+
+describe('settling up', () => {
+  /**
+   * Repayments are recorded in the group currency, so booking a suggested reimbursement
+   * must bring every balance to exactly zero — including when the expense was originally
+   * entered in another currency and converted.
+   */
+  it('brings every balance to zero once the suggestions are booked', () => {
+    const expenses = [
+      expense('alice', 500000, ['alice', 'bob', 'carol']),
+      expense('bob', 12345, ['alice', 'bob', 'carol']),
+      expense('carol', 999, ['alice', 'bob']),
+    ]
+
+    const reimbursements = getSuggestedReimbursements(getBalances(expenses))
+    expect(reimbursements.length).toBeGreaterThan(0)
+
+    const settled = [
+      ...expenses,
+      ...reimbursements.map(({ from, to, amount }) =>
+        expense(from, amount, [to], true),
+      ),
+    ]
+
+    for (const balance of Object.values(getBalances(settled))) {
+      expect(balance.total).toBe(0)
+    }
+  })
+
+  it('leaves no further reimbursement to suggest', () => {
+    const expenses = [expense('alice', 7777, ['alice', 'bob'])]
+    const reimbursements = getSuggestedReimbursements(getBalances(expenses))
+
+    const settled = [
+      ...expenses,
+      ...reimbursements.map(({ from, to, amount }) =>
+        expense(from, amount, [to], true),
+      ),
+    ]
+
+    expect(getSuggestedReimbursements(getBalances(settled))).toEqual([])
+  })
+})
+
+type SplitMode = Expense['splitMode']
+
+const SPLIT_MODES: SplitMode[] = [
+  'EVENLY',
+  'BY_SHARES',
+  'BY_PERCENTAGE',
+  'BY_AMOUNT',
+]
+
+/**
+ * Like `expense` above, but carries an id and a split mode. The id decides
+ * which participant is offered the remaining minor unit of an uneven split.
+ */
+function splitExpense(
+  id: string,
+  paidBy: string,
+  amount: number,
+  paidFor: { id: string; shares: number }[],
+  splitMode: SplitMode = 'EVENLY',
+): Expense {
+  return {
+    id,
+    amount,
+    isReimbursement: false,
+    splitMode,
+    paidBy: { id: paidBy, name: paidBy },
+    paidFor: paidFor.map(({ id, shares }) => ({
+      participant: { id, name: id },
+      shares,
+    })),
+  } as Expense
+}
+
+function evenly(id: string, paidBy: string, amount: number, paidFor: string[]) {
+  return splitExpense(
+    id,
+    paidBy,
+    amount,
+    paidFor.map((id) => ({ id, shares: 1 })),
+  )
+}
+
+function sumOfTotals(balances: ReturnType<typeof getBalances>) {
+  return Object.values(balances).reduce((sum, { total }) => sum + total, 0)
+}
+
+/** Splits `total` into `count` positive integers that add up to exactly `total`. */
+function distribute(total: number, count: number): number[] {
+  const base = Math.floor(total / count)
+  const shares = Array.from({ length: count }, () => base)
+  for (let i = 0; i < total - base * count; i++) shares[i] += 1
+  return shares
+}
+
+/** A seeded LCG, so a failing case is reproducible from the seed alone. */
+function makeRandom(seed: number) {
+  let state = seed >>> 0
+  return (bound: number) => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0
+    return state % bound
+  }
+}
+
+function randomExpense(
+  id: string,
+  participants: string[],
+  random: (bound: number) => number,
+): Expense {
+  const splitMode = SPLIT_MODES[random(SPLIT_MODES.length)]
+  const paidFor = participants.filter(() => random(2) === 0)
+  if (paidFor.length === 0)
+    paidFor.push(participants[random(participants.length)])
+  // BY_AMOUNT shares are validated to add up to the amount, and no share may be
+  // zero, so the amount has to be at least the number of participants.
+  const amount = paidFor.length + random(100000)
+  const paidBy = participants[random(participants.length)]
+
+  switch (splitMode) {
+    case 'BY_SHARES':
+      return splitExpense(
+        id,
+        paidBy,
+        amount,
+        paidFor.map((id) => ({ id, shares: 1 + random(10) })),
+        splitMode,
+      )
+    case 'BY_PERCENTAGE':
+    case 'BY_AMOUNT': {
+      // Percentages are stored times 100, so a full split adds up to 10000.
+      const shares = distribute(
+        splitMode === 'BY_PERCENTAGE' ? 10000 : amount,
+        paidFor.length,
+      )
+      return splitExpense(
+        id,
+        paidBy,
+        amount,
+        paidFor.map((id, index) => ({ id, shares: shares[index] })),
+        splitMode,
+      )
+    }
+    default:
+      return splitExpense(
+        id,
+        paidBy,
+        amount,
+        paidFor.map((id) => ({ id, shares: 1 })),
+        splitMode,
+      )
+  }
+}
+
+describe('balances sum to zero', () => {
+  it('holds for an expense that does not divide evenly', () => {
+    // 100 split three ways used to leave a stranded minor unit that no
+    // reimbursement would ever offer back.
+    const balances = getBalances([
+      evenly('e1', 'alice', 100, ['alice', 'bob', 'carol']),
+    ])
+
+    expect(sumOfTotals(balances)).toBe(0)
+    expect(
+      balances.alice.paidFor + balances.bob.paidFor + balances.carol.paidFor,
+    ).toBe(100)
+  })
+
+  it('holds for an expense split seven ways', () => {
+    const participants = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+    const balances = getBalances([evenly('e1', 'a', 1000, participants)])
+
+    expect(sumOfTotals(balances)).toBe(0)
+    expect(
+      participants.reduce((sum, id) => sum + balances[id].paidFor, 0),
+    ).toBe(1000)
+  })
+
+  it('holds across randomised amounts, participants and split modes', () => {
+    const random = makeRandom(20260804)
+
+    for (let run = 0; run < 500; run++) {
+      const participants = Array.from(
+        { length: 2 + random(7) },
+        (_, index) => `participant-${index}`,
+      )
+      const expenses = Array.from({ length: 1 + random(6) }, (_, index) =>
+        randomExpense(`run-${run}-expense-${index}`, participants, random),
+      )
+
+      expect(sumOfTotals(getBalances(expenses))).toBe(0)
+    }
+  })
+
+  it('offers the whole credit back through the suggested reimbursements', () => {
+    const expenses = [evenly('e1', 'alice', 100, ['alice', 'bob', 'carol'])]
+    const balances = getBalances(expenses)
+    const reimbursements = getSuggestedReimbursements(balances)
+
+    const offeredToAlice = reimbursements
+      .filter(({ to }) => to === 'alice')
+      .reduce((sum, { amount }) => sum + amount, 0)
+
+    expect(offeredToAlice).toBe(balances.alice.total)
+  })
+
+  it('settles completely once every suggestion is booked', () => {
+    const random = makeRandom(1312)
+
+    for (let run = 0; run < 100; run++) {
+      const participants = Array.from(
+        { length: 2 + random(5) },
+        (_, index) => `participant-${index}`,
+      )
+      const expenses = Array.from({ length: 1 + random(4) }, (_, index) =>
+        randomExpense(`run-${run}-expense-${index}`, participants, random),
+      )
+
+      const reimbursements = getSuggestedReimbursements(getBalances(expenses))
+      const settled = [
+        ...expenses,
+        ...reimbursements.map(({ from, to, amount }, index) =>
+          evenly(`run-${run}-settle-${index}`, from, amount, [to]),
+        ),
+      ]
+
+      for (const balance of Object.values(getBalances(settled))) {
+        expect(balance.total).toBe(0)
+      }
+    }
+  })
+})
+
+describe('remainder distribution', () => {
+  it('does not always hand the extra minor unit to the same participant', () => {
+    const participants = ['alice', 'bob', 'carol']
+    const receivers = new Set<string>()
+
+    for (let index = 0; index < 50; index++) {
+      const balances = getBalances([
+        evenly(`expense-${index}`, 'alice', 100, participants),
+      ])
+      for (const id of participants) {
+        if (balances[id].paidFor === 34) receivers.add(id)
+      }
+    }
+
+    expect(receivers).toEqual(new Set(participants))
+  })
+
+  it('gives the same expense the same split every time', () => {
+    const split = () =>
+      getBalances([
+        evenly('expense-1', 'alice', 100, ['alice', 'bob', 'carol']),
+      ])
+
+    expect(split()).toEqual(split())
+  })
+
+  it('does not depend on the order the participants come back from the database', () => {
+    const paidFor = [
+      { id: 'alice', shares: 1 },
+      { id: 'bob', shares: 1 },
+      { id: 'carol', shares: 1 },
+    ]
+    const inOrder = getBalances([splitExpense('e1', 'alice', 100, paidFor)])
+    const reversed = getBalances([
+      splitExpense('e1', 'alice', 100, [...paidFor].reverse()),
+    ])
+
+    expect(reversed).toEqual(inOrder)
+  })
+
+  it('splits an expense entered without an id', () => {
+    const balances = getBalances([
+      expense('alice', 100, ['alice', 'bob', 'carol']),
+    ])
+
+    expect(sumOfTotals(balances)).toBe(0)
+  })
+})
+
+describe('split modes', () => {
+  it('leaves exact BY_AMOUNT shares untouched', () => {
+    const balances = getBalances([
+      splitExpense(
+        'e1',
+        'alice',
+        1000,
+        [
+          { id: 'alice', shares: 333 },
+          { id: 'bob', shares: 333 },
+          { id: 'carol', shares: 334 },
+        ],
+        'BY_AMOUNT',
+      ),
+    ])
+
+    expect(balances.alice.paidFor).toBe(333)
+    expect(balances.bob.paidFor).toBe(333)
+    expect(balances.carol.paidFor).toBe(334)
+    expect(sumOfTotals(balances)).toBe(0)
+  })
+
+  it('rounds BY_PERCENTAGE shares without losing a minor unit', () => {
+    const balances = getBalances([
+      splitExpense(
+        'e1',
+        'alice',
+        100,
+        [
+          { id: 'alice', shares: 3333 },
+          { id: 'bob', shares: 3333 },
+          { id: 'carol', shares: 3334 },
+        ],
+        'BY_PERCENTAGE',
+      ),
+    ])
+
+    expect(sumOfTotals(balances)).toBe(0)
+    expect(
+      balances.alice.paidFor + balances.bob.paidFor + balances.carol.paidFor,
+    ).toBe(100)
+  })
+
+  it('splits BY_SHARES proportionally and to the last minor unit', () => {
+    const balances = getBalances([
+      splitExpense(
+        'e1',
+        'alice',
+        100,
+        [
+          { id: 'alice', shares: 1 },
+          { id: 'bob', shares: 2 },
+        ],
+        'BY_SHARES',
+      ),
+    ])
+
+    expect(balances.alice.paidFor).toBe(33)
+    expect(balances.bob.paidFor).toBe(67)
+    expect(sumOfTotals(balances)).toBe(0)
+  })
+
+  it('splits an income (negative amount) without losing a minor unit', () => {
+    const balances = getBalances([
+      evenly('e1', 'alice', -100, ['alice', 'bob', 'carol']),
+    ])
+
+    expect(sumOfTotals(balances)).toBe(0)
+    expect(
+      balances.alice.paidFor + balances.bob.paidFor + balances.carol.paidFor,
+    ).toBe(-100)
+  })
+})

--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -1,6 +1,6 @@
 import { getGroupExpenses } from '@/lib/api'
+import { getExpenseShares } from '@/lib/shares'
 import { Participant } from '@prisma/client'
-import { match } from 'ts-pattern'
 
 export type Balances = Record<
   Participant['id'],
@@ -20,38 +20,32 @@ export function getBalances(
 
   for (const expense of expenses) {
     const paidBy = expense.paidBy.id
-    const paidFors = expense.paidFor
 
     if (!balances[paidBy]) balances[paidBy] = { paid: 0, paidFor: 0, total: 0 }
     balances[paidBy].paid += expense.amount
 
-    const totalPaidForShares = paidFors.reduce(
-      (sum, paidFor) => sum + paidFor.shares,
-      0,
-    )
-    let remaining = expense.amount
-    paidFors.forEach((paidFor, index) => {
-      if (!balances[paidFor.participant.id])
-        balances[paidFor.participant.id] = { paid: 0, paidFor: 0, total: 0 }
+    const dividedAmounts = getExpenseShares({
+      id: expense.id,
+      amount: expense.amount,
+      splitMode: expense.splitMode,
+      paidFor: expense.paidFor.map(({ participant, shares }) => ({
+        participantId: participant.id,
+        shares,
+      })),
+    })
 
-      const isLast = index === paidFors.length - 1
+    dividedAmounts.forEach((dividedAmount, participantId) => {
+      if (!balances[participantId])
+        balances[participantId] = { paid: 0, paidFor: 0, total: 0 }
 
-      const [shares, totalShares] = match(expense.splitMode)
-        .with('EVENLY', () => [1, paidFors.length])
-        .with('BY_SHARES', () => [paidFor.shares, totalPaidForShares])
-        .with('BY_PERCENTAGE', () => [paidFor.shares, totalPaidForShares])
-        .with('BY_AMOUNT', () => [paidFor.shares, totalPaidForShares])
-        .exhaustive()
-
-      const dividedAmount = isLast
-        ? remaining
-        : (expense.amount * shares) / totalShares
-      remaining -= dividedAmount
-      balances[paidFor.participant.id].paidFor += dividedAmount
+      balances[participantId].paidFor += dividedAmount
     })
   }
 
-  // rounding and add total
+  // Every share is apportioned as a whole minor unit, so the rounding below is
+  // a no-op and only kept as a guard. It is what used to break the books: the
+  // accumulated float totals were rounded per participant, which does not
+  // preserve a sum, and the residue ended up in the group's total balance.
   for (const participantId in balances) {
     // add +0 to avoid negative zeros
     balances[participantId].paidFor =

--- a/src/lib/shares.test.ts
+++ b/src/lib/shares.test.ts
@@ -1,0 +1,291 @@
+import { SplitMode } from '@prisma/client'
+import {
+  ShareInput,
+  distributeAmount,
+  getExpenseShares,
+  getParticipantShare,
+} from './shares'
+
+const SPLIT_MODES: SplitMode[] = [
+  'EVENLY',
+  'BY_SHARES',
+  'BY_PERCENTAGE',
+  'BY_AMOUNT',
+]
+
+function expense(
+  id: string,
+  amount: number,
+  paidFor: [string, number][],
+  splitMode: SplitMode = 'EVENLY',
+): ShareInput {
+  return {
+    id,
+    amount,
+    splitMode,
+    paidFor: paidFor.map(([participantId, shares]) => ({
+      participantId,
+      shares,
+    })),
+  }
+}
+
+function sum(shares: Map<string, number>) {
+  return Array.from(shares.values()).reduce((total, share) => total + share, 0)
+}
+
+/** The shares themselves, smallest first — who gets which is a separate test. */
+function sorted(shares: Map<string, number>) {
+  return Array.from(shares.values()).sort((a, b) => a - b)
+}
+
+describe('getExpenseShares', () => {
+  it.each(SPLIT_MODES)(
+    'splits the whole amount and nothing more (%s)',
+    (splitMode) => {
+      const shares = getExpenseShares(
+        expense(
+          'e1',
+          9500,
+          [
+            ['alice', 1],
+            ['bob', 1],
+            ['carol', 1],
+          ],
+          splitMode,
+        ),
+      )
+
+      expect(sum(shares)).toBe(9500)
+      expect(Array.from(shares.values()).every(Number.isInteger)).toBe(true)
+    },
+  )
+
+  it('does not leave a stranded minor unit on an even split', () => {
+    const shares = getExpenseShares(
+      expense('e1', 9500, [
+        ['alice', 1],
+        ['bob', 1],
+        ['carol', 1],
+      ]),
+    )
+
+    expect(sorted(shares)).toEqual([3166, 3167, 3167])
+  })
+
+  it('ignores the stored shares in EVENLY mode', () => {
+    const shares = getExpenseShares(
+      expense('e1', 100, [
+        ['alice', 7],
+        ['bob', 1],
+      ]),
+    )
+
+    expect(shares.get('alice')).toBe(50)
+    expect(shares.get('bob')).toBe(50)
+  })
+
+  it('splits BY_SHARES proportionally', () => {
+    const shares = getExpenseShares(
+      expense(
+        'e1',
+        100,
+        [
+          ['alice', 1],
+          ['bob', 2],
+        ],
+        'BY_SHARES',
+      ),
+    )
+
+    expect(shares.get('alice')).toBe(33)
+    expect(shares.get('bob')).toBe(67)
+  })
+
+  it('leaves exact BY_AMOUNT shares untouched', () => {
+    const shares = getExpenseShares(
+      expense(
+        'e1',
+        1000,
+        [
+          ['alice', 333],
+          ['bob', 333],
+          ['carol', 334],
+        ],
+        'BY_AMOUNT',
+      ),
+    )
+
+    expect(shares.get('alice')).toBe(333)
+    expect(shares.get('bob')).toBe(333)
+    expect(shares.get('carol')).toBe(334)
+  })
+
+  it('normalises BY_PERCENTAGE shares that do not add up to 100%', () => {
+    // A row that predates the schema refinement, or came in through the import
+    // script: 60/20 of a 100 expense. Taken literally that splits 80 and leaks
+    // the rest; as a ratio it splits the whole amount 75/25.
+    const shares = getExpenseShares(
+      expense(
+        'e1',
+        100,
+        [
+          ['alice', 6000],
+          ['bob', 2000],
+        ],
+        'BY_PERCENTAGE',
+      ),
+    )
+
+    expect(shares.get('alice')).toBe(75)
+    expect(shares.get('bob')).toBe(25)
+    expect(sum(shares)).toBe(100)
+  })
+
+  it('normalises BY_AMOUNT shares that do not add up to the amount', () => {
+    const shares = getExpenseShares(
+      expense(
+        'e1',
+        100,
+        [
+          ['alice', 30],
+          ['bob', 30],
+        ],
+        'BY_AMOUNT',
+      ),
+    )
+
+    expect(sum(shares)).toBe(100)
+  })
+
+  it('splits an income (negative amount) without losing a minor unit', () => {
+    const shares = getExpenseShares(
+      expense('e1', -9500, [
+        ['alice', 1],
+        ['bob', 1],
+        ['carol', 1],
+      ]),
+    )
+
+    expect(sum(shares)).toBe(-9500)
+    expect(sorted(shares)).toEqual([-3167, -3167, -3166])
+  })
+
+  it('gives everyone nothing when the shares add up to zero', () => {
+    const shares = getExpenseShares(
+      expense(
+        'e1',
+        100,
+        [
+          ['alice', 0],
+          ['bob', 0],
+        ],
+        'BY_SHARES',
+      ),
+    )
+
+    expect(shares.get('alice')).toBe(0)
+    expect(shares.get('bob')).toBe(0)
+  })
+
+  it('handles an expense nobody was paid for', () => {
+    expect(getExpenseShares(expense('e1', 100, [])).size).toBe(0)
+  })
+
+  it('does not depend on the order the participants come back from the database', () => {
+    const paidFor: [string, number][] = [
+      ['alice', 1],
+      ['bob', 1],
+      ['carol', 1],
+    ]
+
+    expect(
+      getExpenseShares(expense('e1', 100, [...paidFor].reverse())),
+    ).toEqual(getExpenseShares(expense('e1', 100, paidFor)))
+  })
+
+  it('gives the same expense the same split every time', () => {
+    const split = () =>
+      getExpenseShares(
+        expense('e1', 100, [
+          ['alice', 1],
+          ['bob', 1],
+          ['carol', 1],
+        ]),
+      )
+
+    expect(split()).toEqual(split())
+  })
+
+  it('does not always offer the leftover minor unit to the same participant', () => {
+    const participants = ['alice', 'bob', 'carol']
+    const receivers = new Set<string>()
+
+    for (let index = 0; index < 50; index++) {
+      const shares = getExpenseShares(
+        expense(
+          `expense-${index}`,
+          100,
+          participants.map((id): [string, number] => [id, 1]),
+        ),
+      )
+      for (const id of participants) {
+        if (shares.get(id) === 34) receivers.add(id)
+      }
+    }
+
+    expect(receivers).toEqual(new Set(participants))
+  })
+
+  it('starts at the first participant for an expense without an id', () => {
+    const shares = getExpenseShares({
+      amount: 100,
+      splitMode: 'EVENLY',
+      paidFor: [
+        { participantId: 'bob', shares: 1 },
+        { participantId: 'alice', shares: 1 },
+        { participantId: 'carol', shares: 1 },
+      ],
+    })
+
+    expect(shares.get('alice')).toBe(34)
+    expect(sum(shares)).toBe(100)
+  })
+})
+
+describe('getParticipantShare', () => {
+  const evenly = expense('e1', 100, [
+    ['alice', 1],
+    ['bob', 1],
+  ])
+
+  it('returns the participant’s share', () => {
+    expect(getParticipantShare('alice', evenly)).toBe(50)
+  })
+
+  it('returns zero for someone the expense was not paid for', () => {
+    expect(getParticipantShare('carol', evenly)).toBe(0)
+  })
+
+  it('returns zero when there is no active participant', () => {
+    expect(getParticipantShare(null, evenly)).toBe(0)
+  })
+})
+
+describe('distributeAmount', () => {
+  it('adds up to the amount when it does not divide evenly', () => {
+    expect(distributeAmount(9500, 3)).toEqual([3167, 3167, 3166])
+  })
+
+  it('divides an even amount evenly', () => {
+    expect(distributeAmount(900, 3)).toEqual([300, 300, 300])
+  })
+
+  it('adds up for a negative amount', () => {
+    expect(distributeAmount(-9500, 3)).toEqual([-3166, -3167, -3167])
+  })
+
+  it('has nothing to distribute over nobody', () => {
+    expect(distributeAmount(100, 0)).toEqual([])
+  })
+})

--- a/src/lib/shares.ts
+++ b/src/lib/shares.ts
@@ -1,0 +1,159 @@
+import { SplitMode } from '@prisma/client'
+import { match } from 'ts-pattern'
+
+/**
+ * The minimum an expense has to expose for its shares to be computed. Callers
+ * hold differently shaped `paidFor` rows (nested `participant` from
+ * `getGroupExpenses`, a flat `participantId` from the CSV export's own query),
+ * so they map into this shape rather than the helper guessing.
+ */
+export type ShareInput = {
+  /**
+   * Seeds the rotation that decides who is offered the leftover minor unit of
+   * an uneven split. Absent on expenses that have not been saved yet — ids are
+   * minted server-side — in which case the rotation starts at the first
+   * participant.
+   */
+  id?: string | null
+  /** In minor units. */
+  amount: number
+  splitMode: SplitMode
+  paidFor: { participantId: string; shares: number }[]
+}
+
+/**
+ * A small deterministic string hash (FNV-1a, 32 bit).
+ *
+ * Used to pick which participant is offered the remaining minor unit of an
+ * uneven split. Seeding it with the expense id keeps the split a pure function
+ * of the expense — no persisted cursor, no randomness — while still moving the
+ * extra unit to a different participant from one expense to the next.
+ */
+function hashString(value: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return hash >>> 0
+}
+
+/**
+ * Splits `amount` (in minor units) over the given participants so that the
+ * shares always add up to exactly `amount`.
+ *
+ * Every participant first gets the floor of their exact share; the units left
+ * over are handed out by largest remainder (Hamilton apportionment). Even
+ * splits produce identical remainders, so ties are broken by rotating the
+ * starting position with `offset` — otherwise the same participants would
+ * absorb the extra unit every single time.
+ *
+ * Returns the shares in the order the participants were passed in.
+ */
+function apportion(
+  amount: number,
+  shares: number[],
+  totalShares: number,
+  offset: number,
+): number[] {
+  const count = shares.length
+  if (count === 0) return []
+  // Shares are validated as positive on write, but legacy or directly written
+  // rows are not guaranteed to be.
+  if (totalShares === 0) return shares.map(() => 0)
+
+  const amounts: number[] = []
+  const remainders: { index: number; remainder: number }[] = []
+  let distributed = 0
+
+  shares.forEach((share, index) => {
+    const exact = amount * share
+    // Math.floor keeps the leftover non-negative for negative amounts (income)
+    // just as it does for positive ones, so `remaining` below stays in [0, count).
+    const base = Math.floor(exact / totalShares)
+    amounts.push(base)
+    distributed += base
+    remainders.push({ index, remainder: exact - base * totalShares })
+  })
+
+  const remaining = amount - distributed
+  if (remaining === 0) return amounts
+
+  remainders.sort((a, b) => {
+    if (a.remainder !== b.remainder) return b.remainder - a.remainder
+    // Rotate the starting position so an even split does not always favour the
+    // same participants.
+    const rotate = (index: number) => (index - offset + count) % count
+    return rotate(a.index) - rotate(b.index)
+  })
+  for (let i = 0; i < remaining; i++) {
+    amounts[remainders[i].index] += 1
+  }
+  return amounts
+}
+
+/**
+ * The one definition of "what is each participant's share of this expense".
+ *
+ * Every share is a whole number of minor units and the shares add up to exactly
+ * `expense.amount`, whatever the split mode: `BY_PERCENTAGE` and `BY_AMOUNT`
+ * shares are treated as a ratio rather than taken literally, so rows whose
+ * stored shares do not satisfy the schema invariants (`Σ shares === 10000`
+ * / `Σ shares === amount`, enforced on write in `schemas.ts`) still split the
+ * full amount and nothing leaks. Reimbursements are not special-cased here —
+ * whether they count is up to the caller.
+ *
+ * @returns the share per participant id; participants not paid for are absent.
+ */
+export function getExpenseShares(expense: ShareInput): Map<string, number> {
+  // `paidFor` is fetched without an `orderBy`, so the database is free to
+  // return the rows in any order. Sort a copy by participant id so the split
+  // does not depend on it.
+  const paidFors = [...expense.paidFor].sort((a, b) =>
+    a.participantId < b.participantId ? -1 : 1,
+  )
+
+  const shares = match(expense.splitMode)
+    .with('EVENLY', () => paidFors.map(() => 1))
+    .with('BY_SHARES', 'BY_PERCENTAGE', 'BY_AMOUNT', () =>
+      paidFors.map(({ shares }) => shares),
+    )
+    .exhaustive()
+  const totalShares = shares.reduce((sum, share) => sum + share, 0)
+
+  const offset =
+    expense.id && paidFors.length > 0
+      ? hashString(expense.id) % paidFors.length
+      : 0
+  const amounts = apportion(expense.amount, shares, totalShares, offset)
+
+  return new Map(
+    paidFors.map(({ participantId }, index) => [participantId, amounts[index]]),
+  )
+}
+
+/**
+ * A single participant's share of an expense, in whole minor units. Returns 0
+ * for a participant the expense was not paid for.
+ */
+export function getParticipantShare(
+  participantId: string | null,
+  expense: ShareInput,
+): number {
+  if (participantId === null) return 0
+  return getExpenseShares(expense).get(participantId) ?? 0
+}
+
+/**
+ * Splits `amount` (in minor units) into `count` shares as evenly as possible,
+ * adding up to exactly `amount`. The leftover units go to the first
+ * participants, so the caller decides the order that matters.
+ */
+export function distributeAmount(amount: number, count: number): number[] {
+  return apportion(
+    amount,
+    Array.from({ length: count }, () => 1),
+    count,
+    0,
+  )
+}

--- a/src/lib/totals.test.ts
+++ b/src/lib/totals.test.ts
@@ -1,0 +1,190 @@
+import { getBalances } from './balances'
+import {
+  calculateShare,
+  getTotalActiveUserShare,
+  getTotalGroupSpending,
+} from './totals'
+
+type Expense = Parameters<typeof getTotalGroupSpending>[0][number]
+type SplitMode = Expense['splitMode']
+
+const SPLIT_MODES: SplitMode[] = [
+  'EVENLY',
+  'BY_SHARES',
+  'BY_PERCENTAGE',
+  'BY_AMOUNT',
+]
+
+function makeExpense(partial: Partial<Expense>): Expense {
+  return {
+    id: 'expense',
+    title: 'Expense',
+    amount: 0,
+    category: null,
+    isReimbursement: false,
+    splitMode: 'EVENLY',
+    expenseDate: new Date('2024-01-01T00:00:00Z'),
+    paidBy: { id: 'alice', name: 'Alice' },
+    paidFor: [],
+    ...partial,
+  } as unknown as Expense
+}
+
+function splitExpense(
+  id: string,
+  amount: number,
+  paidFor: [string, number][],
+  splitMode: SplitMode = 'EVENLY',
+): Expense {
+  return makeExpense({
+    id,
+    amount,
+    splitMode,
+    paidBy: { id: paidFor[0][0], name: paidFor[0][0] },
+    paidFor: paidFor.map(([participantId, shares]) => ({
+      participant: { id: participantId, name: participantId },
+      shares,
+    })),
+  } as Partial<Expense>)
+}
+
+/** A seeded LCG, so a failing case is reproducible from the seed alone. */
+function makeRandom(seed: number) {
+  let state = seed >>> 0
+  return (bound: number) => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0
+    return state % bound
+  }
+}
+
+describe('calculateShare', () => {
+  it('does not hand three participants 31.67 each out of 95.00', () => {
+    // The expense form used to show every participant 3166.66…, which
+    // `formatCurrency` then rounded up individually: three people owing 31.67
+    // of a 95.00 expense.
+    const expense = splitExpense('e1', 9500, [
+      ['alice', 1],
+      ['bob', 1],
+      ['carol', 1],
+    ])
+
+    const shares = ['alice', 'bob', 'carol'].map((id) =>
+      calculateShare(id, expense),
+    )
+
+    expect(shares.reduce((sum, share) => sum + share, 0)).toBe(9500)
+    expect([...shares].sort((a, b) => a - b)).toEqual([3166, 3167, 3167])
+  })
+
+  it('ignores reimbursements, which balances deliberately count', () => {
+    const settlement = makeExpense({
+      amount: 500,
+      isReimbursement: true,
+      paidFor: [{ participant: { id: 'bob', name: 'Bob' }, shares: 1 }],
+    } as Partial<Expense>)
+
+    expect(calculateShare('bob', settlement)).toBe(0)
+    expect(getBalances([settlement]).bob.paidFor).toBe(500)
+  })
+
+  it('returns zero for a participant the expense was not paid for', () => {
+    expect(
+      calculateShare('carol', splitExpense('e1', 100, [['alice', 1]])),
+    ).toBe(0)
+  })
+
+  it.each(SPLIT_MODES)(
+    'charges what the balances tab charges (%s)',
+    (splitMode) => {
+      // Deliberately broken invariants: percentages adding up to 90% and
+      // by-amount shares adding up to 90 of a 100 expense are exactly the rows
+      // `calculateShare` used to disagree with `getBalances` on.
+      const shares: [string, number][] =
+        splitMode === 'BY_PERCENTAGE'
+          ? [
+              ['alice', 6000],
+              ['bob', 3000],
+            ]
+          : splitMode === 'BY_AMOUNT'
+            ? [
+                ['alice', 60],
+                ['bob', 30],
+              ]
+            : [
+                ['alice', 2],
+                ['bob', 1],
+              ]
+      const expense = splitExpense('e1', 100, shares, splitMode)
+      const balances = getBalances([expense])
+
+      for (const id of ['alice', 'bob']) {
+        expect(calculateShare(id, expense)).toBe(balances[id].paidFor)
+      }
+    },
+  )
+
+  it('agrees with the balances tab across randomised expenses', () => {
+    const random = makeRandom(20260811)
+
+    for (let run = 0; run < 500; run++) {
+      const participants = Array.from(
+        { length: 2 + random(6) },
+        (_, index) => `participant-${index}`,
+      )
+      const paidFor = participants
+        .filter(() => random(2) === 0)
+        .map((id): [string, number] => [id, 1 + random(5000)])
+      if (paidFor.length === 0)
+        paidFor.push([participants[0], 1 + random(5000)])
+
+      const expense = splitExpense(
+        `run-${run}`,
+        1 + random(100000),
+        paidFor,
+        SPLIT_MODES[random(SPLIT_MODES.length)],
+      )
+      const balances = getBalances([expense])
+
+      for (const id of participants) {
+        expect(calculateShare(id, expense)).toBe(balances[id]?.paidFor ?? 0)
+      }
+    }
+  })
+})
+
+describe('getTotalActiveUserShare', () => {
+  it('sums to the group total once every participant is counted', () => {
+    const participants = ['alice', 'bob', 'carol']
+    const expenses = [
+      splitExpense('e1', 9500, [
+        ['alice', 1],
+        ['bob', 1],
+        ['carol', 1],
+      ]),
+      splitExpense(
+        'e2',
+        10000,
+        [
+          ['alice', 1],
+          ['bob', 2],
+        ],
+        'BY_SHARES',
+      ),
+    ]
+
+    const total = participants.reduce(
+      (sum, id) => sum + getTotalActiveUserShare(id, expenses),
+      0,
+    )
+
+    expect(total).toBe(getTotalGroupSpending(expenses))
+  })
+
+  it('is zero for someone who is not part of any expense', () => {
+    expect(
+      getTotalActiveUserShare('dave', [
+        splitExpense('e1', 100, [['alice', 1]]),
+      ]),
+    ).toBe(0)
+  })
+})

--- a/src/lib/totals.ts
+++ b/src/lib/totals.ts
@@ -1,4 +1,5 @@
 import { getGroupExpenses } from '@/lib/api'
+import { ShareInput, getParticipantShare } from '@/lib/shares'
 
 export function getTotalGroupSpending(
   expenses: NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>,
@@ -25,54 +26,53 @@ export function getTotalActiveUserPaidFor(
 
 type Expense = NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>[number]
 
+type SplittableExpense = Pick<
+  Expense,
+  'amount' | 'paidFor' | 'splitMode' | 'isReimbursement'
+> & { id?: string | null }
+
+/**
+ * Maps an expense into the shape {@link getExpenseShares} takes. The id decides
+ * who is offered the leftover minor unit of an uneven split; passing it keeps
+ * the stats and the expense form in step with the balances tab.
+ */
+function toShareInput(expense: SplittableExpense): ShareInput {
+  return {
+    id: expense.id,
+    amount: expense.amount,
+    splitMode: expense.splitMode,
+    paidFor: expense.paidFor.map(({ participant, shares }) => ({
+      participantId: participant.id,
+      shares: Number(shares),
+    })),
+  }
+}
+
+/**
+ * A participant's share of a single expense, in whole minor units.
+ *
+ * Delegates to the shared apportionment so that the number shown on the totals,
+ * in the CSV export and next to a participant in the expense form is the same
+ * one the balances tab charges them. Reimbursements count as zero here: unlike
+ * balances, the spending totals deliberately ignore settling up.
+ */
 export function calculateShare(
   participantId: string | null,
-  expense: Pick<
-    Expense,
-    'amount' | 'paidFor' | 'splitMode' | 'isReimbursement'
-  >,
+  expense: SplittableExpense,
 ): number {
   if (expense.isReimbursement) return 0
 
-  const paidFors = expense.paidFor
-  const userPaidFor = paidFors.find(
-    (paidFor) => paidFor.participant.id === participantId,
-  )
-
-  if (!userPaidFor) return 0
-
-  const shares = Number(userPaidFor.shares)
-
-  switch (expense.splitMode) {
-    case 'EVENLY':
-      // Divide the total expense evenly among all participants
-      return expense.amount / paidFors.length
-    case 'BY_AMOUNT':
-      // Directly add the user's share if the split mode is BY_AMOUNT
-      return shares
-    case 'BY_PERCENTAGE':
-      // Calculate the user's share based on their percentage of the total expense
-      return (expense.amount * shares) / 10000 // Assuming shares are out of 10000 for percentage
-    case 'BY_SHARES':
-      // Calculate the user's share based on their shares relative to the total shares
-      const totalShares = paidFors.reduce(
-        (sum, paidFor) => sum + Number(paidFor.shares),
-        0,
-      )
-      return (expense.amount * shares) / totalShares
-    default:
-      return 0
-  }
+  return getParticipantShare(participantId, toShareInput(expense))
 }
 
 export function getTotalActiveUserShare(
   activeUserId: string | null,
   expenses: NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>,
 ): number {
-  const total = expenses.reduce(
+  // Every share is a whole number of minor units, so the sum needs no rounding
+  // — rounding it here is what used to make the totals disagree with balances.
+  return expenses.reduce(
     (sum, expense) => sum + calculateShare(activeUserId, expense),
     0,
   )
-
-  return parseFloat(total.toFixed(2))
 }


### PR DESCRIPTION
# fix: split every expense the same way everywhere

Part of the series in #553, and the one I think is worth the most.

> **Ordering:** built on top of the AI/CSV hardening PR, because both touch the
> same block of the CSV export route. Once that one lands this rebases onto
> `main` cleanly. Reviewable on its own — the diff below is only this change.

## The problem

There are three implementations of "what is this participant's share of this
expense", and they disagree:

| | where | how it splits |
|---|---|---|
| `calculateShare` | `src/lib/totals.ts` | floats; hardcodes `/10000` for `BY_PERCENTAGE`; returns `BY_AMOUNT` shares **literally** |
| `getBalances` | `src/lib/balances.ts` | normalises shares against their total; last participant absorbs the float remainder |
| the CSV export | `expenses/export/csv/route.ts` | **ignores the split mode entirely** — always `amount / Σ shares × share` |

They agree only while the schema invariants hold exactly: `Σ shares === 10000`
for `BY_PERCENTAGE`, `Σ shares === amount` for `BY_AMOUNT`. Those are enforced on
write in `schemas.ts` today — but rows that predate that enforcement, arrived
through `src/scripts/migrate.ts`, or were written straight to the database do
not satisfy them. When they don't, the stats page and the CSV contradict the
balances tab, with nothing to indicate which one is right.

A row with percentages adding up to 90% is the clearest case: `calculateShare`
divides by a hardcoded 10000 and so charges out only 90% of the expense — 10% of
the money simply is not attributed to anyone. `getBalances` normalises and
charges the whole thing.

## Rounding, on top of that

Splitting **95.00 evenly across three participants shows everyone 31.67** — 95.01
in total. Each float share (3166.66…) is rounded for display on its own.

The same per-participant rounding is why `getBalances` could produce balances
that don't sum to zero. Inside the loop the last participant absorbed the exact
float remainder, so the unrounded shares did add up; then `Math.round` ran
per participant over the accumulated total at the end, and rounding
independently does not preserve a sum. The residue landed in the group total.
Downstream: a creditor owed 67 was only ever offered 66, that last unit could
not be repaid because the greedy matcher needs at least two entries, and the
group reported itself settled up while it wasn't.

And in the expense form, the `BY_AMOUNT` auto-balance filled in 31.67 three
times and then **rejected its own suggestion** against the "amounts must add up"
validation.

## The fix

A new `src/lib/shares.ts` holds the one apportionment, and all three callers use
it.

Guarantees, in every split mode: every share is a whole number of minor units,
and the shares add up to **exactly** the expense amount. Shares are treated as a
*ratio* rather than taken literally, so the 90%-percentage row above splits the
whole expense instead of leaking 10% of it. Leftover units are handed out by
largest remainder (Hamilton), and since an even split produces identical
remainders, ties are broken by rotating the starting position with a hash of the
expense id — otherwise the same participant absorbs the extra unit on every
single expense.

`isReimbursement` stays a caller concern: balances count settling up, the
spending totals deliberately do not. That difference is now explicit at the two
call sites instead of being baked into the maths.

The `Math.round` in `getBalances` is kept as a guard but is now a no-op.

### Design points worth a look

- **Seeding the rotation with the expense id** rather than a persisted cursor
  keeps the split a pure function of the expense — no migration, no state, same
  answer on every render. A new expense has no id yet (they're minted
  server-side), so the form notes that the leftover unit may land elsewhere once
  saved; when editing, the id is passed and the form matches the balances tab.
- **`paidFor` is fetched without an `orderBy`**, so the database may return rows
  in any order. The helper sorts a copy by participant id, otherwise who gets the
  extra unit could change between two loads of the same page.
- **`Math.floor`, not truncation**, so the leftover stays non-negative for
  negative amounts too.

## Tests

- `shares.test.ts` — the apportionment itself, per split mode, including the
  broken-invariant rows.
- `balances.test.ts` — balances, including the sum-to-zero property.
- `totals.test.ts` — the 95.00/three-way case by name, the reimbursement
  asymmetry, and a property test asserting `calculateShare` agrees with
  `getBalances` across **500 randomised expenses** (seeded LCG, so a failure is
  reproducible from the seed).

`npm test` is not wired into CI yet — a later PR in the series adds that, and
this is a good part of why I'd like it in.

## One style note

The new code avoids `for...of` over a `Map` and spreading `map.values()`:
`tsconfig.json` still targets `es5`, and TS2802 rejects both without
`downlevelIteration`. `Array.from` and `Map.forEach` where you'd otherwise
expect iteration is deliberate, not preference. A later PR in the series
proposes bumping the target.

## Manual check suggested

Create a 95.00 expense split evenly across 3 participants, then confirm the
balances tab, the totals, and the CSV export all agree and sum to exactly 95.00.

## Verification

`npm ci --ignore-scripts`, `npx prisma generate`, `check-types`, `lint`,
`check-formatting` all clean (lint: 16 warnings, all pre-existing).
