### PR TITLE
build: anchor build-image.sh's package.json parsing to the key

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 
-SPLIIT_APP_NAME=$(cat ./package.json | grep name | awk '{print $2}' | sed -r s/\"\,?//g)
-SPLIIT_VERSION=$(cat ./package.json | grep version | awk '{print $2}' | sed -r s/\"\,?//g)
+# Read name/version from package.json using only POSIX tools, so the image can
+# be built on hosts where Node.js/npm is not installed (see #219). Anchored on
+# the key and limited to the first match, so a dependency whose name happens to
+# contain "name" or "version" cannot add a second line to the result.
+read_pkg_field() {
+  grep -m1 "\"$1\"[[:space:]]*:" package.json |
+    sed -E "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"([^\"]+)\".*/\1/"
+}
+
+SPLIIT_APP_NAME=$(read_pkg_field name)
+SPLIIT_VERSION=$(read_pkg_field version)
 
 # we need to set dummy data for POSTGRES env vars in order for build not to fail
 docker buildx build \


### PR DESCRIPTION
# build: anchor build-image.sh's package.json parsing to the key

Part of the series in #553, and the smallest thing in it. A follow-up on #219,
not a replacement for it — the no-Node-required property that made #219 worth
merging is exactly what this keeps.

## The problem

```sh
SPLIIT_APP_NAME=$(cat ./package.json | grep name | awk '{print $2}' | sed -r s/\"\,?//g)
```

`grep` is unanchored and prints **every** matching line. This works today only
because `name` and `version` each happen to appear on exactly one line of
`package.json` — I checked, and they do, so nothing is broken right now. It
stops being true the first time a dependency's name contains either word.

Adding these two to `dependencies`:

```json
"standard-version": "^9.5.0",
"package-name-parser": "^1.0.0",
```

gives:

```
name    -> [spliit2
^1.0.0]
version -> [1.20.2
^9.5.0]

resulting tag: -t spliit2
^1.0.0:1.20.2
^9.5.0
```

The `docker build -t` is malformed, and nothing about the failure points back at
the parser.

## The change

```sh
read_pkg_field() {
  grep -m1 "\"$1\"[[:space:]]*:" package.json |
    sed -E "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"([^\"]+)\".*/\1/"
}
```

Anchors on `"<key>":` so a value can't match, takes `-m1` so only the first
match survives either way, and collapses the pipeline to one `grep` plus one
`sed -E` — the `cat` and the `awk` stage were both doing work the `sed` already
does. Still POSIX tools only; no Node, no `jq`.

## Verification

Ran both parsers against a `package.json` containing the two dependencies above
(output quoted verbatim in the commit message), and against current `main` to
confirm the single-match assumption holds today. Nothing else in the repository
reads these values.

Worth a sanity check on your side that `npm run build-image` still tags the way
you expect — I don't have a Docker daemon here, so I verified the parsing rather
than the build.
