### PR TITLE
CI Baseline

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    # Without grouping, a quiet week still opens half a dozen separate PRs for
+    # patch bumps that would have been reviewed as one. Majors stay separate,
+    # since those are the ones worth reading individually.
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  # Keeps the workflow action pins current. Without this nothing watches them,
+  # which is how checkout/setup-node drifted several majors behind.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      actions:
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
+          # Matches the Dockerfile runtime and ships npm >= 11. npm 10 rejects
+          # lockfiles written by npm >= 11, which is what Dependabot uses.
           node-version: 24
           cache: 'npm'
 
@@ -40,3 +42,6 @@ jobs:
 
       - name: Check Prettier formatting
         run: npm run check-formatting
+
+      - name: Run tests
+        run: npm test

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
# chore: CI and lint baseline

Part of the series in #553. Four small independent commits, no source changes —
this is the gate that everything after it in the series gets measured against,
which is why I'd like it in early.

## 1. CI runs the tests

`main` has **7 test suites and 101 tests**, and CI runs none of them. `npm test`
passes today; nothing stops that changing. This adds one step after the existing
checks.

That number is recent — #548 brought two suites, and #559/#560/#562 brought five
more — so this isn't a long-standing gap so much as one that just opened. The
rest of #553 adds more, and I'd rather they land against a gate that exists.

## 2. TypeScript target `es5` → `ES2017`

`noEmit` is set, so `tsc` never emits anything and SWC does the actual
transpilation. The target here decides **only what type-checks**, and at `es5`
that means TS2802 on any iteration of a `Map` or `Set`:

```
error TS2802: Type 'Map<string, number>' can only be iterated through when
using the '--downlevelIteration' flag or with a '--target' of 'es2015' or
higher.
```

Both `for (const [k, v] of map)` and `[...map.values()]` are rejected. I hit
this porting #562 and wrote around it — `Map.forEach` and `Array.from` where
iteration would read better — and flagged there that I'd propose the bump
separately rather than smuggle it in. This is that.

It also has to happen eventually regardless: TypeScript 6 deprecates the `es5`
target and TypeScript 7 removes it.

**Not included:** the `"types": ["node", "jest"]` restriction that goes with
this in my fork. That one is specifically about TypeScript 6 changing how
ambient `@types` globals are resolved, so it belongs with the TypeScript bump,
not here.

I have deliberately **not** gone back and rewritten the `forEach`/`Array.from`
code now that the constraint is gone — it reads fine, and churning it would make
this PR look bigger than it is.

## 3. Drop the legacy `.eslintrc.json`

`eslint.config.mjs` is what ESLint 9 loads. The `.eslintrc.json` next to it has
been inert since the flat config landed, and the only thing keeping it around
can do is attract an edit that silently has no effect.

Lint output is unchanged: 16 warnings, 0 errors, before and after.

## 4. Dependabot

New `.github/dependabot.yml`: weekly npm, Docker, and GitHub Actions.

**Two choices here are mine and easy to strip if you disagree**, so I want to
flag them rather than bury them:

- **Minor and patch updates are grouped** into one PR per ecosystem; majors stay
  separate. Ungrouped weekly npm updates produced nine separate PRs in my fork
  over a few months, all of which I ended up reviewing as one batch anyway.
- **`github-actions` is included.** Nothing was watching the workflow pins,
  which is how `checkout` and `setup-node` ended up on v3 — the Node 16 runner.
  This PR moves them to v6 by hand; Dependabot is what stops it recurring.

If you'd rather not have Dependabot at all, commit 4 drops cleanly on its own
and the other three stand without it.

## Also in this PR

The `setup-node` step gets a comment recording *why* it pins Node 24: npm 10
refuses to read lockfiles written by npm 11, which is what Dependabot produces.
That combination is a confusing failure if you meet it without the note.

## What is not here

`npm run generate-currency-data` is listed under this item in #553 as broken. It
isn't — I re-checked, and `src/scripts/generateCurrencyData.ts` is byte-identical
between my fork and `main`. The breakage is TS5011 from my fork's TypeScript 6,
so the fix belongs with that upgrade. I've corrected the tracking issue.

## Verification

Against `67a8f8d`: `npm ci --ignore-scripts`, `npx prisma generate`,
`check-types`, `lint` (16 warnings / 0 errors, all pre-existing),
`check-formatting`, `npm test` — 7 suites, 101 tests, all passing. The TS2802
claim above was verified by running `tsc` at both targets over a four-line
probe.
