### PR TITLE
feat: add Playwright end-to-end test suite running against Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Without this the build context is ~1.7 GB (node_modules + .next + postgres-data).
+# Nothing here is COPYed by the Dockerfile, which only takes package*.json,
+# next.config.mjs, tsconfig.json, reset.d.ts, tailwind.config.js,
+# postcss.config.js, scripts/, prisma/, src/, messages/ and public/.
+node_modules
+.next
+out
+build
+postgres-data
+.git
+.github
+.devcontainer
+.claude
+coverage
+
+# e2e tooling is never needed inside the image
+e2e
+playwright.config.ts
+playwright-report
+test-results
+blob-report
+
+*.tsbuildinfo
+.DS_Store
+npm-debug.log*

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,66 @@
+name: E2E
+
+# Manually, or on release tags -- the same trigger as the Docker image build in
+# cd.yml. The app under test is built from this checkout, so this workflow is
+# independent of cd.yml and does not wait for the image to be published.
+on:
+  workflow_dispatch:
+  push:
+    tags: ['*']
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      # --ignore-scripts, as in ci.yml: postinstall runs `prisma migrate deploy`,
+      # which needs a database that does not exist yet at this point.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Start the app stack
+        run: ./scripts/e2e.sh up
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Collect container logs
+        if: failure()
+        run: ./scripts/e2e.sh logs > compose-logs.txt
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+
+      - name: Upload container logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: e2e-container-logs
+          path: compose-logs.txt
+          retention-days: 14
+
+      - name: Stop the app stack
+        if: always()
+        run: ./scripts/e2e.sh down

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ next-env.d.ts
 
 # db
 postgres-data
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -68,6 +68,40 @@ Here is the current state of translation:
 4. Run `npm install` to install dependencies. This will also apply database migrations and update Prisma Client.
 5. Run `npm run dev` to start the development server
 
+## End-to-end tests
+
+The Playwright suite in `e2e/` drives a real browser against the app running in
+Docker, so it exercises the same image users deploy. It needs Docker and a free
+port 3000, and nothing else — the stack builds itself from your checkout and
+throws its database away afterwards.
+
+```sh
+npm run e2e
+```
+
+That builds the image, starts app + PostgreSQL from `compose.e2e.yaml`, waits
+for `/api/health/readiness`, runs the suite and tears everything down. It never
+touches your development stack or `./postgres-data`.
+
+While writing tests it is quicker to keep the stack up:
+
+```sh
+npm run e2e:up                  # build and start, then leave it running
+npm run e2e:test -- --ui        # iterate (also --headed, --grep, --debug)
+npm run e2e:report              # open the HTML report of the last run
+npm run e2e:down                # stop and delete the test database
+```
+
+If port 3000 is already taken — by `npm run dev`, for instance — set
+`E2E_HOST_PORT` to something else:
+
+```sh
+E2E_HOST_PORT=3100 npm run e2e
+```
+
+The same suite runs in GitHub Actions from the **E2E** workflow, which can be
+triggered manually and runs automatically on release tags.
+
 ## Run in a container
 
 1. Run `npm run build-image` to build the docker image from the Dockerfile

--- a/README.md
+++ b/README.md
@@ -92,11 +92,18 @@ npm run e2e:report              # open the HTML report of the last run
 npm run e2e:down                # stop and delete the test database
 ```
 
+`--ui` opens Playwright's UI mode, where you can pick tests, watch them run and
+step through a trace. It does not start the stack itself, so run `npm run e2e:up`
+first.
+
 If port 3000 is already taken — by `npm run dev`, for instance — set
-`E2E_HOST_PORT` to something else:
+`E2E_HOST_PORT` on every command of the session, including the test run:
 
 ```sh
-E2E_HOST_PORT=3100 npm run e2e
+E2E_HOST_PORT=3100 npm run e2e             # one-shot
+E2E_HOST_PORT=3100 npm run e2e:up          # or, for the iteration loop
+E2E_HOST_PORT=3100 npm run e2e:test -- --ui
+E2E_HOST_PORT=3100 npm run e2e:down
 ```
 
 The same suite runs in GitHub Actions from the **E2E** workflow, which can be

--- a/compose.e2e.yaml
+++ b/compose.e2e.yaml
@@ -1,0 +1,73 @@
+# Ephemeral stack for the Playwright end-to-end suite.
+#
+# This is deliberately NOT compose.yaml: that one bind-mounts ./postgres-data
+# (state would leak between runs) and reads the gitignored container.env. Here
+# the database is thrown away on every run and all env is inline, because
+# .gitignore ignores `*.env` and a new env file would be silently untracked.
+#
+# Always invoke through scripts/e2e.sh, which adds the flags that actually
+# guarantee a clean database (see the `db` service).
+name: spliit-e2e
+
+services:
+  app:
+    build:
+      context: .
+    image: spliit-e2e:latest
+    ports:
+      # Keep the container port at 3000: next.config.mjs pins
+      # experimental.serverActions.allowedOrigins to 'localhost:3000'.
+      # E2E_HOST_PORT is only an escape hatch when 3000 is taken on the host.
+      - '${E2E_HOST_PORT:-3000}:3000'
+    environment:
+      POSTGRES_PRISMA_URL: postgresql://postgres:e2e@db:5432/spliit_e2e
+      POSTGRES_URL_NON_POOLING: postgresql://postgres:e2e@db:5432/spliit_e2e
+      NEXT_TELEMETRY_DISABLED: '1'
+    restart: 'no'
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      # 127.0.0.1 rather than localhost: busybox may resolve localhost to ::1.
+      # /api/health/readiness runs `SELECT 1`, and scripts/container-entrypoint.sh
+      # runs `prisma migrate deploy` *before* `npm run start` -- so any 200 here
+      # proves the schema is migrated and the app is serving.
+      test:
+        [
+          'CMD-SHELL',
+          'wget -q -O /dev/null http://127.0.0.1:3000/api/health/readiness || exit 1',
+        ]
+      interval: 3s
+      timeout: 5s
+      retries: 40
+      start_period: 20s
+
+  db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: e2e
+      POSTGRES_DB: spliit_e2e
+    # No published port, so this never collides with a local postgres.
+    #
+    # No named volume either -- but note the postgres image itself declares
+    # `VOLUME /var/lib/postgresql/data`, so Compose still creates an *anonymous*
+    # volume. Freshness therefore comes from `up --renew-anon-volumes` and
+    # `down --volumes` in scripts/e2e.sh, not from the absence of a volume here.
+    #
+    # A tmpfs on that path is deliberately avoided: it mounts root-owned and
+    # initdb (uid 999) fails.
+    command:
+      - postgres
+      - -c
+      - fsync=off
+      - -c
+      - synchronous_commit=off
+      - -c
+      - full_page_writes=off
+    restart: 'no'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres -d spliit_e2e']
+      interval: 2s
+      timeout: 5s
+      retries: 30

--- a/e2e/app.ts
+++ b/e2e/app.ts
@@ -1,0 +1,219 @@
+import { expect, Locator, Page } from '@playwright/test'
+import {
+  clickUntil,
+  escapeRegExp,
+  fillStable,
+  money,
+  selectRadixOption,
+  setChecked,
+} from './ui'
+
+export type SplitMode = 'EVENLY' | 'BY_SHARES' | 'BY_PERCENTAGE' | 'BY_AMOUNT'
+
+export type GroupTab =
+  'Expenses' | 'Balances' | 'Information' | 'Stats' | 'Activity' | 'Settings'
+
+const TAB_PATHS: Record<GroupTab, string> = {
+  Expenses: 'expenses',
+  Balances: 'balances',
+  Information: 'information',
+  Stats: 'stats',
+  Activity: 'activity',
+  Settings: 'edit',
+}
+
+// Regexes, not literals: the labels are "Unevenly – By shares" with an en dash.
+const SPLIT_MODE_LABELS: Record<SplitMode, RegExp> = {
+  EVENLY: /^Evenly$/,
+  BY_SHARES: /By shares/,
+  BY_PERCENTAGE: /By percentage/,
+  BY_AMOUNT: /By amount/,
+}
+
+/** GroupForm ships with three participant rows pre-filled (John / Jane / Jack). */
+const PREFILLED_PARTICIPANTS = 3
+
+/**
+ * The expenses list URL.
+ *
+ * Anchored deliberately: an unanchored /groups/<id>/expenses also matches
+ * /groups/<id>/expenses/create, so waiting on it would return instantly while
+ * still sitting on the form and let assertions run before the write landed.
+ */
+export const EXPENSES_URL = /\/groups\/[^/]+\/expenses(\?|$)/
+
+/** Short random suffix so group names are unique on the shared database. */
+export function uniqueSuffix(): string {
+  return Math.random().toString(36).slice(2, 8)
+}
+
+export async function createGroup(
+  page: Page,
+  opts: { name: string; participants: string[] },
+): Promise<string> {
+  await page.goto('/groups/create')
+
+  // fillStable doubles as the hydration gate: once RHF keeps a value, React is
+  // live and later clicks are safe.
+  await fillStable(page.locator('input[name="name"]'), opts.name)
+
+  for (let i = PREFILLED_PARTICIPANTS; i < opts.participants.length; i++) {
+    await page.getByRole('button', { name: 'Add participant' }).click()
+    await expect(
+      page.locator(`input[name="participants.${i}.name"]`),
+    ).toBeVisible()
+  }
+
+  // Drop surplus rows from the end, so the remaining indices never shift.
+  for (let i = PREFILLED_PARTICIPANTS - 1; i >= opts.participants.length; i--) {
+    const row = page
+      .locator('li')
+      .filter({ has: page.locator(`input[name="participants.${i}.name"]`) })
+    await row.getByRole('button').click()
+    await expect(
+      page.locator(`input[name="participants.${i}.name"]`),
+    ).toHaveCount(0)
+  }
+
+  for (let i = 0; i < opts.participants.length; i++) {
+    await fillStable(
+      page.locator(`input[name="participants.${i}.name"]`),
+      opts.participants[i],
+    )
+  }
+
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await page.waitForURL(EXPENSES_URL, { timeout: 30_000 })
+
+  const groupId = /\/groups\/([^/]+)\/expenses/.exec(page.url())
+  if (!groupId) throw new Error(`Could not read group id from ${page.url()}`)
+  return groupId[1]
+}
+
+export async function addExpense(
+  page: Page,
+  groupId: string,
+  expense: {
+    title: string
+    /** As typed, e.g. '90' or '12.34'. */
+    amount: string
+    /** Participant name. */
+    paidBy: string
+    /** Participant names. Omit to leave every participant checked. */
+    paidFor?: string[]
+    splitMode?: SplitMode
+    /** Participant name -> share value. Set one for every checked participant. */
+    shares?: Record<string, string>
+  },
+): Promise<void> {
+  await page.goto(`/groups/${groupId}/expenses/create`)
+
+  // CreateExpenseForm returns null until its tRPC queries resolve, so the
+  // submit button appearing means both hydrated and data-ready.
+  const submit = page.getByRole('button', { name: 'Create', exact: true })
+  await expect(submit).toBeVisible({ timeout: 30_000 })
+
+  await fillStable(page.locator('input[name="title"]'), expense.title)
+  // Amount before split mode: BY_AMOUNT re-distributes shares whenever the
+  // amount changes, which would wipe values set beforehand.
+  await fillStable(page.locator('input[name="amount"]'), expense.amount)
+  await selectRadixOption(page, page.getByTestId('paid-by'), expense.paidBy)
+
+  if (expense.paidFor) {
+    const wanted = expense.paidFor
+    const rows = await page.locator('[data-id]').all()
+    for (const row of rows) {
+      const label = (await row.innerText()).split('\n')[0].trim()
+      const name = label.replace(/\s*\(.*\)$/, '')
+      await setChecked(row.getByRole('checkbox'), wanted.indexOf(name) !== -1)
+    }
+  }
+
+  const splitMode = expense.splitMode ?? 'EVENLY'
+  if (splitMode !== 'EVENLY') {
+    // Radix Collapsible unmounts its content, so the Split mode select does
+    // not exist in the DOM until this is opened.
+    await page
+      .getByRole('button', { name: /Advanced splitting options/ })
+      .click()
+    await selectRadixOption(
+      page,
+      page.getByTestId('split-mode'),
+      SPLIT_MODE_LABELS[splitMode],
+    )
+  }
+
+  if (expense.shares) {
+    // Set every participant's share, not just the ones being changed: under
+    // BY_AMOUNT the form auto-distributes to whoever has not been edited yet.
+    const shares = expense.shares
+    const names = Object.keys(shares)
+    for (const name of names) {
+      await fillStable(
+        paidForRow(page, name).getByRole('textbox'),
+        shares[name],
+      )
+    }
+  }
+
+  await submit.click()
+  await page.waitForURL(EXPENSES_URL, { timeout: 30_000 })
+}
+
+export async function openTab(page: Page, tab: GroupTab): Promise<void> {
+  const path = new RegExp(`/groups/[^/]+/${TAB_PATHS[tab]}(\\?|$)`)
+  await clickUntil(
+    () => page.getByRole('tab', { name: tab, exact: true }).click(),
+    () => page.waitForURL(path, { timeout: 5_000 }),
+  )
+}
+
+/** Opens an expense for editing. The card is a div with onClick, not a link. */
+export async function openExpense(page: Page, title: string): Promise<void> {
+  await clickUntil(
+    () =>
+      page
+        .getByTestId('expense-card')
+        .filter({ hasText: title })
+        .first()
+        .click(),
+    () => page.waitForURL(/\/expenses\/[^/]+\/edit/, { timeout: 5_000 }),
+  )
+}
+
+/**
+ * A "Paid for" row on the expense form. Scoped by the checkbox's accessible
+ * name because the share inputs inside these rows share a duplicated id and
+ * carry no name attribute -- the row is the only way to tell them apart.
+ */
+export function paidForRow(page: Page, participant: string): Locator {
+  return page.locator('[data-id]').filter({
+    has: page.getByRole('checkbox', {
+      name: new RegExp(`^${escapeRegExp(participant)}\\b`),
+    }),
+  })
+}
+
+export function balanceRow(page: Page, participant: string): Locator {
+  return page.locator(
+    `[data-testid="balance-row"][data-participant="${participant}"]`,
+  )
+}
+
+export async function expectBalance(
+  page: Page,
+  participant: string,
+  amount: number,
+): Promise<void> {
+  await expect(balanceRow(page, participant)).toContainText(money(amount))
+}
+
+export function reimbursementRow(
+  page: Page,
+  from: string,
+  to: string,
+): Locator {
+  return page.locator(
+    `[data-testid="reimbursement-row"][data-from="${from}"][data-to="${to}"]`,
+  )
+}

--- a/e2e/core.spec.ts
+++ b/e2e/core.spec.ts
@@ -1,0 +1,57 @@
+import {
+  addExpense,
+  createGroup,
+  expectBalance,
+  openTab,
+  reimbursementRow,
+  uniqueSuffix,
+} from './app'
+import { expect, test } from './fixtures'
+import { money } from './ui'
+
+test('creates a group, records expenses and computes balances', async ({
+  page,
+}) => {
+  const name = `E2E Core ${uniqueSuffix()}`
+
+  const groupId = await createGroup(page, {
+    name,
+    participants: ['Alice', 'Bob', 'Carol'],
+  })
+
+  await expect(page.getByRole('heading', { name, exact: true })).toBeVisible()
+  await expect(page.getByText(/doesn.t contain any expense yet/)).toBeVisible()
+
+  // Alice pays 90, Bob pays 30. Split evenly, so each owes 40.
+  await addExpense(page, groupId, {
+    title: 'Dinner',
+    amount: '90',
+    paidBy: 'Alice',
+  })
+  await addExpense(page, groupId, {
+    title: 'Taxi',
+    amount: '30',
+    paidBy: 'Bob',
+  })
+
+  const dinner = page.getByTestId('expense-card').filter({ hasText: 'Dinner' })
+  await expect(dinner).toBeVisible()
+  await expect(dinner).toContainText(money(90))
+  await expect(dinner).toContainText('Paid by Alice')
+
+  const taxi = page.getByTestId('expense-card').filter({ hasText: 'Taxi' })
+  await expect(taxi).toContainText(money(30))
+  await expect(taxi).toContainText('Paid by Bob')
+
+  await openTab(page, 'Balances')
+
+  // Alice 90 - 40, Bob 30 - 40, Carol 0 - 40. Sums to zero.
+  await expectBalance(page, 'Alice', 50)
+  await expectBalance(page, 'Bob', -10)
+  await expectBalance(page, 'Carol', -40)
+
+  await expect(reimbursementRow(page, 'Carol', 'Alice')).toContainText(
+    money(40),
+  )
+  await expect(reimbursementRow(page, 'Bob', 'Alice')).toContainText(money(10))
+})

--- a/e2e/expense-edit-delete.spec.ts
+++ b/e2e/expense-edit-delete.spec.ts
@@ -1,0 +1,91 @@
+import {
+  addExpense,
+  createGroup,
+  expectBalance,
+  EXPENSES_URL,
+  openExpense,
+  openTab,
+  paidForRow,
+  uniqueSuffix,
+} from './app'
+import { expect, test } from './fixtures'
+import { fillStable, money, setChecked } from './ui'
+
+test('edits an expense and recomputes balances', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Edit ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob', 'Carol'],
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Groceries',
+    amount: '60',
+    paidBy: 'Alice',
+  })
+
+  await openExpense(page, 'Groceries')
+
+  // The form must arrive pre-filled with what we created.
+  await expect(page.locator('input[name="title"]')).toHaveValue('Groceries')
+  await expect(page.locator('input[name="amount"]')).toHaveValue(/^60/)
+  await expect(page.getByTestId('paid-by')).toContainText('Alice')
+  for (const name of ['Alice', 'Bob', 'Carol']) {
+    await expect(paidForRow(page, name).getByRole('checkbox')).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+  }
+
+  await fillStable(page.locator('input[name="title"]'), 'Groceries and wine')
+  await fillStable(page.locator('input[name="amount"]'), '90')
+  await setChecked(paidForRow(page, 'Carol').getByRole('checkbox'), false)
+
+  await page.getByRole('button', { name: 'Save', exact: true }).click()
+  await page.waitForURL(EXPENSES_URL, { timeout: 30_000 })
+
+  const card = page
+    .getByTestId('expense-card')
+    .filter({ hasText: 'Groceries and wine' })
+  await expect(card).toContainText(money(90))
+  await expect(card).toContainText('Paid by Alice for Alice, Bob')
+
+  // 90 split between Alice and Bob only.
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 45)
+  await expectBalance(page, 'Bob', -45)
+  await expectBalance(page, 'Carol', 0)
+})
+
+test('deletes an expense and clears the balances', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Delete ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob', 'Carol'],
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Museum',
+    amount: '60',
+    paidBy: 'Alice',
+  })
+
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 40)
+
+  await openTab(page, 'Expenses')
+  await openExpense(page, 'Museum')
+
+  await page.getByRole('button', { name: 'Delete', exact: true }).click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toContainText('Delete this expense?')
+  await dialog.getByRole('button', { name: 'Yes', exact: true }).click()
+
+  await page.waitForURL(EXPENSES_URL, { timeout: 30_000 })
+  await expect(page.getByTestId('expense-card')).toHaveCount(0)
+  await expect(page.getByText(/doesn.t contain any expense yet/)).toBeVisible()
+
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 0)
+  await expectBalance(page, 'Bob', 0)
+  await expectBalance(page, 'Carol', 0)
+  await expect(page.getByText(/doesn.t need any reimbursement/)).toBeVisible()
+})

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,49 @@
+import { test as base, expect } from '@playwright/test'
+
+/**
+ * Shared test fixture.
+ *
+ * Two things every spec needs:
+ *
+ * 1. The "Who are you?" dialog. It opens on a group's expenses page whenever
+ *    neither `newGroup-activeUser` nor `<groupId>-activeUser` is in
+ *    localStorage, and it is a modal that blocks pointer events. Creating a
+ *    group through the UI happens to set the key, but navigating straight to a
+ *    group URL does not -- so seed it on every navigation. 'None' is
+ *    deliberate: any other value would pre-fill "Paid by" and make expense
+ *    tests depend on hidden state.
+ *
+ * 2. The locale. Assertions are English literals and amounts are formatted by
+ *    Intl, so both the app locale (NEXT_LOCALE cookie, which outranks
+ *    Accept-Language in src/lib/locale.ts) and the browser locale are pinned.
+ */
+export const test = base.extend({
+  // The second argument is Playwright's `use` callback, renamed because
+  // eslint-plugin-react-hooks would otherwise read `use(...)` as React's hook.
+  page: async ({ page, baseURL }, runTest) => {
+    if (baseURL) {
+      await page
+        .context()
+        .addCookies([{ name: 'NEXT_LOCALE', value: 'en-US', url: baseURL }])
+    }
+
+    await page.addInitScript(() => {
+      try {
+        if (!window.localStorage.getItem('newGroup-activeUser')) {
+          window.localStorage.setItem('newGroup-activeUser', 'None')
+        }
+      } catch (err) {
+        // localStorage is unavailable on about:blank; nothing to seed there.
+      }
+    })
+
+    // The suite must never depend on a third-party API. useCurrencyRate only
+    // calls this when the expense currency differs from the group currency,
+    // which no test does -- this makes that a guarantee rather than a habit.
+    await page.route('https://api.frankfurter.dev/**', (route) => route.abort())
+
+    await runTest(page)
+  },
+})
+
+export { expect }

--- a/e2e/group-management.spec.ts
+++ b/e2e/group-management.spec.ts
@@ -1,0 +1,122 @@
+import {
+  addExpense,
+  createGroup,
+  expectBalance,
+  openTab,
+  paidForRow,
+  uniqueSuffix,
+} from './app'
+import { expect, test } from './fixtures'
+import { fillStable } from './ui'
+
+test('renames a group and adds a participant afterwards', async ({ page }) => {
+  const original = `E2E Settings ${uniqueSuffix()}`
+  const groupId = await createGroup(page, {
+    name: original,
+    participants: ['Alice', 'Bob', 'Carol'],
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Brunch',
+    amount: '60',
+    paidBy: 'Alice',
+  })
+
+  await openTab(page, 'Settings')
+
+  const renamed = `${original} renamed`
+  await fillStable(page.locator('input[name="name"]'), renamed)
+
+  // A participant already involved in an expense cannot be removed.
+  const aliceRow = page
+    .locator('li')
+    .filter({ has: page.locator('input[name="participants.0.name"]') })
+  await expect(aliceRow.getByRole('button')).toBeDisabled()
+
+  await page.getByRole('button', { name: 'Add participant' }).click()
+  await fillStable(page.locator('input[name="participants.3.name"]'), 'Dave')
+
+  // EditGroup saves in place rather than navigating.
+  await page.getByRole('button', { name: 'Save', exact: true }).click()
+  await expect(
+    page.getByRole('heading', { name: renamed, exact: true }),
+  ).toBeVisible({ timeout: 30_000 })
+
+  // The new participant must be usable straight away.
+  await addExpense(page, groupId, {
+    title: 'Drinks',
+    amount: '80',
+    paidBy: 'Dave',
+  })
+  await page.goto(`/groups/${groupId}/expenses/create`)
+  await expect(paidForRow(page, 'Dave')).toBeVisible()
+
+  await page.goto(`/groups/${groupId}/balances`)
+  // Brunch: 60 over 3 (Dave did not exist yet). Drinks: 80 over 4 = 20 each.
+  await expectBalance(page, 'Dave', 60)
+})
+
+test('lists visited groups under Recent groups', async ({ page }) => {
+  const first = `E2E Recent A ${uniqueSuffix()}`
+  const second = `E2E Recent B ${uniqueSuffix()}`
+
+  await createGroup(page, { name: first, participants: ['Alice', 'Bob'] })
+  await createGroup(page, { name: second, participants: ['Alice', 'Bob'] })
+
+  await page.goto('/groups')
+  await expect(
+    page.getByRole('heading', { name: 'Recent groups' }),
+  ).toBeVisible()
+  await expect(page.getByRole('link', { name: first })).toBeVisible()
+  await expect(page.getByRole('link', { name: second })).toBeVisible()
+})
+
+test('shows no recent groups in a fresh browser profile', async ({ page }) => {
+  // Recent groups live in localStorage, so a new context must start empty even
+  // though other tests have created groups on the same database.
+  await page.goto('/groups')
+  await expect(
+    page.getByText('You have not visited any group recently.'),
+  ).toBeVisible()
+})
+
+test('records group and expense changes in the activity log', async ({
+  page,
+}) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Activity ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob'],
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Cinema',
+    amount: '20',
+    paidBy: 'Alice',
+  })
+
+  await openTab(page, 'Activity')
+
+  const activity = page.getByText(/Expense .*Cinema.* created by/)
+  await expect(activity).toBeVisible()
+  // The active user is 'None', so the actor renders as the generic fallback.
+  await expect(activity).toContainText('Someone')
+})
+
+test('exports the expenses as CSV', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Export ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob'],
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Parking',
+    amount: '12',
+    paidBy: 'Alice',
+  })
+
+  const response = await page.request.get(
+    `/groups/${groupId}/expenses/export/csv`,
+  )
+  expect(response.status()).toBe(200)
+  expect(await response.text()).toContain('Parking')
+})

--- a/e2e/reimbursements.spec.ts
+++ b/e2e/reimbursements.spec.ts
@@ -1,0 +1,64 @@
+import {
+  addExpense,
+  createGroup,
+  expectBalance,
+  EXPENSES_URL,
+  openTab,
+  paidForRow,
+  reimbursementRow,
+  uniqueSuffix,
+} from './app'
+import { expect, test } from './fixtures'
+import { money } from './ui'
+
+test('settles a debt through "Mark as paid"', async ({ page }) => {
+  // Two participants, so the suggested reimbursement is unique and deterministic.
+  const groupId = await createGroup(page, {
+    name: `E2E Reimbursement ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob'],
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Hotel',
+    amount: '100',
+    paidBy: 'Alice',
+  })
+
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 50)
+  await expectBalance(page, 'Bob', -50)
+
+  const row = reimbursementRow(page, 'Bob', 'Alice')
+  await expect(row).toContainText('Bob owes Alice')
+  await expect(row).toContainText(money(50))
+
+  await row.getByRole('link', { name: 'Mark as paid' }).click()
+  await page.waitForURL(/\/expenses\/create\?.*reimbursement=yes/, {
+    timeout: 30_000,
+  })
+
+  // The link prefills the whole form from its query string.
+  await expect(page.locator('input[name="title"]')).toHaveValue('Reimbursement')
+  await expect(page.locator('input[name="amount"]')).toHaveValue(/^50/)
+  await expect(page.getByTestId('paid-by')).toContainText('Bob')
+  await expect(paidForRow(page, 'Alice').getByRole('checkbox')).toHaveAttribute(
+    'aria-checked',
+    'true',
+  )
+  await expect(paidForRow(page, 'Bob').getByRole('checkbox')).toHaveAttribute(
+    'aria-checked',
+    'false',
+  )
+
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await page.waitForURL(EXPENSES_URL, { timeout: 30_000 })
+
+  await expect(
+    page.getByTestId('expense-card').filter({ hasText: 'Reimbursement' }),
+  ).toBeVisible()
+
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 0)
+  await expectBalance(page, 'Bob', 0)
+  await expect(page.getByText(/doesn.t need any reimbursement/)).toBeVisible()
+})

--- a/e2e/split-modes.spec.ts
+++ b/e2e/split-modes.spec.ts
@@ -1,0 +1,104 @@
+import {
+  addExpense,
+  createGroup,
+  expectBalance,
+  openTab,
+  paidForRow,
+  uniqueSuffix,
+} from './app'
+import { expect, test } from './fixtures'
+import { fillStable, selectRadixOption } from './ui'
+
+const PARTICIPANTS = ['Alice', 'Bob', 'Carol']
+
+test('splits an expense by shares', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Shares ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  // 100 over 2/1/1 shares: Alice owes 50, Bob and Carol 25 each.
+  await addExpense(page, groupId, {
+    title: 'Rent',
+    amount: '100',
+    paidBy: 'Alice',
+    splitMode: 'BY_SHARES',
+    shares: { Alice: '2', Bob: '1', Carol: '1' },
+  })
+
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 50)
+  await expectBalance(page, 'Bob', -25)
+  await expectBalance(page, 'Carol', -25)
+})
+
+test('splits an expense by percentage', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Percentage ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Villa',
+    amount: '100',
+    paidBy: 'Alice',
+    splitMode: 'BY_PERCENTAGE',
+    shares: { Alice: '50', Bob: '30', Carol: '20' },
+  })
+
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 50)
+  await expectBalance(page, 'Bob', -30)
+  await expectBalance(page, 'Carol', -20)
+})
+
+test('splits an expense by amount', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Amount ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Flights',
+    amount: '100',
+    paidBy: 'Alice',
+    splitMode: 'BY_AMOUNT',
+    shares: { Alice: '50', Bob: '30', Carol: '20' },
+  })
+
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 50)
+  await expectBalance(page, 'Bob', -30)
+  await expectBalance(page, 'Carol', -20)
+})
+
+test('rejects percentages that do not add up to 100', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E BadPercent ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  // Driven inline rather than through addExpense, which waits for a successful
+  // navigation -- the whole point here is that submitting must not navigate.
+  await page.goto(`/groups/${groupId}/expenses/create`)
+  const submit = page.getByRole('button', { name: 'Create', exact: true })
+  await expect(submit).toBeVisible({ timeout: 30_000 })
+
+  await fillStable(page.locator('input[name="title"]'), 'Invalid')
+  await fillStable(page.locator('input[name="amount"]'), '100')
+  await selectRadixOption(page, page.getByTestId('paid-by'), 'Alice')
+  await page.getByRole('button', { name: /Advanced splitting options/ }).click()
+  await selectRadixOption(page, page.getByTestId('split-mode'), /By percentage/)
+
+  const shares: Record<string, string> = { Alice: '50', Bob: '30', Carol: '10' }
+  for (const name of Object.keys(shares)) {
+    await fillStable(paidForRow(page, name).getByRole('textbox'), shares[name])
+  }
+
+  await submit.click()
+
+  await expect(
+    page.getByText('Sum of percentages must equal 100.'),
+  ).toBeVisible()
+  await expect(page).toHaveURL(/\/expenses\/create/)
+})

--- a/e2e/ui.ts
+++ b/e2e/ui.ts
@@ -1,0 +1,120 @@
+import { expect, Locator, Page } from '@playwright/test'
+
+/**
+ * Generic UI primitives. These exist to absorb three recurring hazards in this
+ * app: React hydration racing the first interaction, Radix rendering its
+ * options/dialogs in a portal, and Intl emitting glyphs that vary by ICU build.
+ */
+
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Formats an amount exactly as the app does -- see formatCurrency in
+ * src/lib/utils.ts, which builds an Intl.NumberFormat with the group currency.
+ * Never hardcode '$30.00' in a spec; call money(30).
+ */
+export function money(
+  amount: number,
+  currency = 'USD',
+  locale = 'en-US',
+): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount)
+}
+
+/** Folds glyph variants (NBSP, narrow NBSP, U+2212 minus) to their ASCII form. */
+export function normalizeMoney(value: string): string {
+  return value.replace(/[  ]/g, ' ').replace(/−/g, '-').trim()
+}
+
+/**
+ * Fills a react-hook-form input and proves the value stuck.
+ *
+ * Every form field here is controlled by RHF inside a client component that is
+ * server-rendered with identical markup, so there is no visual signal for
+ * "hydrated". A fill that lands too early is silently reverted to ''. Retrying
+ * until the value survives is the only reliable approach.
+ */
+export async function fillStable(input: Locator, value: string): Promise<void> {
+  await expect(async () => {
+    await input.fill(value)
+    await expect(input).toHaveValue(value, { timeout: 1000 })
+  }).toPass({ timeout: 20_000 })
+}
+
+/**
+ * Picks an option from a Radix Select.
+ *
+ * Options are portalled to document.body, and the trigger may not respond
+ * before hydration. Re-opening on each attempt handles both. Pass a regex for
+ * any label containing a non-ASCII glyph (the split modes use an en dash).
+ */
+export async function selectRadixOption(
+  page: Page,
+  trigger: Locator,
+  option: string | RegExp,
+): Promise<void> {
+  await expect(async () => {
+    const choice = page.getByRole('option', { name: option }).first()
+    const alreadyOpen = await choice.isVisible().catch(() => false)
+    if (!alreadyOpen) await trigger.click({ timeout: 5_000 })
+    await choice.click({ timeout: 5_000 })
+  }).toPass({ timeout: 20_000 })
+}
+
+/**
+ * Sets a Radix Checkbox, which is a <button role="checkbox"> driven by
+ * aria-checked rather than an <input>. Playwright's check() is more brittle
+ * against it than simply reading state and clicking when it differs.
+ */
+export async function setChecked(
+  checkbox: Locator,
+  checked: boolean,
+): Promise<void> {
+  await expect(async () => {
+    const state = await checkbox.getAttribute('aria-checked')
+    if ((state === 'true') !== checked) await checkbox.click({ timeout: 5_000 })
+    expect(await checkbox.getAttribute('aria-checked')).toBe(String(checked))
+  }).toPass({ timeout: 15_000 })
+}
+
+/**
+ * The <Card> whose CardTitle (an h3) is `title`. Balances and Suggested
+ * reimbursements are two structurally identical, unlabelled cards, so
+ * assertions have to be scoped to one of them.
+ */
+export function cardByTitle(page: Page, title: string): Locator {
+  return page
+    .getByRole('heading', { name: title, exact: true })
+    .locator('xpath=../..')
+}
+
+/**
+ * The FormItem <div> wrapping the <label> with this exact text. Needed because
+ * several Radix Select triggers in expense-form.tsx are not wrapped in
+ * FormControl, so their FormLabel's htmlFor points at an element that does not
+ * exist and getByLabel() cannot reach them.
+ */
+export function fieldByLabel(page: Page, label: string): Locator {
+  return page
+    .locator('label')
+    .filter({ hasText: new RegExp(`^${escapeRegExp(label)}$`) })
+    .locator('xpath=..')
+}
+
+/** Retries `action` until `settled` succeeds -- for clicks that precede hydration. */
+export async function clickUntil(
+  action: () => Promise<void>,
+  settled: () => Promise<void>,
+): Promise<void> {
+  await expect(async () => {
+    await action()
+    await settled()
+  }).toPass({ timeout: 20_000 })
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,6 +10,9 @@ const createJestConfig = nextJest({
 const config: Config = {
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
+  // Jest's default testMatch would pick up the Playwright specs in e2e/, which
+  // must be run with `npx playwright test` instead.
+  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/e2e/'],
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1315,9 +1316,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1333,9 +1331,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1353,9 +1348,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1371,9 +1363,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1391,9 +1380,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1407,9 +1393,6 @@
       "version": "1.3.2",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1427,9 +1410,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1446,9 +1426,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1464,9 +1441,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1490,9 +1464,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1514,9 +1485,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1540,9 +1508,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1565,9 +1530,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1587,9 +1549,6 @@
       "version": "0.35.3",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1613,9 +1572,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1637,9 +1593,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2290,9 +2243,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2309,9 +2259,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2325,9 +2272,6 @@
       "version": "16.3.1",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2344,9 +2288,6 @@
       "integrity": "sha512-6yy3FT13KgUFOj5H8bl8w/6nKiJwHIvbtwh1V+1acsu+7y4tJjnemSa6mhsh53BeoVrlozE+fMgZhXH46WmjMA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2545,9 +2486,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2567,9 +2505,6 @@
       "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2591,9 +2526,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2614,9 +2546,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2634,9 +2563,6 @@
       "version": "2.6.0",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2657,9 +2583,6 @@
       "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2722,6 +2645,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@prisma/client": {
@@ -3926,9 +3865,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3944,9 +3880,6 @@
       "integrity": "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -3964,9 +3897,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3983,9 +3913,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3999,9 +3926,6 @@
       "version": "1.15.47",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -4018,9 +3942,6 @@
       "integrity": "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -4863,9 +4784,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4880,9 +4798,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4897,9 +4812,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4914,9 +4826,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4931,9 +4840,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4948,9 +4854,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4965,9 +4868,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4982,9 +4882,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4997,9 +4894,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5014,9 +4908,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10486,6 +10377,53 @@
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/po-parser": {

--- a/package.json
+++ b/package.json
@@ -8,12 +8,18 @@
     "start": "next start",
     "lint": "eslint .",
     "check-types": "tsc --noEmit",
-    "check-formatting": "prettier -c src",
-    "prettier": "prettier -w src",
+    "check-formatting": "prettier -c src e2e playwright.config.ts",
+    "prettier": "prettier -w src e2e playwright.config.ts",
     "postinstall": "prisma migrate deploy && prisma generate",
     "build-image": "./scripts/build-image.sh",
     "start-container": "docker compose --env-file container.env up",
     "test": "jest",
+    "e2e": "./scripts/e2e.sh",
+    "e2e:up": "./scripts/e2e.sh up",
+    "e2e:down": "./scripts/e2e.sh down",
+    "e2e:logs": "./scripts/e2e.sh logs",
+    "e2e:test": "playwright test",
+    "e2e:report": "playwright show-report",
     "generate-currency-data": "ts-node -T ./src/scripts/generateCurrencyData.ts"
   },
   "dependencies": {
@@ -75,6 +81,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "e2e:up": "./scripts/e2e.sh up",
     "e2e:down": "./scripts/e2e.sh down",
     "e2e:logs": "./scripts/e2e.sh logs",
-    "e2e:test": "playwright test",
+    "e2e:test": "./scripts/e2e.sh test",
     "e2e:report": "playwright show-report",
     "generate-currency-data": "ts-node -T ./src/scripts/generateCurrencyData.ts"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * The app under test is started by scripts/e2e.sh (docker compose), not by
+ * Playwright's `webServer`: we need to build an image, we need `docker compose
+ * logs` as a CI artifact on failure, and compose's healthchecks are a stricter
+ * readiness signal than URL polling (they also fail when a container exits).
+ */
+export default defineConfig({
+  testDir: './e2e',
+  outputDir: './test-results',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  // A single `next start` process serves every worker; too many just adds
+  // latency and flake without adding coverage.
+  workers: process.env.CI ? 2 : 4,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI
+    ? [
+        ['github'],
+        ['list'],
+        ['html', { open: 'never', outputFolder: 'playwright-report' }],
+      ]
+    : [
+        ['list'],
+        ['html', { open: 'never', outputFolder: 'playwright-report' }],
+      ],
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
+    navigationTimeout: 30_000,
+    // retain-on-failure rather than on-first-retry: with retries in CI, a test
+    // that fails then passes would otherwise leave no evidence behind.
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Must stay >= 768px wide: useMediaQuery('(min-width: 768px)') swaps
+        // Radix Dialog <-> Vaul Drawer and Popover <-> Drawer, so a narrow
+        // viewport renders a completely different component tree.
+        viewport: { width: 1280, height: 900 },
+        // Locale drives next-intl (via Accept-Language) *and* Intl currency
+        // formatting. Both must be pinned for text assertions to be stable.
+        locale: 'en-US',
+        timezoneId: 'UTC',
+      },
+    },
+  ],
+})

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Runs the Playwright suite against an isolated app + postgres stack built from
+# this checkout. CI calls the same subcommands, so local and CI runs are identical.
+#
+#   ./scripts/e2e.sh                  build, start, test, tear down
+#   ./scripts/e2e.sh up               start and leave running
+#   ./scripts/e2e.sh test --ui        run tests against an already-running stack
+#   ./scripts/e2e.sh logs             dump container logs
+#   ./scripts/e2e.sh down             stop and delete the database
+#
+# Env:
+#   E2E_HOST_PORT    host port to publish (default 3000)
+#   E2E_SKIP_BUILD   set to 1 when the image was already built (CI cache path)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+E2E_HOST_PORT="${E2E_HOST_PORT:-3000}"
+export E2E_HOST_PORT
+export E2E_BASE_URL="${E2E_BASE_URL:-http://localhost:${E2E_HOST_PORT}}"
+
+compose() { docker compose -f compose.e2e.yaml "$@"; }
+
+up() {
+  # --force-recreate --renew-anon-volumes is what actually guarantees a clean
+  # database: the postgres image declares its own VOLUME, so a plain `up` would
+  # silently reattach the previous run's anonymous volume.
+  #
+  # Spelled out twice rather than built as an array: macOS still ships bash 3.2,
+  # where `set -u` treats an empty array expansion as an unbound variable.
+  if [ "${E2E_SKIP_BUILD:-}" = "1" ]; then
+    compose up --wait --wait-timeout 300 --force-recreate --renew-anon-volumes
+  else
+    compose up --wait --wait-timeout 300 --force-recreate --renew-anon-volumes --build
+  fi
+}
+
+down() { compose down --volumes --remove-orphans --timeout 10; }
+
+logs() { compose logs --no-color --timestamps; }
+
+case "${1:-all}" in
+up) up ;;
+down) down ;;
+logs) logs ;;
+test)
+  shift
+  npx playwright test "$@"
+  ;;
+all)
+  # Drop an explicit leading "all" so it is not forwarded as a test filter.
+  # Spelled as an if, not `[ ... ] && shift`: under `set -e` a false test as the
+  # last command in the branch would abort the script.
+  if [ $# -gt 0 ]; then shift; fi
+  trap 'status=$?; if [ $status -ne 0 ]; then logs || true; fi; down || true; exit $status' EXIT
+  up
+  npx playwright test "$@"
+  ;;
+*)
+  echo "usage: $0 [all|up|test|down|logs]" >&2
+  exit 2
+  ;;
+esac

--- a/src/app/groups/[groupId]/balances-list.tsx
+++ b/src/app/groups/[groupId]/balances-list.tsx
@@ -24,6 +24,8 @@ export function BalancesList({ balances, participants, currency }: Props) {
         return (
           <div
             key={participant.id}
+            data-testid="balance-row"
+            data-participant={participant.name}
             className={cn('flex', isLeft || 'flex-row-reverse')}
           >
             <div className={cn('w-1/2 p-2', isLeft && 'text-right')}>

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -63,6 +63,8 @@ export function ExpenseCard({
   return (
     <div
       key={expense.id}
+      data-testid="expense-card"
+      data-expense-id={expense.id}
       className={cn(
         'flex justify-between sm:mx-6 px-4 sm:rounded-lg sm:pr-2 sm:pl-4 py-4 text-sm cursor-pointer hover:bg-accent gap-1 items-stretch',
         expense.isReimbursement && 'italic',

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -765,7 +765,7 @@ export function ExpenseForm({
                     onValueChange={field.onChange}
                     defaultValue={getSelectedPayer(field)}
                   >
-                    <SelectTrigger>
+                    <SelectTrigger data-testid="paid-by">
                       <SelectValue
                         placeholder={t(`${sExpense}.paidByField.placeholder`)}
                       />
@@ -1226,7 +1226,7 @@ export function ExpenseForm({
                             }}
                             defaultValue={field.value}
                           >
-                            <SelectTrigger>
+                            <SelectTrigger data-testid="split-mode">
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>

--- a/src/app/groups/[groupId]/reimbursement-list.tsx
+++ b/src/app/groups/[groupId]/reimbursement-list.tsx
@@ -29,7 +29,13 @@ export function ReimbursementList({
   return (
     <div className="text-sm">
       {reimbursements.map((reimbursement, index) => (
-        <div className="py-4 flex justify-between" key={index}>
+        <div
+          className="py-4 flex justify-between"
+          key={index}
+          data-testid="reimbursement-row"
+          data-from={getParticipant(reimbursement.from)?.name ?? ''}
+          data-to={getParticipant(reimbursement.to)?.name ?? ''}
+        >
           <div className="flex flex-col gap-1 items-start sm:flex-row sm:items-baseline sm:gap-4">
             <div>
               {t.rich('owes', {


### PR DESCRIPTION
Adds an end-to-end suite that drives a real browser (Chromium) against the app running in Docker — app container + PostgreSQL — so it exercises the same image users deploy.

## What it covers

13 tests across 5 specs, all happy paths:

| Spec | Covers |
| --- | --- |
| `e2e/core.spec.ts` | Create a group, record expenses, assert the expense list, balances and suggested reimbursements |
| `e2e/expense-edit-delete.spec.ts` | Edit an expense (amount + paid-for) and delete it, asserting balances recompute both times |
| `e2e/split-modes.spec.ts` | The three uneven split modes (by shares / percentage / amount), plus a validation-failure case |
| `e2e/reimbursements.spec.ts` | "Mark as paid" settle-up, including the query-string prefill |
| `e2e/group-management.spec.ts` | Rename a group, add a participant later, recent groups, activity log, CSV export |

## Running it

```sh
npm run e2e                     # build image, fresh DB, run suite, tear down
npm run e2e:up                  # keep the stack warm while writing tests
npm run e2e:test -- --ui        # iterate
npm run e2e:down
E2E_HOST_PORT=3100 npm run e2e  # when port 3000 is taken by `npm run dev`
```

CI is the new **E2E** workflow: `workflow_dispatch` plus `push: tags: ['*']`, the same trigger as the Docker image build in `cd.yml`. It builds the image from the checkout rather than pulling from ghcr.io, so it is independent of `cd.yml` and needs no published artifact. The HTML report uploads as an artifact always; container logs upload on failure.

## Notable decisions

**A separate `compose.e2e.yaml`.** The development stack is unsuitable and is left untouched: it bind-mounts `./postgres-data` (state would leak between runs), has no project `name:` (it would clobber the dev containers), and reads the gitignored `container.env`. The test stack uses its own project name, inline env and a database thrown away every run.

Worth knowing: the `postgres` image declares its own `VOLUME /var/lib/postgresql/data`, so Compose creates an anonymous volume even with no `volumes:` key. Freshness therefore comes from `--force-recreate --renew-anon-volumes` on up and `down --volumes`, both baked into `scripts/e2e.sh` so neither local nor CI can forget.

**Readiness is gated on `/api/health/readiness`.** Since `scripts/container-entrypoint.sh` runs `prisma migrate deploy` before starting the server, a 200 there proves the schema is migrated and the app is serving — no sleep, no polling heuristics.

**No Playwright `webServer`.** We need to build an image, and we need `docker compose logs` as a CI artifact on failure. Compose healthchecks are also a stricter signal than URL polling because they fail when a container *exits*. `scripts/e2e.sh` is the single entry point, so local and CI run identical commands.

**A new `.dockerignore`.** Without one the build context is ~1.7 GB (`node_modules` + `.next` + `postgres-data`), which makes local image builds painful. Nothing it excludes is `COPY`ed by the Dockerfile, so the production image is unaffected — `cd.yml` should get slightly faster too.

## Changes to app source

Limited to **13 lines of attributes across 4 files**, no behaviour change: `data-testid`/`data-participant` on balance rows, `data-testid`/`data-from`/`data-to` on reimbursement rows, `data-testid`/`data-expense-id` on expense cards, and `data-testid` on the paid-by and split-mode `SelectTrigger`s.

These earn their place because the app had no test hooks at all, five controls on the expense form expose `role="combobox"`, and the "Paid by" `Select` is not wrapped in `FormControl` — so its `FormLabel`'s `htmlFor` points at an element that does not exist and `getByLabel('Paid by')` cannot reach it.

`jest.config.ts` gains `testPathIgnorePatterns` for `e2e/`: Jest's default `testMatch` would otherwise pick up the Playwright specs and fail. `check-formatting` and `prettier` are widened to cover `e2e/`.

## Verification

- Full clean cycle from a scratch image build: **13/13 passed in 10.7s**, then containers, network and anonymous volume all removed (exit 0).
- Mutation check: flipping an expected balance from `$50.00` to `$51.00` fails with `Received: "Alice$50.00"`, confirming assertions read the real rendered app rather than passing vacuously.
- `npm test` still green (101 unit tests) and no longer matches `e2e/`; `check-types`, `lint` and `check-formatting` all clean.
- Confirmed `./postgres-data` is never created or touched by the test stack.

Notes for reviewers: the suite pins viewport ≥768px (the app swaps Radix Dialog↔Vaul Drawer below that), pins `locale: 'en-US'` and `timezoneId: 'UTC'`, seeds `newGroup-activeUser` to suppress the blocking "Who are you?" modal, and never asserts a hardcoded money string — amounts go through an `Intl.NumberFormat` helper mirroring `formatCurrency`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSY36HmNZhHTFLwuwyMRVu
