### PR TITLE
test: extend E2E coverage to active user, recurrence, income and stats

### DIFF
--- a/e2e/active-user.spec.ts
+++ b/e2e/active-user.spec.ts
@@ -1,0 +1,104 @@
+import { addExpense, createGroup, expenseCard, uniqueSuffix } from './app'
+import { expect, test } from './fixtures'
+import { money } from './ui'
+
+// The rest of the suite seeds `newGroup-activeUser` so this dialog stays shut.
+// Here it is the subject, so the seeding is switched off.
+test.use({ seedActiveUser: false })
+
+/**
+ * Puts the browser in the state a first-time visitor is in: the group exists,
+ * but this device has never picked an active user. Creating a group through
+ * the UI writes `newGroup-activeUser` itself, so it has to be cleared.
+ */
+async function forgetActiveUser(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    window.localStorage.removeItem('newGroup-activeUser')
+    for (const key of Object.keys(window.localStorage)) {
+      if (key.endsWith('-activeUser')) window.localStorage.removeItem(key)
+    }
+  })
+}
+
+test('asks who you are and personalises the expense list', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E ActiveUser ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob', 'Carol'],
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Dinner',
+    amount: '90',
+    paidBy: 'Alice',
+  })
+
+  await forgetActiveUser(page)
+  await page.goto(`/groups/${groupId}/expenses`)
+
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  await expect(dialog).toContainText('Who are you?')
+
+  await dialog.getByLabel('Bob', { exact: true }).click()
+  await dialog.getByRole('button', { name: 'Save changes' }).click()
+  await expect(dialog).toBeHidden()
+
+  // The reload is required, not incidental: useActiveUser (src/lib/hooks.ts)
+  // reads localStorage once in a useEffect keyed on groupId, so it is not
+  // reactive and already-mounted cards keep the previous value until they
+  // remount. Asserting before a reload would be asserting a bug fix nobody
+  // has made.
+  await page.reload()
+
+  // The dialog does not come back...
+  await expect(page.getByRole('dialog')).toBeHidden()
+  // ...and Bob now sees his own third of Alice's 90 on the card.
+  await expect(expenseCard(page, 'Dinner')).toContainText('Your balance:')
+  await expect(expenseCard(page, 'Dinner')).toContainText(money(-30))
+})
+
+test('pre-fills "Paid by" with the active user', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E ActiveUserPaidBy ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob', 'Carol'],
+  })
+
+  await forgetActiveUser(page)
+  await page.goto(`/groups/${groupId}/expenses`)
+
+  const dialog = page.getByRole('dialog')
+  await dialog.getByLabel('Carol', { exact: true }).click()
+  await dialog.getByRole('button', { name: 'Save changes' }).click()
+  await expect(dialog).toBeHidden()
+
+  await page.goto(`/groups/${groupId}/expenses/create`)
+  await expect(page.getByTestId('paid-by')).toContainText('Carol')
+})
+
+test('lets you decline to pick anyone', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E ActiveUserNobody ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob'],
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Taxi',
+    amount: '20',
+    paidBy: 'Alice',
+  })
+
+  await forgetActiveUser(page)
+  await page.goto(`/groups/${groupId}/expenses`)
+
+  const dialog = page.getByRole('dialog')
+  // "I don't want to select anyone" -- curly apostrophe in the source string.
+  await dialog.getByText(/don.t want to select anyone/).click()
+  await dialog.getByRole('button', { name: 'Save changes' }).click()
+  await expect(dialog).toBeHidden()
+
+  // With nobody selected there is no personalised balance on the card...
+  await expect(expenseCard(page, 'Taxi')).not.toContainText('Your balance:')
+  // ...and the dialog does not come back.
+  await page.reload()
+  await expect(page.getByRole('dialog')).toBeHidden()
+})

--- a/e2e/app.ts
+++ b/e2e/app.ts
@@ -2,6 +2,7 @@ import { expect, Locator, Page } from '@playwright/test'
 import {
   clickUntil,
   escapeRegExp,
+  fieldByLabel,
   fillStable,
   money,
   selectRadixOption,
@@ -9,6 +10,8 @@ import {
 } from './ui'
 
 export type SplitMode = 'EVENLY' | 'BY_SHARES' | 'BY_PERCENTAGE' | 'BY_AMOUNT'
+
+export type Recurrence = 'None' | 'Daily' | 'Weekly' | 'Monthly'
 
 export type GroupTab =
   'Expenses' | 'Balances' | 'Information' | 'Stats' | 'Activity' | 'Settings'
@@ -104,6 +107,12 @@ export async function addExpense(
     splitMode?: SplitMode
     /** Participant name -> share value. Set one for every checked participant. */
     shares?: Record<string, string>
+    /** YYYY-MM-DD. Defaults to today. */
+    date?: string
+    /** Visible category name, e.g. 'Groceries'. Defaults to General. */
+    category?: string
+    /** Visible label: 'None' | 'Daily' | 'Weekly' | 'Monthly'. Defaults to None. */
+    recurrence?: Recurrence
   },
 ): Promise<void> {
   await page.goto(`/groups/${groupId}/expenses/create`)
@@ -118,6 +127,29 @@ export async function addExpense(
   // amount changes, which would wipe values set beforehand.
   await fillStable(page.locator('input[name="amount"]'), expense.amount)
   await selectRadixOption(page, page.getByTestId('paid-by'), expense.paidBy)
+
+  if (expense.date) {
+    // The date input spreads no RHF field, so it has no name attribute.
+    await fillStable(page.locator('input[type="date"]'), expense.date)
+  }
+
+  if (expense.category) {
+    // A cmdk Command in a Popover, not a Radix Select, but the trigger is still
+    // role=combobox and the items are still role=option.
+    await selectRadixOption(
+      page,
+      fieldByLabel(page, 'Category').getByRole('combobox'),
+      expense.category,
+    )
+  }
+
+  if (expense.recurrence) {
+    await selectRadixOption(
+      page,
+      fieldByLabel(page, 'Expense Recurrence').getByRole('combobox'),
+      expense.recurrence,
+    )
+  }
 
   if (expense.paidFor) {
     const wanted = expense.paidFor
@@ -192,6 +224,50 @@ export function paidForRow(page: Page, participant: string): Locator {
       name: new RegExp(`^${escapeRegExp(participant)}\\b`),
     }),
   })
+}
+
+/**
+ * Makes `name` the active user for this group.
+ *
+ * Goes through the app's own migration path rather than writing the id
+ * directly: ExpenseList resolves `newGroup-activeUser` from a participant name
+ * to an id on mount. Writing `<groupId>-activeUser` by hand would not survive,
+ * because the shared fixture re-seeds `newGroup-activeUser` on every
+ * navigation and that migration always wins.
+ */
+export async function setActiveUser(
+  page: Page,
+  groupId: string,
+  name: string,
+): Promise<void> {
+  await page.addInitScript((participantName) => {
+    window.localStorage.setItem('newGroup-activeUser', participantName)
+  }, name)
+
+  await page.goto(`/groups/${groupId}/expenses`)
+
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          (id) => window.localStorage.getItem(`${id}-activeUser`) ?? '',
+          groupId,
+        ),
+      { timeout: 20_000 },
+    )
+    .not.toMatch(/^(|None)$/)
+}
+
+/** An expense row in the list. */
+export function expenseCard(page: Page, title: string): Locator {
+  return page.getByTestId('expense-card').filter({ hasText: title })
+}
+
+/** YYYY-MM-DD, n days before today. The suite pins the timezone to UTC. */
+export function daysAgo(n: number): string {
+  const date = new Date()
+  date.setUTCDate(date.getUTCDate() - n)
+  return date.toISOString().slice(0, 10)
 }
 
 export function balanceRow(page: Page, participant: string): Locator {

--- a/e2e/expense-variants.spec.ts
+++ b/e2e/expense-variants.spec.ts
@@ -1,0 +1,97 @@
+import {
+  addExpense,
+  createGroup,
+  expectBalance,
+  expenseCard,
+  openExpense,
+  openTab,
+  uniqueSuffix,
+} from './app'
+import { expect, test } from './fixtures'
+import { fieldByLabel, fillStable, money } from './ui'
+
+const PARTICIPANTS = ['Alice', 'Bob', 'Carol']
+
+test('records a negative amount as an income', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Income ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await page.goto(`/groups/${groupId}/expenses/create`)
+  await expect(
+    page.getByRole('button', { name: 'Create', exact: true }),
+  ).toBeVisible({ timeout: 30_000 })
+
+  await fillStable(page.locator('input[name="title"]'), 'Deposit refund')
+  await fillStable(page.locator('input[name="amount"]'), '-90')
+
+  // A negative amount re-labels the whole form: the heading and the payer
+  // field switch from expense wording to income wording.
+  await expect(
+    page.getByRole('heading', { name: 'Create income' }),
+  ).toBeVisible()
+  await expect(page.getByText('Received by')).toBeVisible()
+
+  await page.getByTestId('paid-by').click()
+  await page.getByRole('option', { name: 'Alice' }).click()
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await page.waitForURL(/\/groups\/[^/]+\/expenses(\?|$)/, { timeout: 30_000 })
+
+  await expect(expenseCard(page, 'Deposit refund')).toContainText(money(-90))
+  await expect(expenseCard(page, 'Deposit refund')).toContainText(
+    'Received by Alice',
+  )
+
+  // Income inverts the balances: Alice took the money in, so she owes it.
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', -60)
+  await expectBalance(page, 'Bob', 30)
+  await expectBalance(page, 'Carol', 30)
+})
+
+test('assigns a category to an expense', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Category ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Weekly shop',
+    amount: '60',
+    paidBy: 'Alice',
+    category: 'Groceries',
+  })
+
+  await openExpense(page, 'Weekly shop')
+  await expect(
+    fieldByLabel(page, 'Category').getByRole('combobox'),
+  ).toContainText('Groceries')
+})
+
+test('filters the expense list with the search bar', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Search ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Cinema tickets',
+    amount: '30',
+    paidBy: 'Alice',
+  })
+  await addExpense(page, groupId, {
+    title: 'Train fare',
+    amount: '40',
+    paidBy: 'Bob',
+  })
+
+  await expect(expenseCard(page, 'Cinema tickets')).toBeVisible()
+  await expect(expenseCard(page, 'Train fare')).toBeVisible()
+
+  // Placeholder contains a U+2026 ellipsis, so match on a prefix.
+  await page.getByPlaceholder(/Search for an expense/).fill('Cinema')
+
+  await expect(expenseCard(page, 'Cinema tickets')).toBeVisible()
+  await expect(expenseCard(page, 'Train fare')).toHaveCount(0)
+})

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -17,25 +17,38 @@ import { test as base, expect } from '@playwright/test'
  *    Intl, so both the app locale (NEXT_LOCALE cookie, which outranks
  *    Accept-Language in src/lib/locale.ts) and the browser locale are pinned.
  */
-export const test = base.extend({
+type Options = {
+  /**
+   * Seed `newGroup-activeUser` so the "Who are you?" dialog stays shut.
+   * Defaults to true. Set `test.use({ seedActiveUser: false })` in the spec
+   * that exercises the dialog itself.
+   */
+  seedActiveUser: boolean
+}
+
+export const test = base.extend<Options>({
+  seedActiveUser: [true, { option: true }],
+
   // The second argument is Playwright's `use` callback, renamed because
   // eslint-plugin-react-hooks would otherwise read `use(...)` as React's hook.
-  page: async ({ page, baseURL }, runTest) => {
+  page: async ({ page, baseURL, seedActiveUser }, runTest) => {
     if (baseURL) {
       await page
         .context()
         .addCookies([{ name: 'NEXT_LOCALE', value: 'en-US', url: baseURL }])
     }
 
-    await page.addInitScript(() => {
-      try {
-        if (!window.localStorage.getItem('newGroup-activeUser')) {
-          window.localStorage.setItem('newGroup-activeUser', 'None')
+    if (seedActiveUser) {
+      await page.addInitScript(() => {
+        try {
+          if (!window.localStorage.getItem('newGroup-activeUser')) {
+            window.localStorage.setItem('newGroup-activeUser', 'None')
+          }
+        } catch (err) {
+          // localStorage is unavailable on about:blank; nothing to seed there.
         }
-      } catch (err) {
-        // localStorage is unavailable on about:blank; nothing to seed there.
-      }
-    })
+      })
+    }
 
     // The suite must never depend on a third-party API. useCurrencyRate only
     // calls this when the expense currency differs from the group currency,

--- a/e2e/group-management.spec.ts
+++ b/e2e/group-management.spec.ts
@@ -102,6 +102,27 @@ test('records group and expense changes in the activity log', async ({
   await expect(activity).toContainText('Someone')
 })
 
+test('exports the expenses as JSON', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E ExportJson ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob'],
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Ferry',
+    amount: '18',
+    paidBy: 'Bob',
+  })
+
+  const response = await page.request.get(
+    `/groups/${groupId}/expenses/export/json`,
+  )
+  expect(response.status()).toBe(200)
+
+  const body = await response.json()
+  expect(JSON.stringify(body)).toContain('Ferry')
+})
+
 test('exports the expenses as CSV', async ({ page }) => {
   const groupId = await createGroup(page, {
     name: `E2E Export ${uniqueSuffix()}`,

--- a/e2e/recurrence.spec.ts
+++ b/e2e/recurrence.spec.ts
@@ -1,0 +1,70 @@
+import {
+  addExpense,
+  createGroup,
+  daysAgo,
+  expenseCard,
+  EXPENSES_URL,
+  openExpense,
+  uniqueSuffix,
+} from './app'
+import { expect, test } from './fixtures'
+import { fieldByLabel, selectRadixOption } from './ui'
+
+const PARTICIPANTS = ['Alice', 'Bob']
+
+test('round-trips a recurrence rule through the form', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Recurrence ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Netflix',
+    amount: '20',
+    paidBy: 'Alice',
+    recurrence: 'Monthly',
+  })
+
+  await openExpense(page, 'Netflix')
+  const field = fieldByLabel(page, 'Expense Recurrence').getByRole('combobox')
+  await expect(field).toContainText('Monthly')
+
+  // Turning a recurring expense back off is a distinct branch in
+  // src/lib/api.ts, so assert the transition persists.
+  await selectRadixOption(page, field, 'None')
+  await page.getByRole('button', { name: 'Save', exact: true }).click()
+  await page.waitForURL(EXPENSES_URL, { timeout: 30_000 })
+
+  await openExpense(page, 'Netflix')
+  await expect(
+    fieldByLabel(page, 'Expense Recurrence').getByRole('combobox'),
+  ).toContainText('None')
+})
+
+test('materialises past occurrences of a daily expense', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Daily ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  // getGroupExpenses() calls createRecurringExpenses() on every read, which
+  // fills in every occurrence whose date has already passed. Backdating by
+  // three days should therefore yield the original plus one per elapsed day.
+  await addExpense(page, groupId, {
+    title: 'Coffee',
+    amount: '5',
+    paidBy: 'Alice',
+    recurrence: 'Daily',
+    date: daysAgo(3),
+  })
+
+  await page.goto(`/groups/${groupId}/expenses`)
+
+  // Asserted as a floor rather than an exact count: the backfill depends on
+  // the wall clock, and a run spanning midnight UTC would produce one more.
+  await expect
+    .poll(async () => await expenseCard(page, 'Coffee').count(), {
+      timeout: 20_000,
+    })
+    .toBeGreaterThanOrEqual(4)
+})

--- a/e2e/stats.spec.ts
+++ b/e2e/stats.spec.ts
@@ -1,0 +1,51 @@
+import {
+  addExpense,
+  createGroup,
+  openTab,
+  setActiveUser,
+  uniqueSuffix,
+} from './app'
+import { expect, test } from './fixtures'
+import { cardByTitle, money } from './ui'
+
+const PARTICIPANTS = ['Alice', 'Bob', 'Carol']
+
+test('shows group totals, and personal totals once you pick a user', async ({
+  page,
+}) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Stats ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Dinner',
+    amount: '90',
+    paidBy: 'Alice',
+  })
+  await addExpense(page, groupId, {
+    title: 'Taxi',
+    amount: '30',
+    paidBy: 'Bob',
+  })
+
+  await openTab(page, 'Stats')
+  const totals = cardByTitle(page, 'Totals')
+
+  await expect(totals).toContainText('Total group spendings')
+  await expect(totals).toContainText(money(120))
+
+  // Without an active user there is nobody to compute a personal total for.
+  await expect(totals).not.toContainText('Your total spendings')
+  await expect(totals).not.toContainText('Your total share')
+
+  await setActiveUser(page, groupId, 'Alice')
+
+  await openTab(page, 'Stats')
+  const personalised = cardByTitle(page, 'Totals')
+  await expect(personalised).toContainText('Your total spendings')
+  // Alice paid for Dinner only; her share of both expenses is 40.
+  await expect(personalised).toContainText(money(90))
+  await expect(personalised).toContainText('Your total share')
+  await expect(personalised).toContainText(money(40))
+})


### PR DESCRIPTION
Stacked on #577 — **base branch is `worktree-e2e-playwright`, not `main`.** Review #577 first; this diff shows only the 10 additional tests.

Closes the coverage gaps identified after the initial suite landed. Full suite is now **23 tests in ~14s**.

## Active user — the gap the base suite created

`e2e/active-user.spec.ts`

The shared fixture seeds `newGroup-activeUser` so the blocking "Who are you?" dialog stays shut. That kept every other test deterministic, but it also meant the dialog — and everything downstream of it — was completely untested, despite being the first thing a new visitor meets. The fixture now takes a `seedActiveUser` option so this spec can switch the seeding off and drive the real flow:

- picking a participant, and declining to pick anyone
- the personalised `Your balance:` annotation on each expense card
- `Paid by` pre-filled from the active user

**One finding worth a look.** The reload in the first test is *required*, not incidental: `useActiveUser` (`src/lib/hooks.ts:57`) reads localStorage once inside a `useEffect` keyed on `groupId`, so it isn't reactive. After you pick your name in the dialog, the "Your balance" annotations don't appear until the component remounts. The test documents that behaviour rather than papering over it — if you consider it a bug, it's a small one and a separate fix.

## Recurrence

`e2e/recurrence.spec.ts`

- Round-trips a rule through the form, including the recurring → `NONE` transition, which is its own branch in `src/lib/api.ts`.
- Materialisation: `getGroupExpenses()` calls `createRecurringExpenses()` on **every** read, so a backdated daily expense fills in its elapsed occurrences on the next list load.

The occurrence count is asserted as a **floor, not an exact number** — it depends on the wall clock, and a run spanning midnight UTC would legitimately produce one more. Preferred an assertion that can't flake over one that's precisely wrong twice a year.

## Expense variants

`e2e/expense-variants.spec.ts`

- **Income**: a negative amount re-labels the whole form ("Create income", "Received by") and inverts the balances.
- **Categories**: every previous test left this at the default *General*, so the cmdk/Popover selector was never exercised.
- **Search**: the debounced filter on the expense list.

## Stats + JSON export

`e2e/stats.spec.ts` asserts group totals always render and personal totals appear only once an active user exists.

This needed a `setActiveUser` helper that goes through the app's own name→id migration in `ExpenseList`, because writing `<groupId>-activeUser` directly does **not** survive — the fixture re-seeds `newGroup-activeUser` on every navigation and that migration always wins. Worth knowing if you write more tests against active-user state.

A JSON export test sits alongside the existing CSV one.

## Deliberately not covered

- **Multi-currency conversion** — worth doing, but it needs a mocked `api.frankfurter.dev` response (the fixture currently aborts that host). Left out pending a decision on mocking a live rate; happy to add it.
- **Documents / receipt extraction / category extraction** — structurally impossible against this image: `scripts/build.env` bakes the `NEXT_PUBLIC_ENABLE_*` flags to `false`, and being `NEXT_PUBLIC_` they're inlined into the bundle at build time, not read at container start. Would need a second image built with different args plus mocked OpenAI/S3.
- **Infinite-scroll pagination** — needs more than `PAGE_SIZE` expenses per test, which would dominate runtime for little signal.

## Verification

23/23 pass against the Dockerized stack. The timing-sensitive specs (recurrence, active-user, stats) were additionally run with `--repeat-each=3` — 18/18, no flakes. `check-types`, `lint`, `check-formatting` clean; Jest still 101 passing and still ignoring `e2e/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSY36HmNZhHTFLwuwyMRVu
