### PR TITLE
test: cover multi-currency expense conversion

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -24,14 +24,22 @@ type Options = {
    * that exercises the dialog itself.
    */
   seedActiveUser: boolean
+
+  /**
+   * Rate returned for every api.frankfurter.dev request, so currency
+   * conversion is deterministic and offline. Null (the default) aborts the
+   * request instead, which is what every non-currency spec wants.
+   */
+  exchangeRate: number | null
 }
 
 export const test = base.extend<Options>({
   seedActiveUser: [true, { option: true }],
+  exchangeRate: [null, { option: true }],
 
   // The second argument is Playwright's `use` callback, renamed because
   // eslint-plugin-react-hooks would otherwise read `use(...)` as React's hook.
-  page: async ({ page, baseURL, seedActiveUser }, runTest) => {
+  page: async ({ page, baseURL, seedActiveUser, exchangeRate }, runTest) => {
     if (baseURL) {
       await page
         .context()
@@ -50,10 +58,32 @@ export const test = base.extend<Options>({
       })
     }
 
-    // The suite must never depend on a third-party API. useCurrencyRate only
-    // calls this when the expense currency differs from the group currency,
-    // which no test does -- this makes that a guarantee rather than a habit.
-    await page.route('https://api.frankfurter.dev/**', (route) => route.abort())
+    // The suite must never depend on a third-party API. useCurrencyRate calls
+    // this only when the expense currency differs from the group currency.
+    await page.route('https://api.frankfurter.dev/**', (route) => {
+      if (exchangeRate === null) return route.abort()
+
+      // Request shape: /v1/<YYYY-MM-DD>?base=<CODE>. The hook turns the
+      // response into a RangeError unless `date` echoes the requested date
+      // exactly, so mirror it back rather than inventing one.
+      const url = new URL(route.request().url())
+      const date = url.pathname.split('/').pop() ?? ''
+      const base = url.searchParams.get('base') ?? ''
+
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          base,
+          date,
+          rates: { USD: exchangeRate, EUR: exchangeRate, GBP: exchangeRate },
+        }),
+      })
+    })
+
+    // Currency and category pickers render flag images from a CDN. Nothing is
+    // asserted on them and they only add latency, so keep the run hermetic.
+    await page.route('https://flagcdn.com/**', (route) => route.abort())
 
     await runTest(page)
   },

--- a/e2e/multi-currency.spec.ts
+++ b/e2e/multi-currency.spec.ts
@@ -1,0 +1,153 @@
+import {
+  createGroup,
+  expectBalance,
+  expenseCard,
+  EXPENSES_URL,
+  openExpense,
+  openTab,
+  uniqueSuffix,
+} from './app'
+import { expect, test } from './fixtures'
+import { fieldByLabel, fillStable, money, selectRadixOption } from './ui'
+
+// Groups default to USD, so picking EUR for an expense forces a conversion.
+// The rate is mocked, so 80 EUR is always exactly 100 USD.
+test.use({ exchangeRate: 1.25 })
+
+const PARTICIPANTS = ['Alice', 'Bob']
+
+type Page = import('@playwright/test').Page
+
+async function openExpenseForm(page: Page, id: string) {
+  await page.goto(`/groups/${id}/expenses/create`)
+  await expect(
+    page.getByRole('button', { name: 'Create', exact: true }),
+  ).toBeVisible({ timeout: 30_000 })
+}
+
+/**
+ * Types the foreign amount and blurs it.
+ *
+ * The blur is load-bearing: expense-form.tsx only recomputes the group-currency
+ * amount once `getFieldState('originalAmount').isTouched` is true, and
+ * react-hook-form flips that on blur. fill() alone leaves the amount at 0.
+ */
+async function setOriginalAmount(page: Page, value: string) {
+  const input = page.locator('input[name="originalAmount"]')
+  await fillStable(input, value)
+  await input.blur()
+}
+
+test('converts a foreign-currency expense into the group currency', async ({
+  page,
+}) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Currency ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await openExpenseForm(page, groupId)
+
+  // While the expense is in the group's own currency there is nothing to
+  // convert, and the conversion fields are present but hidden.
+  await expect(page.locator('input[name="originalAmount"]')).toBeHidden()
+
+  await fillStable(page.locator('input[name="title"]'), 'Paris hotel')
+  await selectRadixOption(
+    page,
+    fieldByLabel(page, 'Currency of expense').getByRole('combobox'),
+    /Euro \(EUR\)/,
+  )
+
+  await expect(page.locator('input[name="originalAmount"]')).toBeVisible()
+
+  // Typing the foreign amount drives the group-currency amount: 80 x 1.25.
+  await setOriginalAmount(page, '80')
+  await expect(page.locator('input[name="amount"]')).toHaveValue('100')
+
+  // The fetched rate is surfaced to the user (with non-breaking spaces).
+  await expect(page.getByText(/EUR\s*1\s*=\s*USD\s*1\.25/)).toBeVisible()
+
+  await selectRadixOption(page, page.getByTestId('paid-by'), 'Alice')
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await page.waitForURL(EXPENSES_URL, { timeout: 30_000 })
+
+  // The list and the balances are all in the group currency.
+  await expect(expenseCard(page, 'Paris hotel')).toContainText(money(100))
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 50)
+  await expectBalance(page, 'Bob', -50)
+
+  // The original amount and currency survive the round trip.
+  await openTab(page, 'Expenses')
+  await openExpense(page, 'Paris hotel')
+  await expect(page.locator('input[name="originalAmount"]')).toHaveValue(/^80/)
+  await expect(
+    fieldByLabel(page, 'Currency of expense').getByRole('combobox'),
+  ).toContainText('EUR')
+  await expect(page.locator('input[name="amount"]')).toHaveValue(/^100/)
+})
+
+test('lets a custom rate override the fetched one', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E CustomRate ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await openExpenseForm(page, groupId)
+
+  await fillStable(page.locator('input[name="title"]'), 'Berlin train')
+  await selectRadixOption(
+    page,
+    fieldByLabel(page, 'Currency of expense').getByRole('combobox'),
+    /Euro \(EUR\)/,
+  )
+  await setOriginalAmount(page, '80')
+  await expect(page.locator('input[name="amount"]')).toHaveValue('100')
+
+  // Opening the custom-rate collapsible stops the API rate being applied.
+  await page.getByRole('button', { name: 'Use custom rate' }).click()
+  await fillStable(page.locator('input[name="conversionRate"]'), '2')
+  await expect(page.locator('input[name="amount"]')).toHaveValue('160')
+
+  await selectRadixOption(page, page.getByTestId('paid-by'), 'Alice')
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await page.waitForURL(EXPENSES_URL, { timeout: 30_000 })
+
+  await expect(expenseCard(page, 'Berlin train')).toContainText(money(160))
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 80)
+  await expectBalance(page, 'Bob', -80)
+})
+
+test('exports the original currency and rate to CSV', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E CurrencyExport ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await openExpenseForm(page, groupId)
+  await fillStable(page.locator('input[name="title"]'), 'Rome dinner')
+  await selectRadixOption(
+    page,
+    fieldByLabel(page, 'Currency of expense').getByRole('combobox'),
+    /Euro \(EUR\)/,
+  )
+  await setOriginalAmount(page, '80')
+  await expect(page.locator('input[name="amount"]')).toHaveValue('100')
+  await selectRadixOption(page, page.getByTestId('paid-by'), 'Alice')
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await page.waitForURL(EXPENSES_URL, { timeout: 30_000 })
+
+  const response = await page.request.get(
+    `/groups/${groupId}/expenses/export/csv`,
+  )
+  expect(response.status()).toBe(200)
+
+  const csv = await response.text()
+  expect(csv).toContain('Rome dinner')
+  // Original cost, original currency and conversion rate are dedicated
+  // columns, and are only populated for converted expenses.
+  expect(csv).toContain('EUR')
+  expect(csv).toContain('1.25')
+})


### PR DESCRIPTION
Stacked on #578 — **base branch is `e2e-extended-coverage`.** Review #577 → #578 first; this diff is 2 files.

Covers the currency-conversion path, the last significant untested feature reachable with the current image. Full suite is now **26 tests in ~15s**.

## Mocking the rate

The fixture gains an `exchangeRate` option: `null` (the default) keeps aborting `api.frankfurter.dev` exactly as before, and a number fulfills the request instead. Specs opt in with `test.use({ exchangeRate: 1.25 })`.

Two details that matter:

- **The mock echoes the requested date back.** `useCurrencyRate` converts the response into a `RangeError` whenever `data.date` differs from the date it asked for (the real API does this for future dates). A mock returning a fixed date would exercise the error path instead of the happy one.
- **The fixed rate makes the assertions exact.** 80 EUR × 1.25 = exactly 100 USD. A real API response (~1.08) could not satisfy these assertions, so the tests cannot silently start depending on the network — if the route stopped intercepting, they'd fail rather than pass with different numbers.

## What's covered

| Test | Asserts |
| --- | --- |
| `converts a foreign-currency expense…` | Conversion fields stay hidden while the expense is in the group currency; picking EUR reveals them; the foreign amount drives the group-currency amount; the fetched rate is displayed; original amount + currency survive a round trip through the edit form; balances are in the group currency |
| `lets a custom rate override the fetched one` | The "Use custom rate" collapsible overrides the API rate and recomputes the amount |
| `exports the original currency and rate to CSV` | The dedicated *Original cost* / *Original currency* / *Conversion rate* columns are populated |

## A trap worth recording

`expense-form.tsx` only recomputes the converted amount once `getFieldState('originalAmount').isTouched` is true, and react-hook-form flips that **on blur**. Playwright's `fill()` doesn't blur, so the amount silently stayed at `0` and all three tests failed identically until the helper blurred explicitly. The helper carries a comment saying the blur is load-bearing, so nobody "tidies" it away.

This is the only place in the suite where a blur is required — everywhere else `fillStable` is sufficient.

## Also

Blocks `flagcdn.com`, which the currency picker uses for flag images. Nothing asserts on them and they only add latency, so the run stays hermetic.

## Verification

26/26 pass against the Dockerized stack; the new spec additionally run with `--repeat-each=3` (9/9, no flakes). `check-types`, `lint` and `check-formatting` clean.

## Still not covered

Documents / receipt extraction / category extraction remain structurally untestable against this image: `scripts/build.env` bakes the `NEXT_PUBLIC_ENABLE_*` flags to `false`, and being `NEXT_PUBLIC_` they are inlined into the bundle at build time rather than read at container start. Covering them needs a second image built with different args plus mocked OpenAI/S3 — happy to do it if you want that complexity, but it's a bigger change than the rest of this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSY36HmNZhHTFLwuwyMRVu
