### PR TITLE
[DO NOT MERGE] ci: temporary pull_request trigger to run E2E on this stack

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,22 @@ on:
   push:
     tags: ['*']
 
+  # ---------------------------------------------------------------------------
+  # TEMPORARY - DO NOT MERGE THIS TRIGGER.
+  #
+  # workflow_dispatch only works once the workflow file is on the default
+  # branch, and this stack is not merged yet, so there is otherwise no way to
+  # see this workflow run on a pull request. For same-repo PRs GitHub uses the
+  # workflow file from the PR's head branch, so adding this here makes it run.
+  #
+  # Deliberately unfiltered: the stack targets non-main base branches, so
+  # `branches: ['main']` would never fire.
+  #
+  # Remove this trigger (and the branch carrying it) once the stack is merged
+  # and dispatch works. The agreed policy is dispatch + release tags only.
+  # ---------------------------------------------------------------------------
+  pull_request:
+
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
**Do not merge.** This branch exists only to prove the E2E workflow is green in CI. Stacked on #580, so it carries every commit in the stack (#577 → #578 → #580) and its run validates all 26 tests.

## Why this is needed

`workflow_dispatch` only becomes available once the workflow file is on the **default branch**. `origin/main` currently has just `ci.yml` and `cd.yml`, so `E2E` doesn't appear in `gh workflow list` and there is no "Run workflow" button to press.

For same-repo pull requests GitHub uses the workflow file from the PR's **head branch**, so adding a `pull_request` trigger here makes it run without anything being merged first.

The trigger is deliberately **unfiltered**. `branches: ['main']` would never fire, because this stack targets non-main base branches.

## Why not just push a tag

`cd.yml` runs on `push: tags: ['*']`, and its `merge` job tags the built image **`:latest`** on ghcr.io:

```
docker buildx imagetools create \
  --tag "${REGISTRY}/${REPO}:${{ github.ref_name }}" \
  --tag "${REGISTRY}/${REPO}:latest" ...
```

So a throwaway tag on a feature branch would publish unreviewed code to every user pulling `spliit:latest`. Not an option.

## What to do with this

Once #577 lands on main, `workflow_dispatch` works and this branch becomes unnecessary:

```sh
gh workflow run e2e.yml --ref e2e-multi-currency
```

Then close this PR and delete the branch. The agreed policy stays **dispatch + release tags only** — no PR gating.

The only change is the trigger block in `.github/workflows/e2e.yml`, marked with a `TEMPORARY - DO NOT MERGE` comment so it can't be mistaken for intended config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSY36HmNZhHTFLwuwyMRVu
