### PR TITLE
feat: global balance

### DIFF
--- a/e2e/global-balance.spec.ts
+++ b/e2e/global-balance.spec.ts
@@ -1,0 +1,94 @@
+import { addExpense, createGroup, setActiveUser, uniqueSuffix } from './app'
+import { expect, test } from './fixtures'
+import { cardByTitle, money } from './ui'
+
+const CARD_TITLE = 'Your total balance'
+
+/**
+ * The card reads `<groupId>-activeUser` for every group in the recent list,
+ * which lives in localStorage -- so each test's browser context sees only the
+ * groups that test visited, even though the whole suite shares one database.
+ */
+
+test('sums balances across groups once you are identified in them', async ({
+  page,
+}) => {
+  const first = await createGroup(page, {
+    name: `E2E Global A ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob'],
+  })
+  // Alice pays 100 split evenly, so she is owed 50.
+  await addExpense(page, first, {
+    title: 'Hotel',
+    amount: '100',
+    paidBy: 'Alice',
+  })
+
+  const second = await createGroup(page, {
+    name: `E2E Global B ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob'],
+  })
+  // Alice pays 60 split evenly, so she is owed 30.
+  await addExpense(page, second, {
+    title: 'Train',
+    amount: '60',
+    paidBy: 'Alice',
+  })
+
+  await setActiveUser(page, first, 'Alice')
+  await setActiveUser(page, second, 'Alice')
+
+  await page.goto('/groups')
+
+  const card = cardByTitle(page, CARD_TITLE)
+  await expect(card).toBeVisible()
+  await expect(card).toContainText('You are owed')
+  await expect(card).toContainText(money(80))
+})
+
+test('reports being settled up when every balance is zero', async ({
+  page,
+}) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Global Settled ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob'],
+  })
+  // Alice pays and is the only participant charged, so nobody owes anybody.
+  await addExpense(page, groupId, {
+    title: 'Coffee',
+    amount: '10',
+    paidBy: 'Alice',
+    paidFor: ['Alice'],
+  })
+
+  await setActiveUser(page, groupId, 'Alice')
+
+  await page.goto('/groups')
+
+  const card = cardByTitle(page, CARD_TITLE)
+  await expect(card).toBeVisible()
+  await expect(card).toContainText('You are all settled up across your groups.')
+})
+
+test('stays hidden until you say who you are', async ({ page }) => {
+  // A visited group with no active user: there is nobody to aggregate for, so
+  // the card must not appear at all rather than render an empty shell.
+  const groupId = await createGroup(page, {
+    name: `E2E Global Anonymous ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob'],
+  })
+  await addExpense(page, groupId, {
+    title: 'Lunch',
+    amount: '40',
+    paidBy: 'Alice',
+  })
+
+  await page.goto('/groups')
+
+  await expect(
+    page.getByRole('link', { name: /E2E Global Anonymous/ }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole('heading', { name: CARD_TITLE, exact: true }),
+  ).toHaveCount(0)
+})

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -57,6 +57,13 @@
       "create": "Create one",
       "orAsk": "or ask a friend to send you the link to an existing one."
     },
+    "GlobalBalance": {
+      "title": "Your total balance",
+      "description": "Your combined balance across all your groups.",
+      "owedToYou": "You are owed",
+      "youOwe": "You owe",
+      "settledUp": "You are all settled up across your groups."
+    },
     "recent": "Recent groups",
     "starred": "Starred groups",
     "archived": "Archived groups",

--- a/src/app/groups/global-balance-card.tsx
+++ b/src/app/groups/global-balance-card.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { RecentGroups } from '@/app/groups/recent-groups-helpers'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Currency } from '@/lib/currency'
+import { cn, formatCurrency, getCurrencyFromGroup } from '@/lib/utils'
+import { trpc } from '@/trpc/client'
+import { useLocale, useTranslations } from 'next-intl'
+import { useEffect, useState } from 'react'
+
+type CurrencyBalance = {
+  currency: Currency
+  amount: number
+}
+
+export function GlobalBalanceCard({ groups }: { groups: RecentGroups }) {
+  const [activeUserGroups, setActiveUserGroups] = useState<
+    { groupId: string; participantId: string }[] | null
+  >(null)
+
+  useEffect(() => {
+    setActiveUserGroups(
+      groups.flatMap((group) => {
+        const participantId = localStorage.getItem(`${group.id}-activeUser`)
+        if (!participantId || participantId === 'None') return []
+        return [{ groupId: group.id, participantId }]
+      }),
+    )
+  }, [groups])
+
+  // Wait until local storage has been read on the client.
+  if (activeUserGroups === null) return null
+
+  // Nothing to aggregate until the user has told us who they are in a group.
+  if (activeUserGroups.length === 0) return null
+
+  return <GlobalBalanceCard_ activeUserGroups={activeUserGroups} />
+}
+
+function GlobalBalanceCard_({
+  activeUserGroups,
+}: {
+  activeUserGroups: { groupId: string; participantId: string }[]
+}) {
+  const locale = useLocale()
+  const t = useTranslations('Groups.GlobalBalance')
+  const { data, isLoading } = trpc.groups.balances.forUser.useQuery({
+    groups: activeUserGroups,
+  })
+
+  if (isLoading || !data) {
+    return (
+      <Card className="mb-4">
+        <CardHeader>
+          <CardTitle>{t('title')}</CardTitle>
+          <CardDescription>{t('description')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-6 w-40" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // Amounts from different currencies cannot be summed, so we aggregate them
+  // into one bucket per currency.
+  const byCurrency = new Map<string, CurrencyBalance>()
+  for (const balance of data.balances) {
+    const currency = getCurrencyFromGroup(balance)
+    const key = currency.code || `custom:${currency.symbol}`
+    const existing = byCurrency.get(key)
+    if (existing) {
+      existing.amount += balance.amount
+    } else {
+      byCurrency.set(key, { currency, amount: balance.amount })
+    }
+  }
+
+  const currencyBalances = [...byCurrency.values()]
+  const isSettledUp = currencyBalances.every(({ amount }) => amount === 0)
+
+  return (
+    <Card className="mb-4">
+      <CardHeader>
+        <CardTitle>{t('title')}</CardTitle>
+        <CardDescription>{t('description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isSettledUp ? (
+          <p className="text-muted-foreground text-sm">{t('settledUp')}</p>
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {currencyBalances.map(({ currency, amount }) => {
+              if (amount === 0) return null
+              const formatted = formatCurrency(
+                currency,
+                Math.abs(amount),
+                locale,
+              )
+              return (
+                <li
+                  key={currency.code || currency.symbol}
+                  className="flex justify-between items-baseline gap-2 text-sm"
+                >
+                  <span className="text-muted-foreground">
+                    {amount > 0 ? t('owedToYou') : t('youOwe')}
+                  </span>
+                  <span
+                    className={cn(
+                      'font-semibold tabular-nums',
+                      amount > 0 ? 'text-green-600' : 'text-red-600',
+                    )}
+                  >
+                    {formatted}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/groups/recent-group-list.tsx
+++ b/src/app/groups/recent-group-list.tsx
@@ -14,6 +14,7 @@ import { Loader2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { PropsWithChildren, useEffect, useState } from 'react'
+import { GlobalBalanceCard } from './global-balance-card'
 import { RecentGroupListCard } from './recent-group-list-card'
 
 export type RecentGroupsState =
@@ -142,6 +143,8 @@ function RecentGroupList_({
 
   return (
     <GroupsPage reload={refreshGroupsFromStorage}>
+      <GlobalBalanceCard groups={groups} />
+
       {starredGroupInfo.length > 0 && (
         <>
           <h2 className="mb-2">{t('starred')}</h2>

--- a/src/trpc/routers/groups/balances/forUser.procedure.ts
+++ b/src/trpc/routers/groups/balances/forUser.procedure.ts
@@ -1,0 +1,52 @@
+import { getGroup, getGroupExpenses } from '@/lib/api'
+import { getBalances } from '@/lib/balances'
+import { baseProcedure } from '@/trpc/init'
+import { z } from 'zod'
+
+/**
+ * Aggregates a user's net balance across several groups at once.
+ *
+ * The active user is tracked client-side (per group, in local storage), so the
+ * client passes the list of `{ groupId, participantId }` pairs it knows about
+ * and receives the participant's net balance in each group, together with the
+ * group's currency so the client can group amounts by currency.
+ */
+export const forUserBalancesProcedure = baseProcedure
+  .input(
+    z.object({
+      groups: z.array(
+        z.object({
+          groupId: z.string().min(1),
+          participantId: z.string().min(1),
+        }),
+      ),
+    }),
+  )
+  .query(async ({ input: { groups } }) => {
+    const balances = await Promise.all(
+      groups.map(async ({ groupId, participantId }) => {
+        const group = await getGroup(groupId)
+        if (!group) return null
+
+        const participant = group.participants.find(
+          (p) => p.id === participantId,
+        )
+        if (!participant) return null
+
+        const expenses = await getGroupExpenses(groupId)
+        const amount = getBalances(expenses)[participantId]?.total ?? 0
+
+        return {
+          groupId,
+          groupName: group.name,
+          currency: group.currency,
+          currencyCode: group.currencyCode,
+          participantId,
+          participantName: participant.name,
+          amount,
+        }
+      }),
+    )
+
+    return { balances: balances.filter((balance) => balance !== null) }
+  })

--- a/src/trpc/routers/groups/balances/index.ts
+++ b/src/trpc/routers/groups/balances/index.ts
@@ -1,6 +1,8 @@
 import { createTRPCRouter } from '@/trpc/init'
+import { forUserBalancesProcedure } from '@/trpc/routers/groups/balances/forUser.procedure'
 import { listGroupBalancesProcedure } from '@/trpc/routers/groups/balances/list.procedure'
 
 export const groupBalancesRouter = createTRPCRouter({
   list: listGroupBalancesProcedure,
+  forUser: forUserBalancesProcedure,
 })


### PR DESCRIPTION
# feat: global balance summary across all groups

Implements #509. Part of the series in #553. Two commits, 289 lines, no
changes to existing behaviour.

## What it does

Adds a card at the top of "My groups" showing your aggregated net balance
across the groups you've visited.

The active user is tracked client-side, per group, in local storage — the
server has no idea who "you" are. So the client collects the
`{ groupId, participantId }` pairs it can see and a new
`groups.balances.forUser` procedure returns each group's net balance for that
participant, plus the group's currency.

Two decisions worth surfacing:

- **Amounts are bucketed by currency, not summed.** A €20 credit and a $20 debt
  are not a zero balance. Each currency gets its own line.
- **The card renders `null` until you've identified yourself in at least one
  group**, rather than showing an empty shell above the group list. It also
  returns `null` while local storage is still being read, so it never flashes
  the wrong state during hydration.

## It needed no adaptation to land here

This has been running in my fork for a while, and I expected to have to rework
it. I didn't: `getCurrencyFromGroup`, the `Currency` type, `formatCurrency`'s
`(currency, amount, locale)` signature and `Group.currencyCode` all already
exist on `main` in the shape the card wants. The port is the files as-is.

English strings only, so Weblate picks the keys up through the normal
round-trip.

## E2E coverage — and I ran it

The second commit adds `e2e/global-balance.spec.ts` against the suite you
landed in #577: the cross-group sum, the settled-up wording, and the card
staying absent while no active user is set.

I did the mutation check you describe in #577's body rather than trusting a
green run. Flipping the expected total from `$80.00` to `$81.00` fails with:

```
Expected substring: "$81.00"
Received string:    "Your total balanceYour combined balance across all
                     your groups.You are owed$80.00"
```

So the assertion is reading the real rendered card, and the 50 + 30 aggregation
across two groups is genuinely computed by the app.

**Full suite: 29/29 passing** on this branch — your 26 plus these 3.

One thing I checked specifically, because it was the obvious way for this PR to
break your suite: `group-management.spec.ts` locates groups with
`getByRole('link', { name })`, which is strict-mode. A card that linked to each
group would make that ambiguous and fail. This one emits no links — it
aggregates per currency — so there's nothing to collide. And under your
fixtures it renders `null` throughout the existing specs anyway, since they seed
`newGroup-activeUser` to `'None'` and the card filters that out.

It's a separate commit so you can drop it if you'd rather own the E2E specs
yourself.

## Verification

Against `c3d8d3e`, Node 24 / npm 11: `npm ci --ignore-scripts`,
`npx prisma generate`, `check-types`, `lint` (16 warnings / 0 errors, all
pre-existing), `check-formatting`, `npm test` (7 suites / 101 tests), and a full
`npm run build`.

E2E ran against a real Postgres 16 and the built app rather than the compose
stack — no Docker daemon where I'm working — driven through `E2E_BASE_URL`. That
exercises the same app and the same specs; what it does *not* exercise is the
image build and `scripts/e2e.sh` itself, so if anything here is going to
misbehave in CI that's where it would show up.
