### PR TITLE
Vouch for the iOS app so group links open it

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ The application has a health check endpoint that can be used to check if the app
 - `GET /api/health/readiness` or `GET /api/health` - Check if the application is ready to serve requests, including database connectivity.
 - `GET /api/health/liveness` - Check if the application is running, but not necessarily ready to serve requests.
 
+## iOS app links
+
+Every instance serves `GET /.well-known/apple-app-site-association`, the file iOS reads to decide whether the site is allowed to hand `/groups/<id>` links to the [Spliit iOS app](https://github.com/spliit-app/spliit-ios) instead of opening them in Safari.
+
+Nothing to configure: it names the official app, so a group link from your own instance opens in the app for anyone who has it installed. Two requirements come from iOS rather than from Spliit — the file has to be reachable over https with no redirect, and served as `application/json`. Both are worth checking if you put a proxy in front of the app, because iOS ignores the file without reporting why. An instance served over plain http can't use these links at all; the app's `app.spliit.spliitmobile://groups/<id>` scheme still opens groups there.
+
 ## Opt-in features
 
 ### Expense documents

--- a/e2e/universal-links.spec.ts
+++ b/e2e/universal-links.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from './fixtures'
+
+/**
+ * The unit test next to the route handler proves the payload; this proves the
+ * server actually answers at that path. `.well-known` is a dot-directory in
+ * `src/app`, so whether it becomes a route at all is up to Next's file-system
+ * router — a build that quietly stopped emitting it would leave the unit test
+ * green and Universal Links dead.
+ */
+test('serves the Apple app site association at the well-known path', async ({
+  request,
+}) => {
+  // iOS refuses to follow redirects for this file, so a redirect is a failure
+  // rather than something to chase.
+  const response = await request.get(
+    '/.well-known/apple-app-site-association',
+    { maxRedirects: 0 },
+  )
+
+  expect(response.status()).toBe(200)
+  // Served without an extension: a host that guesses the type from the name
+  // hands back octet-stream and iOS ignores the file without saying why.
+  expect(response.headers()['content-type']).toContain('application/json')
+
+  const association = await response.json()
+  expect(association.applinks.details[0].appIDs).toContain(
+    'VKY5EKKU47.app.spliit.spliitmobile',
+  )
+})

--- a/src/app/.well-known/apple-app-site-association/route.test.ts
+++ b/src/app/.well-known/apple-app-site-association/route.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from './route'
+
+/**
+ * iOS never reports why it rejected an association file, so the failures worth
+ * catching here are the silent ones: a wrong content type, a body that isn’t
+ * JSON, or an app ID missing its team prefix.
+ */
+describe('apple-app-site-association', () => {
+  it('is served as JSON on a plain 200', async () => {
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('application/json')
+    await expect(response.json()).resolves.toBeDefined()
+  })
+
+  it('names the iOS app, team prefix included', async () => {
+    const { applinks } = await (await GET()).json()
+
+    const appIDs = applinks.details.flatMap(
+      (detail: { appIDs: string[] }) => detail.appIDs,
+    )
+    expect(appIDs).toContain('VKY5EKKU47.app.spliit.spliitmobile')
+    for (const appID of appIDs) {
+      expect(appID).toMatch(/^[A-Z0-9]{10}\.[a-z0-9.-]+$/)
+    }
+  })
+
+  it('claims group links and nothing else', async () => {
+    const { applinks } = await (await GET()).json()
+
+    const paths = applinks.details.flatMap(
+      (detail: { components: { '/': string }[] }) =>
+        detail.components.map((component) => component['/']),
+    )
+    expect(paths).toEqual(['/groups/*'])
+  })
+})

--- a/src/app/.well-known/apple-app-site-association/route.ts
+++ b/src/app/.well-known/apple-app-site-association/route.ts
@@ -1,0 +1,43 @@
+/**
+ * The file iOS reads to decide whether this instance vouches for the Spliit iOS
+ * app, letting `/groups/<id>` links open the app instead of Safari (“Universal
+ * Links”). Without it the app’s entitlement is inert and links stay in the
+ * browser.
+ *
+ * Every instance serves it, not only spliit.app: the app follows links to
+ * whichever instance it is pointed at, and iOS only hands a link over if that
+ * host names the app. The IDs below belong to the official app — team
+ * `VKY5EKKU47`, bundle `app.spliit.spliitmobile`.
+ *
+ * A Route Handler rather than a file in `public/`, because iOS silently ignores
+ * the association unless it arrives as `application/json` on a plain 200, and
+ * the extensionless name gives static hosts nothing to guess the type from.
+ *
+ * See https://github.com/spliit-app/spliit-ios/blob/main/Docs/universal-links.md
+ */
+const appleAppSiteAssociation = {
+  applinks: {
+    details: [
+      {
+        appIDs: ['VKY5EKKU47.app.spliit.spliitmobile'],
+        components: [
+          {
+            '/': '/groups/*',
+            comment: 'Opens a group in the iOS app',
+          },
+        ],
+      },
+    ],
+  },
+}
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  return new Response(JSON.stringify(appleAppSiteAssociation), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  })
+}


### PR DESCRIPTION
The web half of Universal Links. [spliit-app/spliit-ios#18](https://github.com/spliit-app/spliit-ios/pull/18) shipped the entitlement and the link parser; both are inert until the site names the app, and that naming is a single file which lives here.

```
GET /.well-known/apple-app-site-association
```

**Every instance serves it, not only spliit.app.** The app follows links to whichever instance it is pointed at, and iOS only hands a link over if that host vouches for the app — so a self-hosted instance gets working group links with nothing to configure.

## Why a Route Handler and not `public/`

iOS ignores the association without explanation unless it arrives as `application/json` on a plain 200, and the extensionless name gives a static host nothing to guess the type from — `application/octet-stream` is the usual result. A handler states the type outright. `dynamic = 'force-static'` keeps it prerendered at build time (`○ /.well-known/apple-app-site-association` in the build output).

The claim is `/groups/*`, which covers the sub-pages too. That is deliberate rather than sloppy: the app's parser reads the segment after `groups`, so a link to a group's balances opens that group instead of the app shrugging at a URL it was handed.

## Two tests, because they fail differently

- **Unit** — the payload and the content type, the parts iOS rejects silently.
- **Playwright** — whether the server answers at that path *at all*. `.well-known` is a dot-directory under `src/app`, so that is Next's file-system router's decision, not ours; a build that quietly stopped emitting the route would leave the unit test green and Universal Links dead.

## Verification

`next build` lists the route as static; against `next start` it returns `200`, `content-type: application/json`, no redirect. Full jest suite 117 passed; `tsc`, eslint and prettier clean.

The E2E workflow is dispatch/tag-triggered rather than automatic on PRs, so it was [dispatched on this branch](https://github.com/spliit-app/spliit/actions/runs/31955324046) to exercise the new spec against the Docker image — the artifact that actually ships. `.dockerignore` has no dot-glob, so the directory is in the build context.

## Still needed, outside this repo

Associated Domains has to be enabled for the App ID in the Apple developer portal — a signed device build fails until it exists (simulator builds and CI are unaffected). Until this PR is deployed *and* that capability is added, an https group link opens Safari exactly as it does today. Nothing regresses either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAPVbmCRTBMm7u8LDMyQPR
