### PR TITLE
feat: stats date range and expense drill-downs

### DIFF
--- a/e2e/stats-breakdown.spec.ts
+++ b/e2e/stats-breakdown.spec.ts
@@ -99,3 +99,107 @@ test('restricts the stats to the selected period', async ({ page }) => {
   await expect(totals).toContainText(money(20))
   await expect(totals).not.toContainText(money(70))
 })
+
+test('drills down from a category into its expenses', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Drilldown ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await addExpense(page, groupId, {
+    title: 'Weekly shop',
+    amount: '40',
+    paidBy: 'Alice',
+    category: 'Groceries',
+  })
+  await addExpense(page, groupId, {
+    title: 'Cab home',
+    amount: '25',
+    paidBy: 'Bob',
+    category: 'Taxi',
+  })
+
+  await openTab(page, 'Stats')
+
+  await page
+    .getByRole('button', { name: 'Show expenses for Groceries' })
+    .click()
+
+  // The dialog lists the category's own expenses and nothing else.
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toContainText('Weekly shop')
+  await expect(dialog).toContainText(money(40))
+  await expect(dialog).not.toContainText('Cab home')
+})
+
+test('drills down from a month into its expenses', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Month Drilldown ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await addExpense(page, groupId, {
+    title: 'This month',
+    amount: '35',
+    paidBy: 'Alice',
+  })
+  await addExpense(page, groupId, {
+    title: 'Long ago',
+    amount: '15',
+    paidBy: 'Bob',
+    date: '2020-03-10',
+  })
+
+  await openTab(page, 'Stats')
+
+  await page.getByRole('button', { name: 'Show expenses for Mar 2020' }).click()
+
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toContainText('Long ago')
+  await expect(dialog).toContainText(money(15))
+  await expect(dialog).not.toContainText('This month')
+})
+
+test('scopes the stats to a custom date range', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E Custom Range ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await addExpense(page, groupId, {
+    title: 'In range',
+    amount: '80',
+    paidBy: 'Alice',
+    date: '2021-06-15',
+  })
+  await addExpense(page, groupId, {
+    title: 'Out of range',
+    amount: '45',
+    paidBy: 'Bob',
+    date: '2022-06-15',
+  })
+
+  await openTab(page, 'Stats')
+
+  const totals = cardByTitle(page, 'Totals')
+  await expect(totals).toContainText(money(125))
+
+  await selectRadixOption(
+    page,
+    page.getByRole('combobox').first(),
+    'Custom range',
+  )
+  // Each date field is an <input> inside a <label> that also carries an
+  // aria-label, so getByLabel matches both nodes. Scope to the input.
+  const dateField = (label: string) =>
+    page
+      .locator('label')
+      .filter({ hasText: new RegExp(`^${label}$`) })
+      .locator('input[type="date"]')
+
+  await dateField('From').fill('2021-01-01')
+  await dateField('To').fill('2021-12-31')
+
+  await expect(totals).toContainText(money(80))
+  await expect(totals).not.toContainText(money(125))
+})

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -325,7 +325,10 @@
       "all": "All time",
       "thisMonth": "This month",
       "last30": "Last 30 days",
-      "thisYear": "This year"
+      "thisYear": "This year",
+      "custom": "Custom range",
+      "from": "From",
+      "to": "To"
     },
     "Totals": {
       "title": "Totals",
@@ -347,8 +350,11 @@
     },
     "OverTime": {
       "title": "Spending over time",
-      "description": "Total group spending per month.",
-      "empty": "There are no expenses yet."
+      "description": "Total group spending per month. Select a month to see its expenses.",
+      "empty": "There are no expenses yet.",
+      "showExpenses": "Show expenses for {month}",
+      "detailsDescription": "Expenses in this month for the selected period.",
+      "detailsEmpty": "There are no expenses in this month."
     },
     "ByParticipant": {
       "title": "Spending by participant",
@@ -361,8 +367,11 @@
     },
     "ByCategory": {
       "title": "Spending by category",
-      "description": "Total amount spent in each category.",
-      "empty": "There are no expenses yet."
+      "description": "Total amount spent in each category. Select a category to see its expenses.",
+      "empty": "There are no expenses yet.",
+      "showExpenses": "Show expenses for {category}",
+      "detailsDescription": "Expenses in this category for the selected period.",
+      "detailsEmpty": "There are no expenses in this category."
     },
     "Recurring": {
       "title": "Recurring expenses",

--- a/src/app/groups/[groupId]/stats/category-breakdown.tsx
+++ b/src/app/groups/[groupId]/stats/category-breakdown.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { CategoryIcon } from '@/app/groups/[groupId]/expenses/category-icon'
+import { ExpensesDialog } from '@/app/groups/[groupId]/stats/expenses-dialog'
 import {
   StatBar,
   StatBarListSkeleton,
@@ -14,14 +15,26 @@ import {
 import { Currency } from '@/lib/currency'
 import { CategorySpending } from '@/lib/totals'
 import { formatCurrency } from '@/lib/utils'
+import { trpc } from '@/trpc/client'
+import { ChevronRight } from 'lucide-react'
 import { useLocale, useTranslations } from 'next-intl'
+import { useState } from 'react'
 
 type Props = {
+  groupId: string
   categories?: CategorySpending[]
   currency?: Currency
+  from?: string
+  to?: string
 }
 
-export function CategoryBreakdown({ categories, currency }: Props) {
+export function CategoryBreakdown({
+  groupId,
+  categories,
+  currency,
+  from,
+  to,
+}: Props) {
   const t = useTranslations('Stats.ByCategory')
 
   return (
@@ -36,7 +49,13 @@ export function CategoryBreakdown({ categories, currency }: Props) {
         ) : categories.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t('empty')}</p>
         ) : (
-          <CategoryBars categories={categories} currency={currency} />
+          <CategoryBars
+            groupId={groupId}
+            categories={categories}
+            currency={currency}
+            from={from}
+            to={to}
+          />
         )}
       </CardContent>
     </Card>
@@ -44,49 +63,107 @@ export function CategoryBreakdown({ categories, currency }: Props) {
 }
 
 function CategoryBars({
+  groupId,
   categories,
   currency,
+  from,
+  to,
 }: {
+  groupId: string
   categories: CategorySpending[]
   currency: Currency
+  from?: string
+  to?: string
 }) {
   const locale = useLocale()
   const t = useTranslations('Categories')
+  const tByCategory = useTranslations('Stats.ByCategory')
+  const [selected, setSelected] = useState<CategorySpending | null>(null)
   const total = categories.reduce((sum, category) => sum + category.total, 0)
   const max = Math.max(...categories.map((category) => category.total))
 
+  const { data, isLoading } = trpc.groups.stats.categoryExpenses.useQuery(
+    {
+      groupId,
+      categoryId: selected?.categoryId ?? 0,
+      from,
+      to,
+    },
+    { enabled: selected !== null },
+  )
+
   return (
-    <div className="flex flex-col gap-4">
-      {categories.map((category, index) => {
-        const share = total > 0 ? Math.round((category.total / total) * 100) : 0
-        return (
-          <div key={category.categoryId} className="flex flex-col gap-1.5">
-            <div className="flex items-center justify-between gap-2 text-sm">
-              <div className="flex min-w-0 items-center gap-2">
-                <CategoryIcon
-                  category={{
-                    id: category.categoryId,
-                    grouping: category.grouping,
-                    name: category.name,
-                  }}
-                  className="h-4 w-4 shrink-0 text-muted-foreground"
-                />
-                <span className="truncate">
-                  {t(`${category.grouping}.${category.name}`)}
-                </span>
+    <>
+      <div className="flex flex-col gap-4">
+        {categories.map((category, index) => {
+          const share =
+            total > 0 ? Math.round((category.total / total) * 100) : 0
+          return (
+            <button
+              key={category.categoryId}
+              type="button"
+              onClick={() => setSelected(category)}
+              className="group -mx-2 flex w-full cursor-pointer flex-col gap-1.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label={tByCategory('showExpenses', {
+                category: t(`${category.grouping}.${category.name}`),
+              })}
+            >
+              <div className="flex items-center justify-between gap-2 text-sm">
+                <div className="flex min-w-0 items-center gap-2">
+                  <CategoryIcon
+                    category={{
+                      id: category.categoryId,
+                      grouping: category.grouping,
+                      name: category.name,
+                    }}
+                    className="h-4 w-4 shrink-0 text-muted-foreground"
+                  />
+                  <span className="truncate">
+                    {t(`${category.grouping}.${category.name}`)}
+                  </span>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <span className="tabular-nums text-muted-foreground">
+                    {`${formatCurrency(currency, category.total, locale)} (${share}%)`}
+                  </span>
+                  <ChevronRight className="h-4 w-4 text-muted-foreground/50 transition-colors group-hover:text-muted-foreground" />
+                </div>
               </div>
-              <span className="shrink-0 tabular-nums text-muted-foreground">
-                {formatCurrency(currency, category.total, locale)} ({share}%)
-              </span>
-            </div>
-            <StatBar
-              value={category.total}
-              max={max}
-              color={`hsl(var(--chart-${(index % 5) + 1}))`}
-            />
-          </div>
-        )
-      })}
-    </div>
+              <StatBar
+                value={category.total}
+                max={max}
+                color={`hsl(var(--chart-${(index % 5) + 1}))`}
+              />
+            </button>
+          )
+        })}
+      </div>
+
+      <ExpensesDialog
+        open={selected !== null}
+        onClose={() => setSelected(null)}
+        groupId={groupId}
+        currency={currency}
+        title={
+          selected && (
+            <>
+              <CategoryIcon
+                category={{
+                  id: selected.categoryId,
+                  grouping: selected.grouping,
+                  name: selected.name,
+                }}
+                className="h-4 w-4 shrink-0 text-muted-foreground"
+              />
+              {t(`${selected.grouping}.${selected.name}`)}
+            </>
+          )
+        }
+        description={tByCategory('detailsDescription')}
+        emptyText={tByCategory('detailsEmpty')}
+        expenses={data?.expenses}
+        isLoading={isLoading}
+      />
+    </>
   )
 }

--- a/src/app/groups/[groupId]/stats/expenses-dialog.tsx
+++ b/src/app/groups/[groupId]/stats/expenses-dialog.tsx
@@ -1,0 +1,102 @@
+'use client'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Currency } from '@/lib/currency'
+import { formatCurrency, formatDateOnly } from '@/lib/utils'
+import { ChevronRight } from 'lucide-react'
+import { useLocale } from 'next-intl'
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+export type DialogExpense = {
+  id: string
+  title: string
+  amount: number
+  expenseDate: Date
+}
+
+type Props = {
+  open: boolean
+  onClose: () => void
+  groupId: string
+  currency: Currency
+  title: ReactNode
+  description: ReactNode
+  emptyText: string
+  expenses?: DialogExpense[]
+  isLoading: boolean
+}
+
+/**
+ * Shared drill-down dialog for the stats cards: lists individual expenses with
+ * a link to each one. The caller owns the data-fetching (which stats slice the
+ * list comes from) and passes the header content; this component only renders
+ * the list, loading and empty states.
+ */
+export function ExpensesDialog({
+  open,
+  onClose,
+  groupId,
+  currency,
+  title,
+  description,
+  emptyText,
+  expenses,
+  isLoading,
+}: Props) {
+  const locale = useLocale()
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className="max-h-[80vh] gap-0 overflow-hidden p-0">
+        <DialogHeader className="space-y-1.5 border-b p-6">
+          <DialogTitle className="flex items-center gap-2">{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="overflow-y-auto">
+          {isLoading || !expenses ? (
+            <div className="flex flex-col gap-3 p-6">
+              {[0, 1, 2].map((index) => (
+                <Skeleton key={index} className="h-5 w-full" />
+              ))}
+            </div>
+          ) : expenses.length === 0 ? (
+            <p className="p-6 text-sm text-muted-foreground">{emptyText}</p>
+          ) : (
+            <ul className="divide-y">
+              {expenses.map((expense) => (
+                <li key={expense.id}>
+                  <Link
+                    href={`/groups/${groupId}/expenses/${expense.id}/edit`}
+                    className="flex items-center justify-between gap-2 px-6 py-3 text-sm hover:bg-accent"
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate">{expense.title}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {formatDateOnly(expense.expenseDate, locale, {
+                          dateStyle: 'medium',
+                        })}
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <span className="font-bold tabular-nums">
+                        {formatCurrency(currency, expense.amount, locale)}
+                      </span>
+                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/groups/[groupId]/stats/page.client.tsx
+++ b/src/app/groups/[groupId]/stats/page.client.tsx
@@ -5,8 +5,9 @@ import { ParticipantSpendingStats } from '@/app/groups/[groupId]/stats/participa
 import { RecurringSpendingStats } from '@/app/groups/[groupId]/stats/recurring-spending'
 import { SpendingOverTime } from '@/app/groups/[groupId]/stats/spending-over-time'
 import {
-  getRangeForPeriod,
+  resolveStatsRange,
   StatsPeriod,
+  StatsRange,
 } from '@/app/groups/[groupId]/stats/stats-range'
 import { StatsRangeSelector } from '@/app/groups/[groupId]/stats/stats-range-selector'
 import { SummaryStats } from '@/app/groups/[groupId]/stats/summary-stats'
@@ -32,7 +33,8 @@ export function TotalsPageClient() {
     activeUser && activeUser !== 'None' ? activeUser : undefined
 
   const [period, setPeriod] = useState<StatsPeriod>('all')
-  const range = getRangeForPeriod(period)
+  const [customRange, setCustomRange] = useState<StatsRange>({})
+  const range = resolveStatsRange(period, customRange)
 
   const { data } = trpc.groups.stats.overview.useQuery({
     groupId,
@@ -45,7 +47,12 @@ export function TotalsPageClient() {
 
   return (
     <>
-      <StatsRangeSelector period={period} onPeriodChange={setPeriod} />
+      <StatsRangeSelector
+        period={period}
+        customRange={customRange}
+        onPeriodChange={setPeriod}
+        onCustomRangeChange={setCustomRange}
+      />
       <SummaryStats summary={data?.summary} currency={currency} />
       <Card className="mb-4">
         <CardHeader>
@@ -61,12 +68,24 @@ export function TotalsPageClient() {
           />
         </CardContent>
       </Card>
-      <SpendingOverTime months={data?.months} currency={currency} />
+      <SpendingOverTime
+        groupId={groupId}
+        months={data?.months}
+        currency={currency}
+        from={range.from}
+        to={range.to}
+      />
       <ParticipantSpendingStats
         participants={data?.participants}
         currency={currency}
       />
-      <CategoryBreakdown categories={data?.categories} currency={currency} />
+      <CategoryBreakdown
+        groupId={groupId}
+        categories={data?.categories}
+        currency={currency}
+        from={range.from}
+        to={range.to}
+      />
       <RecurringSpendingStats recurring={data?.recurring} currency={currency} />
     </>
   )

--- a/src/app/groups/[groupId]/stats/spending-over-time.tsx
+++ b/src/app/groups/[groupId]/stats/spending-over-time.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { ExpensesDialog } from '@/app/groups/[groupId]/stats/expenses-dialog'
 import {
   StatBar,
   StatBarListSkeleton,
@@ -13,14 +14,26 @@ import {
 import { Currency } from '@/lib/currency'
 import { MonthlySpending } from '@/lib/totals'
 import { formatCurrency } from '@/lib/utils'
+import { trpc } from '@/trpc/client'
+import { ChevronRight } from 'lucide-react'
 import { useLocale, useTranslations } from 'next-intl'
+import { useState } from 'react'
 
 type Props = {
+  groupId: string
   months?: MonthlySpending[]
   currency?: Currency
+  from?: string
+  to?: string
 }
 
-export function SpendingOverTime({ months, currency }: Props) {
+export function SpendingOverTime({
+  groupId,
+  months,
+  currency,
+  from,
+  to,
+}: Props) {
   const t = useTranslations('Stats.OverTime')
 
   return (
@@ -35,7 +48,13 @@ export function SpendingOverTime({ months, currency }: Props) {
         ) : months.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t('empty')}</p>
         ) : (
-          <MonthlyBars months={months} currency={currency} />
+          <MonthlyBars
+            groupId={groupId}
+            months={months}
+            currency={currency}
+            from={from}
+            to={to}
+          />
         )}
       </CardContent>
     </Card>
@@ -43,35 +62,84 @@ export function SpendingOverTime({ months, currency }: Props) {
 }
 
 function MonthlyBars({
+  groupId,
   months,
   currency,
+  from,
+  to,
 }: {
+  groupId: string
   months: MonthlySpending[]
   currency: Currency
+  from?: string
+  to?: string
 }) {
   const locale = useLocale()
+  const t = useTranslations('Stats.OverTime')
+  const [selected, setSelected] = useState<string | null>(null)
   const max = Math.max(...months.map((month) => month.total))
   const monthFormat = new Intl.DateTimeFormat(locale, {
     month: 'short',
     year: 'numeric',
     timeZone: 'UTC',
   })
+  const formatMonth = (month: string) =>
+    monthFormat.format(new Date(`${month}-01T00:00:00Z`))
+
+  const { data, isLoading } = trpc.groups.stats.monthExpenses.useQuery(
+    {
+      groupId,
+      month: selected ?? '',
+      from,
+      to,
+    },
+    { enabled: selected !== null },
+  )
 
   return (
-    <div className="flex flex-col gap-4">
-      {months.map((month) => (
-        <div key={month.month} className="flex flex-col gap-1.5">
-          <div className="flex items-center justify-between gap-2 text-sm">
-            <span className="capitalize">
-              {monthFormat.format(new Date(`${month.month}-01T00:00:00Z`))}
-            </span>
-            <span className="shrink-0 tabular-nums text-muted-foreground">
-              {formatCurrency(currency, month.total, locale)}
-            </span>
-          </div>
-          <StatBar value={month.total} max={max} color="hsl(var(--chart-1))" />
-        </div>
-      ))}
-    </div>
+    <>
+      <div className="flex flex-col gap-4">
+        {months.map((month) => (
+          <button
+            key={month.month}
+            type="button"
+            onClick={() => setSelected(month.month)}
+            className="group -mx-2 flex w-full cursor-pointer flex-col gap-1.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={t('showExpenses', { month: formatMonth(month.month) })}
+          >
+            <div className="flex items-center justify-between gap-2 text-sm">
+              <span className="capitalize">{formatMonth(month.month)}</span>
+              <div className="flex shrink-0 items-center gap-1">
+                <span className="tabular-nums text-muted-foreground">
+                  {formatCurrency(currency, month.total, locale)}
+                </span>
+                <ChevronRight className="h-4 w-4 text-muted-foreground/50 transition-colors group-hover:text-muted-foreground" />
+              </div>
+            </div>
+            <StatBar
+              value={month.total}
+              max={max}
+              color="hsl(var(--chart-1))"
+            />
+          </button>
+        ))}
+      </div>
+
+      <ExpensesDialog
+        open={selected !== null}
+        onClose={() => setSelected(null)}
+        groupId={groupId}
+        currency={currency}
+        title={
+          selected && (
+            <span className="capitalize">{formatMonth(selected)}</span>
+          )
+        }
+        description={t('detailsDescription')}
+        emptyText={t('detailsEmpty')}
+        expenses={data?.expenses}
+        isLoading={isLoading}
+      />
+    </>
   )
 }

--- a/src/app/groups/[groupId]/stats/stats-range-selector.tsx
+++ b/src/app/groups/[groupId]/stats/stats-range-selector.tsx
@@ -2,7 +2,9 @@
 import {
   STATS_PERIODS,
   StatsPeriod,
+  StatsRange,
 } from '@/app/groups/[groupId]/stats/stats-range'
+import { Input } from '@/components/ui/input'
 import {
   Select,
   SelectContent,
@@ -14,30 +16,75 @@ import { useTranslations } from 'next-intl'
 
 type Props = {
   period: StatsPeriod
+  customRange: StatsRange
   onPeriodChange: (period: StatsPeriod) => void
+  onCustomRangeChange: (range: StatsRange) => void
 }
 
-export function StatsRangeSelector({ period, onPeriodChange }: Props) {
+export function StatsRangeSelector({
+  period,
+  customRange,
+  onPeriodChange,
+  onCustomRangeChange,
+}: Props) {
   const t = useTranslations('Stats.range')
 
   return (
-    <div className="mb-4 flex items-center justify-end gap-2">
-      <span className="text-sm text-muted-foreground">{t('label')}</span>
-      <Select
-        value={period}
-        onValueChange={(value) => onPeriodChange(value as StatsPeriod)}
-      >
-        <SelectTrigger className="w-auto gap-2">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {STATS_PERIODS.map((value) => (
-            <SelectItem key={value} value={value}>
-              {t(value)}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+    <div className="mb-4 flex flex-col items-end gap-2">
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground">{t('label')}</span>
+        <Select
+          value={period}
+          onValueChange={(value) => onPeriodChange(value as StatsPeriod)}
+        >
+          <SelectTrigger className="w-auto gap-2">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {STATS_PERIODS.map((value) => (
+              <SelectItem key={value} value={value}>
+                {t(value)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {period === 'custom' && (
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span>{t('from')}</span>
+            <Input
+              className="date-base w-auto"
+              type="date"
+              max={customRange.to || undefined}
+              value={customRange.from ?? ''}
+              onChange={(event) =>
+                onCustomRangeChange({
+                  ...customRange,
+                  from: event.target.value || undefined,
+                })
+              }
+              aria-label={t('from')}
+            />
+          </label>
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span>{t('to')}</span>
+            <Input
+              className="date-base w-auto"
+              type="date"
+              min={customRange.from || undefined}
+              value={customRange.to ?? ''}
+              onChange={(event) =>
+                onCustomRangeChange({
+                  ...customRange,
+                  to: event.target.value || undefined,
+                })
+              }
+              aria-label={t('to')}
+            />
+          </label>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/groups/[groupId]/stats/stats-range.test.ts
+++ b/src/app/groups/[groupId]/stats/stats-range.test.ts
@@ -1,0 +1,98 @@
+import {
+  getRangeForPeriod,
+  resolveStatsRange,
+  STATS_PERIODS,
+} from './stats-range'
+
+describe('getRangeForPeriod', () => {
+  const now = new Date('2026-07-09T12:00:00')
+
+  it('returns an empty range for "all"', () => {
+    expect(getRangeForPeriod('all', now)).toEqual({})
+  })
+
+  it('returns an empty range for "custom"', () => {
+    expect(getRangeForPeriod('custom', now)).toEqual({})
+  })
+
+  it('covers the current month', () => {
+    expect(getRangeForPeriod('thisMonth', now)).toEqual({
+      from: '2026-07-01',
+      to: '2026-07-09',
+    })
+  })
+
+  it('covers the last 30 days inclusively', () => {
+    expect(getRangeForPeriod('last30', now)).toEqual({
+      from: '2026-06-10',
+      to: '2026-07-09',
+    })
+  })
+
+  it('covers the current year', () => {
+    expect(getRangeForPeriod('thisYear', now)).toEqual({
+      from: '2026-01-01',
+      to: '2026-07-09',
+    })
+  })
+})
+
+describe('resolveStatsRange', () => {
+  const now = new Date('2026-07-09T12:00:00')
+
+  it('delegates to getRangeForPeriod for named periods', () => {
+    expect(resolveStatsRange('thisYear', {}, now)).toEqual(
+      getRangeForPeriod('thisYear', now),
+    )
+  })
+
+  it('ignores the custom range for named periods', () => {
+    expect(
+      resolveStatsRange('all', { from: '2026-01-01', to: '2026-02-01' }, now),
+    ).toEqual({})
+  })
+
+  it('passes a custom range through verbatim', () => {
+    expect(
+      resolveStatsRange(
+        'custom',
+        { from: '2026-01-01', to: '2026-03-31' },
+        now,
+      ),
+    ).toEqual({ from: '2026-01-01', to: '2026-03-31' })
+  })
+
+  it('supports open-ended custom bounds', () => {
+    expect(resolveStatsRange('custom', { from: '2026-02-01' }, now)).toEqual({
+      from: '2026-02-01',
+      to: undefined,
+    })
+    expect(resolveStatsRange('custom', { to: '2026-02-01' }, now)).toEqual({
+      from: undefined,
+      to: '2026-02-01',
+    })
+  })
+
+  it('drops empty strings so partial input does not over-filter', () => {
+    expect(resolveStatsRange('custom', { from: '', to: '' }, now)).toEqual({
+      from: undefined,
+      to: undefined,
+    })
+  })
+
+  it('swaps reversed bounds', () => {
+    expect(
+      resolveStatsRange(
+        'custom',
+        { from: '2026-03-31', to: '2026-01-01' },
+        now,
+      ),
+    ).toEqual({ from: '2026-01-01', to: '2026-03-31' })
+  })
+})
+
+describe('STATS_PERIODS', () => {
+  it('includes the custom option', () => {
+    expect(STATS_PERIODS).toContain('custom')
+  })
+})

--- a/src/app/groups/[groupId]/stats/stats-range.ts
+++ b/src/app/groups/[groupId]/stats/stats-range.ts
@@ -1,4 +1,4 @@
-export type StatsPeriod = 'all' | 'thisMonth' | 'last30' | 'thisYear'
+export type StatsPeriod = 'all' | 'thisMonth' | 'last30' | 'thisYear' | 'custom'
 
 export type StatsRange = { from?: string; to?: string }
 
@@ -7,6 +7,7 @@ export const STATS_PERIODS: StatsPeriod[] = [
   'thisMonth',
   'last30',
   'thisYear',
+  'custom',
 ]
 
 function toDateString(date: Date): string {
@@ -41,8 +42,28 @@ export function getRangeForPeriod(
         from: toDateString(new Date(now.getFullYear(), 0, 1)),
         to: toDateString(now),
       }
+    case 'custom':
     case 'all':
     default:
       return {}
   }
+}
+
+/**
+ * Resolves the range that should actually be queried. Named periods delegate
+ * to {@link getRangeForPeriod}; the `custom` period uses the user-provided
+ * `customRange` verbatim, tolerating a reversed order (from > to) by swapping
+ * the bounds and dropping empty strings so partial input doesn't over-filter.
+ */
+export function resolveStatsRange(
+  period: StatsPeriod,
+  customRange: StatsRange,
+  now = new Date(),
+): StatsRange {
+  if (period !== 'custom') return getRangeForPeriod(period, now)
+
+  const from = customRange.from || undefined
+  const to = customRange.to || undefined
+  if (from && to && from > to) return { from: to, to: from }
+  return { from, to }
 }

--- a/src/lib/totals.test.ts
+++ b/src/lib/totals.test.ts
@@ -2,6 +2,8 @@ import { getBalances } from './balances'
 import {
   calculateShare,
   filterExpensesByDateRange,
+  getExpensesByCategory,
+  getExpensesByMonth,
   getRecurringSpending,
   getSpendingByCategory,
   getSpendingByParticipant,
@@ -230,6 +232,85 @@ describe('getSpendingByCategory', () => {
         total: 200,
       },
     ])
+  })
+})
+
+describe('getExpensesByCategory', () => {
+  it('returns only the matching category, excludes reimbursements and sorts newest first', () => {
+    const older = makeExpense({
+      id: 'a',
+      amount: 1000,
+      category: groceries,
+      expenseDate: new Date('2024-01-10T00:00:00Z'),
+    })
+    const newer = makeExpense({
+      id: 'b',
+      amount: 500,
+      category: groceries,
+      expenseDate: new Date('2024-02-20T00:00:00Z'),
+    })
+    const otherCategory = makeExpense({
+      id: 'c',
+      amount: 3000,
+      category: transport,
+      expenseDate: new Date('2024-03-01T00:00:00Z'),
+    })
+    const reimbursement = makeExpense({
+      id: 'd',
+      amount: 9999,
+      category: groceries,
+      isReimbursement: true,
+      expenseDate: new Date('2024-04-01T00:00:00Z'),
+    })
+
+    const result = getExpensesByCategory(
+      [older, newer, otherCategory, reimbursement],
+      groceries.id,
+    )
+
+    expect(result.map((expense) => expense.id)).toEqual(['b', 'a'])
+  })
+
+  it('matches expenses without a category against the Uncategorized id (0)', () => {
+    const uncategorized = makeExpense({ id: 'a', amount: 200, category: null })
+    const categorized = makeExpense({
+      id: 'b',
+      amount: 300,
+      category: groceries,
+    })
+
+    const result = getExpensesByCategory([uncategorized, categorized], 0)
+
+    expect(result.map((expense) => expense.id)).toEqual(['a'])
+  })
+})
+
+describe('getExpensesByMonth', () => {
+  it('returns only the matching month, excludes reimbursements and sorts newest first', () => {
+    const early = makeExpense({
+      id: 'a',
+      expenseDate: new Date('2024-03-05T00:00:00Z'),
+    })
+    const late = makeExpense({
+      id: 'b',
+      expenseDate: new Date('2024-03-25T00:00:00Z'),
+    })
+    const otherMonth = makeExpense({
+      id: 'c',
+      expenseDate: new Date('2024-04-01T00:00:00Z'),
+    })
+    const reimbursement = makeExpense({
+      id: 'd',
+      isReimbursement: true,
+      expenseDate: new Date('2024-03-15T00:00:00Z'),
+    })
+
+    const result = getExpensesByMonth(
+      [early, late, otherMonth, reimbursement],
+      '2024-03',
+    )
+
+    expect(result.map((expense) => expense.id)).toEqual(['b', 'a'])
   })
 })
 

--- a/src/lib/totals.ts
+++ b/src/lib/totals.ts
@@ -138,6 +138,47 @@ export function getSpendingByCategory(
     .sort((a, b) => b.total - a.total)
 }
 
+/**
+ * Returns the individual expenses that make up a single category's spending,
+ * so the stats page can drill down from the "by category" card into the
+ * matching expenses. Uses the same category-matching (`category?.id ?? 0`) and
+ * reimbursement exclusion as {@link getSpendingByCategory} so the list is
+ * consistent with the aggregated total, and sorts newest first.
+ */
+export function getExpensesByCategory<
+  T extends {
+    category: { id: number } | null
+    isReimbursement: boolean
+    expenseDate: Date
+  },
+>(expenses: T[], categoryId: number): T[] {
+  return expenses
+    .filter(
+      (expense) =>
+        !expense.isReimbursement && (expense.category?.id ?? 0) === categoryId,
+    )
+    .sort((a, b) => b.expenseDate.getTime() - a.expenseDate.getTime())
+}
+
+/**
+ * Returns the individual expenses that fall within a single `YYYY-MM` month, so
+ * the stats page can drill down from the "over time" card into the matching
+ * expenses. Uses the same month key and reimbursement exclusion as
+ * {@link getSpendingOverTime} so the list is consistent with the bar's total,
+ * and sorts newest first.
+ */
+export function getExpensesByMonth<
+  T extends { isReimbursement: boolean; expenseDate: Date },
+>(expenses: T[], month: string): T[] {
+  return expenses
+    .filter(
+      (expense) =>
+        !expense.isReimbursement &&
+        expense.expenseDate.toISOString().slice(0, 7) === month,
+    )
+    .sort((a, b) => b.expenseDate.getTime() - a.expenseDate.getTime())
+}
+
 export type ParticipantSpending = {
   participantId: string
   name: string

--- a/src/trpc/routers/groups/stats/category-expenses.procedure.ts
+++ b/src/trpc/routers/groups/stats/category-expenses.procedure.ts
@@ -1,0 +1,33 @@
+import { getGroupExpenses } from '@/lib/api'
+import { filterExpensesByDateRange, getExpensesByCategory } from '@/lib/totals'
+import { baseProcedure } from '@/trpc/init'
+import { z } from 'zod'
+
+/**
+ * Lists the expenses that make up a single category's spending on the stats
+ * page. Loaded on demand when a category in the "by category" card is clicked,
+ * so the overview payload stays lean. The date range is applied first so the
+ * drill-down matches the range currently selected on the page.
+ */
+export const getStatsCategoryExpensesProcedure = baseProcedure
+  .input(
+    z.object({
+      groupId: z.string().min(1),
+      categoryId: z.number().int(),
+      from: z.string().optional(),
+      to: z.string().optional(),
+    }),
+  )
+  .query(async ({ input: { groupId, categoryId, from, to } }) => {
+    const allExpenses = await getGroupExpenses(groupId)
+    const expenses = filterExpensesByDateRange(allExpenses, from, to)
+
+    return {
+      expenses: getExpensesByCategory(expenses, categoryId).map((expense) => ({
+        id: expense.id,
+        title: expense.title,
+        amount: expense.amount,
+        expenseDate: expense.expenseDate,
+      })),
+    }
+  })

--- a/src/trpc/routers/groups/stats/index.ts
+++ b/src/trpc/routers/groups/stats/index.ts
@@ -1,6 +1,10 @@
 import { createTRPCRouter } from '@/trpc/init'
+import { getStatsCategoryExpensesProcedure } from '@/trpc/routers/groups/stats/category-expenses.procedure'
+import { getStatsMonthExpensesProcedure } from '@/trpc/routers/groups/stats/month-expenses.procedure'
 import { getStatsOverviewProcedure } from '@/trpc/routers/groups/stats/overview.procedure'
 
 export const groupStatsRouter = createTRPCRouter({
   overview: getStatsOverviewProcedure,
+  categoryExpenses: getStatsCategoryExpensesProcedure,
+  monthExpenses: getStatsMonthExpensesProcedure,
 })

--- a/src/trpc/routers/groups/stats/month-expenses.procedure.ts
+++ b/src/trpc/routers/groups/stats/month-expenses.procedure.ts
@@ -1,0 +1,34 @@
+import { getGroupExpenses } from '@/lib/api'
+import { filterExpensesByDateRange, getExpensesByMonth } from '@/lib/totals'
+import { baseProcedure } from '@/trpc/init'
+import { z } from 'zod'
+
+/**
+ * Lists the expenses that make up a single month's spending on the stats page.
+ * Loaded on demand when a bar in the "spending over time" card is clicked, so
+ * the overview payload stays lean. The date range is applied first so that a
+ * partial month (e.g. the current month under a "last 30 days" range) drills
+ * down into exactly the expenses that contributed to the bar.
+ */
+export const getStatsMonthExpensesProcedure = baseProcedure
+  .input(
+    z.object({
+      groupId: z.string().min(1),
+      month: z.string().regex(/^\d{4}-\d{2}$/),
+      from: z.string().optional(),
+      to: z.string().optional(),
+    }),
+  )
+  .query(async ({ input: { groupId, month, from, to } }) => {
+    const allExpenses = await getGroupExpenses(groupId)
+    const expenses = filterExpensesByDateRange(allExpenses, from, to)
+
+    return {
+      expenses: getExpensesByMonth(expenses, month).map((expense) => ({
+        id: expense.id,
+        title: expense.title,
+        amount: expense.amount,
+        expenseDate: expense.expenseDate,
+      })),
+    }
+  })


### PR DESCRIPTION
# feat: stats date range and expense drill-downs

Part of the series in #553, and the direct follow-on to #584. Three commits,
14 files.

## What lands

**A custom date range.** The period selector gains "Custom range" with From/To
fields, each constrained against the other so the range cannot invert.

**Drill-downs.** The bars in "spending by category" and "spending over time"
become buttons; selecting one opens a dialog listing the expenses behind it,
each linking to its edit page. Both dialogs query *within the currently selected
period*, so a drill-down always matches the bar that opened it.

The bars also gain hover, focus-visible and cursor styling. Without it nothing
indicated they could be selected at all — that was a follow-up commit in my
fork, folded in here rather than shipped as "add drill-downs" then "make them
look clickable".

## Three commits, in review order

**1. The lookups** (`totals.ts`, `stats-range.ts`) — pure functions with tests.
**Stands alone: `check-types` clean, 129 tests green with no UI in the tree.**

`getExpensesByCategory` and `getExpensesByMonth` reuse the category matching
(`category?.id ?? 0`) and reimbursement exclusion of the aggregate they drill
into, so a bar and its expense list can't disagree.

`resolveStatsRange` tolerates a reversed custom range by swapping the bounds,
and drops empty strings so half-filled input doesn't over-filter to nothing —
you get "everything" while typing the first date, not "nothing".

**2. The UI** — selector, dialogs, two tRPC procedures, `en-US` strings only.

**3. E2E** — extends `e2e/stats-breakdown.spec.ts` from #584 rather than adding
a file, since these are new assertions on cards it already exercises.

## Verification

Against `e4b8fba`, Node 24 / npm 11: `npm ci --ignore-scripts`,
`npx prisma generate`, `check-types`, `lint` (16 warnings / 0 errors, all
pre-existing), `check-formatting`, `npm test` — 8 suites, **129 tests** (114
before) — and a full `npm run build`.

**Your E2E suite: 35/35.** Worth noting the three specs #584 added for these two
cards still pass unchanged, which is the useful signal here — this PR rewrites
`category-breakdown.tsx` and `spending-over-time.tsx` fairly heavily to turn the
rows into buttons, and the existing display assertions confirm that didn't
disturb what they render.

The three new specs were mutation-checked rather than assumed:

```
Expected substring: "$41.00"
Received string:    "GroceriesExpenses in this category for the selected
                     period.Weekly shopAug 16, 2026$40.00Close"

Expected substring: "$16.00"
Received string:    "Mar 2020Expenses in this month for the selected
                     period.Long agoMar 10, 2020$15.00Close"
```

So the dialogs really do open on the right bar and list only that bar's
expenses. The month test records one expense today and one dated 2020-03-10,
then drills into "Mar 2020" — fixed dates, so it holds whenever the suite runs.

E2E ran against a real Postgres 16 and the built app rather than the compose
stack — no Docker daemon where I work — driven through `E2E_BASE_URL`. Same app,
same specs; it does not exercise the image build or `scripts/e2e.sh`.

## One note for whoever writes specs against this next

The From/To date fields are each an `<input>` inside a `<label>` that *also*
carries an `aria-label`, so `getByLabel('To')` hits strict-mode with two nodes.
The spec scopes to the input instead. Worth knowing before it bites someone
else; happy to drop the redundant `aria-label` in a follow-up if you'd prefer
the simpler locator to work.
