### PR TITLE
feat: PWA service worker with offline assets and an update prompt

### DIFF
--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -1,0 +1,94 @@
+import { Page } from '@playwright/test'
+import { addExpense, createGroup, uniqueSuffix } from './app'
+import { expect, test } from './fixtures'
+
+/**
+ * The worker registers only in a production build (see
+ * service-worker-registration.tsx), which is what scripts/e2e.sh serves. It
+ * would never register against `next dev`.
+ *
+ * Each test gets its own browser context, so each installs the worker from
+ * scratch and none can see another's caches.
+ */
+
+/** Resolves once the worker is active *and* has claimed this page. */
+async function waitForServiceWorker(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => !!navigator.serviceWorker?.controller,
+    null,
+    {
+      timeout: 30_000,
+    },
+  )
+}
+
+/** Every URL held in every cache, as pathnames. */
+async function cachedPaths(page: Page): Promise<string[]> {
+  return page.evaluate(async () => {
+    const paths: string[] = []
+    for (const name of await caches.keys()) {
+      const cache = await caches.open(name)
+      for (const request of await cache.keys()) {
+        paths.push(new URL(request.url).pathname)
+      }
+    }
+    return paths
+  })
+}
+
+test('registers a service worker that takes control of the page', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await waitForServiceWorker(page)
+
+  const scriptURL = await page.evaluate(
+    () => navigator.serviceWorker.controller?.scriptURL ?? '',
+  )
+  expect(new URL(scriptURL).pathname).toBe('/sw.js')
+})
+
+test('serves the offline page when a navigation cannot reach the network', async ({
+  page,
+  context,
+}) => {
+  await page.goto('/')
+  await waitForServiceWorker(page)
+
+  await context.setOffline(true)
+  try {
+    // A group id this context has never visited, so the runtime cache cannot
+    // satisfy it and the worker has to fall through to /offline.html.
+    await page.goto(`/groups/${uniqueSuffix()}/expenses`)
+    await expect(
+      page.getByRole('heading', { name: "You're offline" }),
+    ).toBeVisible()
+  } finally {
+    await context.setOffline(false)
+  }
+})
+
+test('caches static assets but never API responses', async ({ page }) => {
+  const groupId = await createGroup(page, {
+    name: `E2E PWA ${uniqueSuffix()}`,
+    participants: ['Alice', 'Bob'],
+  })
+  // Real tRPC traffic, so there is something the worker could wrongly cache.
+  await addExpense(page, groupId, {
+    title: 'Coffee',
+    amount: '10',
+    paidBy: 'Alice',
+  })
+
+  await page.goto(`/groups/${groupId}/expenses`)
+  await waitForServiceWorker(page)
+  // The worker claims the page mid-load, so assets requested before it took
+  // control land in the cache only on a second pass.
+  await page.reload()
+
+  const paths = await cachedPaths(page)
+
+  // Non-vacuous: the assertion below is only meaningful if caching happened.
+  expect(paths.some((path) => path.startsWith('/_next/static/'))).toBe(true)
+  expect(paths.filter((path) => path.startsWith('/api/'))).toEqual([])
+})

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -526,5 +526,10 @@
     "other": {
       "heading": "Other currencies"
     }
+  },
+  "Pwa": {
+    "updateTitle": "Update available",
+    "updateDescription": "A new version of Spliit is available.",
+    "reload": "Reload"
   }
 }

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Offline · Spliit</title>
+    <link rel="icon" href="/favicon.ico" />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100dvh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 1.25rem;
+        padding: 2rem;
+        text-align: center;
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto,
+          Helvetica, Arial, sans-serif;
+        background: #f8fafc;
+        color: #0f172a;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #020817;
+          color: #f8fafc;
+        }
+      }
+      img {
+        width: 160px;
+        height: auto;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin: 0;
+      }
+      p {
+        margin: 0;
+        max-width: 28rem;
+        opacity: 0.8;
+        line-height: 1.5;
+      }
+      button {
+        margin-top: 0.5rem;
+        padding: 0.625rem 1.25rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: #fff;
+        background: #047857;
+        border: none;
+        border-radius: 0.5rem;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #036249;
+      }
+    </style>
+  </head>
+  <body>
+    <img src="/logo-with-text.png" alt="Spliit" />
+    <h1>You're offline</h1>
+    <p>
+      This page isn't available without a connection. Pages and data you've
+      already visited may still work. Reconnect and try again.
+    </p>
+    <button onclick="location.reload()">Try again</button>
+  </body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,148 @@
+/*
+ * Spliit service worker.
+ *
+ * A lightweight, dependency-free service worker that caches static assets to
+ * save bandwidth and improve load performance, while always serving fresh data
+ * for dynamic/API requests.
+ *
+ * Caching strategy:
+ *  - Immutable, content-hashed assets (/_next/static, /logo, icons, fonts):
+ *    cache-first — fetched from the network once, then served from cache.
+ *  - Optimized images (/_next/image): stale-while-revalidate.
+ *  - Page navigations: network-first with a cached fallback, then the offline
+ *    page when both network and cache miss.
+ *  - API / tRPC requests and any non-GET request: never cached (always network),
+ *    so expense data is never stale.
+ *
+ * Bump CACHE_VERSION to invalidate all previously cached content on deploy.
+ */
+
+const CACHE_VERSION = 'v1'
+const PRECACHE = `spliit-precache-${CACHE_VERSION}`
+const RUNTIME = `spliit-runtime-${CACHE_VERSION}`
+const IMAGE_CACHE = `spliit-images-${CACHE_VERSION}`
+
+const OFFLINE_URL = '/offline.html'
+
+// Minimal app shell precached on install so the app can boot offline.
+const PRECACHE_URLS = [
+  OFFLINE_URL,
+  '/manifest.webmanifest',
+  '/logo-with-text.png',
+  '/logo/192x192.png',
+  '/logo/512x512.png',
+]
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(PRECACHE)
+      // Use `addAll` per-URL so a single missing asset does not abort install.
+      await Promise.allSettled(
+        PRECACHE_URLS.map((url) => cache.add(new Request(url, { cache: 'reload' }))),
+      )
+      // Note: we intentionally do NOT call skipWaiting() here. A new worker
+      // stays in the "waiting" state until the page explicitly tells it to
+      // activate (see the message handler below), which lets the UI prompt the
+      // user to reload instead of swapping assets out from under a live page.
+    })(),
+  )
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keep = new Set([PRECACHE, RUNTIME, IMAGE_CACHE])
+      const keys = await caches.keys()
+      await Promise.all(
+        keys.map((key) => (keep.has(key) ? undefined : caches.delete(key))),
+      )
+      await self.clients.claim()
+    })(),
+  )
+})
+
+/** Cache-first: serve from cache, falling back to network and storing the result. */
+async function cacheFirst(request, cacheName) {
+  // Match across all caches (including PRECACHE) so precached assets such as
+  // the offline page's logo are served even before they land in `cacheName`.
+  const cached = await caches.match(request)
+  if (cached) return cached
+  const cache = await caches.open(cacheName)
+  const response = await fetch(request)
+  if (response && response.ok) cache.put(request, response.clone())
+  return response
+}
+
+/** Stale-while-revalidate: serve cache immediately, refresh in the background. */
+async function staleWhileRevalidate(request, cacheName) {
+  const cache = await caches.open(cacheName)
+  const cached = await cache.match(request)
+  const network = fetch(request)
+    .then((response) => {
+      if (response && response.ok) cache.put(request, response.clone())
+      return response
+    })
+    .catch(() => undefined)
+  return cached || (await network) || Response.error()
+}
+
+/** Network-first: try the network, fall back to cache, then the offline page. */
+async function networkFirst(request, cacheName) {
+  const cache = await caches.open(cacheName)
+  try {
+    const response = await fetch(request)
+    if (response && response.ok) cache.put(request, response.clone())
+    return response
+  } catch (err) {
+    const cached = await cache.match(request)
+    if (cached) return cached
+    const offline = await caches.match(OFFLINE_URL)
+    if (offline) return offline
+    throw err
+  }
+}
+
+function isStaticAsset(url) {
+  return (
+    url.pathname.startsWith('/_next/static/') ||
+    url.pathname.startsWith('/logo/') ||
+    /\.(?:js|css|woff2?|ttf|otf|eot|png|svg|ico|webp|gif|jpg|jpeg)$/.test(
+      url.pathname,
+    )
+  )
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event
+  const url = new URL(request.url)
+
+  // Only handle same-origin GET requests; let everything else hit the network.
+  if (request.method !== 'GET' || url.origin !== self.location.origin) return
+
+  // Never cache dynamic data — always go to the network.
+  if (url.pathname.startsWith('/api/')) return
+
+  // Page navigations: network-first with offline fallback.
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirst(request, RUNTIME))
+    return
+  }
+
+  // Optimized images: stale-while-revalidate (URLs vary by query params).
+  if (url.pathname.startsWith('/_next/image')) {
+    event.respondWith(staleWhileRevalidate(request, IMAGE_CACHE))
+    return
+  }
+
+  // Immutable static assets: cache-first.
+  if (isStaticAsset(url)) {
+    event.respondWith(cacheFirst(request, RUNTIME))
+    return
+  }
+})
+
+// Allow the page to trigger an immediate activation of a waiting worker.
+self.addEventListener('message', (event) => {
+  if (event.data === 'SKIP_WAITING') self.skipWaiting()
+})

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -164,7 +164,7 @@ export default async function RootLayout({
       dir={['ar', 'he'].includes(locale) ? 'rtl' : 'ltr'}
       suppressHydrationWarning
     >
-      <ApplePwaSplash icon="/logo-with-text.png" color="#027756" />
+      <ApplePwaSplash icon="/logo-with-text.png" color="#047857" />
       <body className="min-h-[100dvh] flex flex-col items-stretch bg-slate-50 bg-opacity-30 dark:bg-background">
         <NextIntlClientProvider messages={messages}>
           {/* Rendered inside the provider because it reads translations via

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { ApplePwaSplash } from '@/app/apple-pwa-splash'
 import { LocaleSwitcher } from '@/components/locale-switcher'
 import { ProgressBar } from '@/components/progress-bar'
+import { ServiceWorkerRegistration } from '@/components/service-worker-registration'
 import { ThemeProvider } from '@/components/theme-provider'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { Button } from '@/components/ui/button'
@@ -166,6 +167,10 @@ export default async function RootLayout({
       <ApplePwaSplash icon="/logo-with-text.png" color="#027756" />
       <body className="min-h-[100dvh] flex flex-col items-stretch bg-slate-50 bg-opacity-30 dark:bg-background">
         <NextIntlClientProvider messages={messages}>
+          {/* Rendered inside the provider because it reads translations via
+              `useTranslations`, which needs NextIntlClientProvider in its
+              ancestor tree. */}
+          <ServiceWorkerRegistration />
           <Analytics config={analyticsConfig}>
             <ThemeProvider
               attribute="class"

--- a/src/components/service-worker-registration.tsx
+++ b/src/components/service-worker-registration.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { ToastAction } from '@/components/ui/toast'
+import { useToast } from '@/components/ui/use-toast'
+import { useTranslations } from 'next-intl'
+import { useEffect, useRef } from 'react'
+
+// How often to ask the browser to check for a new service worker (1 hour),
+// so long-lived tabs notice deploys without a manual refresh.
+const UPDATE_CHECK_INTERVAL = 60 * 60 * 1000
+
+/**
+ * Registers the service worker (public/sw.js) that caches static assets to save
+ * bandwidth and improve performance, and prompts the user to reload when a new
+ * version has been deployed.
+ *
+ * Registration only runs in production: in development a cached service worker
+ * would serve stale assets and mask changes.
+ */
+export function ServiceWorkerRegistration() {
+  const { toast } = useToast()
+  const t = useTranslations('Pwa')
+
+  // Keep the latest toast/t available to the run-once effect without making
+  // them effect dependencies (which would re-register the worker on identity
+  // changes). Refs are synced after every render.
+  const toastRef = useRef(toast)
+  const tRef = useRef(t)
+  useEffect(() => {
+    toastRef.current = toast
+    tRef.current = t
+  })
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return
+    if (!('serviceWorker' in navigator)) return
+
+    let cleanup: (() => void) | undefined
+
+    const register = async () => {
+      try {
+        // Whether the page is already controlled by a worker. If so, a later
+        // `controllerchange` means a NEW worker took over (an update) and we
+        // should reload. On a first install, `clients.claim()` also fires
+        // `controllerchange`, but reloading then would be a jarring,
+        // unnecessary refresh — so we skip it.
+        const hadController = !!navigator.serviceWorker.controller
+
+        const registration = await navigator.serviceWorker.register('/sw.js')
+
+        // Reload once the new worker takes control so the page picks up the new
+        // assets. Guard against reload loops and the first-install claim.
+        let refreshing = false
+        const onControllerChange = () => {
+          if (!hadController || refreshing) return
+          refreshing = true
+          window.location.reload()
+        }
+        navigator.serviceWorker.addEventListener(
+          'controllerchange',
+          onControllerChange,
+        )
+
+        const promptUpdate = (worker: ServiceWorker) => {
+          const t = tRef.current
+          toastRef.current({
+            title: t('updateTitle'),
+            description: t('updateDescription'),
+            duration: Infinity,
+            action: (
+              <ToastAction
+                altText={t('reload')}
+                onClick={() => worker.postMessage('SKIP_WAITING')}
+              >
+                {t('reload')}
+              </ToastAction>
+            ),
+          })
+        }
+
+        // A new worker may already be waiting (installed before this page load).
+        if (registration.waiting && navigator.serviceWorker.controller) {
+          promptUpdate(registration.waiting)
+        }
+
+        // Otherwise watch for one to finish installing.
+        registration.addEventListener('updatefound', () => {
+          const newWorker = registration.installing
+          if (!newWorker) return
+          newWorker.addEventListener('statechange', () => {
+            // `controller` is only set when an older worker is already in
+            // control, which distinguishes an update from a first install.
+            if (
+              newWorker.state === 'installed' &&
+              navigator.serviceWorker.controller
+            ) {
+              promptUpdate(newWorker)
+            }
+          })
+        })
+
+        // Proactively check for updates on an interval and when the tab is
+        // brought back to the foreground.
+        const interval = window.setInterval(
+          () => registration.update(),
+          UPDATE_CHECK_INTERVAL,
+        )
+        const onVisibilityChange = () => {
+          if (document.visibilityState === 'visible') registration.update()
+        }
+        document.addEventListener('visibilitychange', onVisibilityChange)
+
+        cleanup = () => {
+          navigator.serviceWorker.removeEventListener(
+            'controllerchange',
+            onControllerChange,
+          )
+          document.removeEventListener('visibilitychange', onVisibilityChange)
+          window.clearInterval(interval)
+        }
+      } catch (error) {
+        console.error('Service worker registration failed:', error)
+      }
+    }
+
+    if (document.readyState === 'complete') {
+      register()
+    } else {
+      const onLoad = () => register()
+      window.addEventListener('load', onLoad)
+      cleanup = () => window.removeEventListener('load', onLoad)
+    }
+
+    // Run once on mount: registration is a one-time setup. toast/t are read
+    // from refs so their identity does not retrigger registration.
+    return () => cleanup?.()
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
# feat: PWA service worker with offline assets and an update prompt

Part of the series in #553. Four commits, 6 files, no new dependencies.

Spliit already ships a manifest and an iOS splash, so it installs as a PWA —
but there is no service worker, so an installed app is still a blank page
without a connection and every asset is refetched on every visit. This adds
one.

## The caching policy, which is the part worth reviewing

| Request | Strategy |
| --- | --- |
| `/_next/static`, `/logo`, font/image extensions | cache-first (content-hashed, so they cannot go stale) |
| `/_next/image` | stale-while-revalidate (URLs vary by query params) |
| Page navigations | network-first → cache → `/offline.html` |
| `/api/*` and every non-GET request | **never cached** |

The last row is the one that matters: expense data must never be served from a
cache. There is a test for it rather than just a comment — see below.

## The update flow

Installing deliberately does **not** call `skipWaiting()`. A worker that
activates immediately swaps hashed assets out from under a live page, which is
how you get chunk-load errors on deploy. Instead the new worker waits, the page
shows a persistent toast, and it activates only when the user clicks Reload.
Updates are checked hourly and whenever the tab regains focus, so a long-lived
tab still notices a deploy.

## Four commits, in review order

**1. `public/sw.js` + `public/offline.html`** — no React, nothing registers the
worker yet, so this commit is inert on its own. The whole caching policy is
reviewable here in isolation.

**2. The registration component, the layout wiring, and `en-US` strings.**

Three things in it are non-obvious and are commented in the source:

- It renders **inside `NextIntlClientProvider`** because it reads translations.
  next-intl's client `useTranslations` throws without the provider as an
  ancestor, which server-side is a crash on every page rather than a broken
  toast. (I shipped that bug in my fork first; it is fixed here, not folded in
  as a follow-up.)
- `controllerchange` only reloads when the page **already had a controller**.
  A first install fires the same event via `clients.claim()`, and reloading
  there is a jarring refresh for a brand-new visitor.
- Registration runs once on mount; `toast` and `t` are read from refs synced in
  an effect, so their identity does not re-register the worker.

Registration is production-only — in development a cached worker would serve
stale assets and mask changes.

**3. `#027756` → `#047857` on the Apple splash.** One line, independent of the
rest, easy to drop. `manifest.ts`'s `theme_color`, the viewport `themeColor` and
the new offline page all use `#047857`; the splash is the only place the other
green appears, so the iOS launch screen is a shade off from everything else. If
that is deliberate, drop this commit — the rest of the PR does not depend on it.

**4. E2E coverage.** Also separate so it can be dropped.

## Verification

Against `b9bd45b`, Node 24 / npm 11: `npm ci --ignore-scripts`,
`npx prisma generate`, `check-types`, `lint` (16 warnings / 0 errors, all
pre-existing), `check-formatting`, `npm test` (8 suites, 129 tests — unchanged,
this PR adds no unit-testable logic), and a full `npm run build`.

**Your E2E suite: 38/38.** That number is the main thing I want to put in front
of you. A service worker is a global change to how *every* request in the app is
served, so the risk here is not the three new specs — it is the other 35. All 35
pass unchanged, against a build with the worker active.

The three new specs in `e2e/pwa.spec.ts` were mutation-checked rather than
assumed:

```
Expected: "/worker.js"
Received: "/sw.js"

expect(locator).toBeVisible() failed        # "You are offline" vs "You're offline"
Error: element(s) not found

expect(received).toEqual(expected)          # /_next/image instead of /api/
- Expected  - 1
+ Received  + 3
```

The third is the interesting one. Swapping the `/api/` filter for
`/_next/image` turns up **3 cached entries**, which proves two things at once:
the cache really is populated when that assertion runs, so `/api/` returning
nothing is a real result and not a vacuous one — and the image cache is doing
what the policy says. The spec also asserts that at least one `/_next/static/`
entry exists, for the same reason.

The offline spec runs with `context.setOffline(true)` and navigates to a group
id that context has never visited, so the runtime cache cannot satisfy it and
the worker has to fall through to `/offline.html`.

Each spec ran twice in a row to check for flake; stable both times.

E2E ran against a real Postgres 16 and the built app rather than the compose
stack — no Docker daemon where I work — driven through `E2E_BASE_URL`. Same
app, same specs; it does not exercise the image build or `scripts/e2e.sh`.

## What I could not check here

The iOS install path. The splash colour, `appleWebApp` metadata and the
standalone display mode all want a real iPhone, and I have only Chromium in this
environment. Nothing in the worker is Safari-specific, but the PWA install
experience is the one part of this I am asserting rather than demonstrating.
