### PR TITLE
feat: settle up in a currency other than the group's

### DIFF
--- a/e2e/repayment-currency.spec.ts
+++ b/e2e/repayment-currency.spec.ts
@@ -1,0 +1,126 @@
+import {
+  addExpense,
+  createGroup,
+  expectBalance,
+  expenseCard,
+  EXPENSES_URL,
+  openExpense,
+  openTab,
+  reimbursementRow,
+  uniqueSuffix,
+} from './app'
+import { expect, test } from './fixtures'
+import { fieldByLabel, money, selectRadixOption } from './ui'
+
+// Groups default to USD, so picking EUR forces a conversion. The rate is
+// mocked, so 1 EUR is always exactly 1.25 USD.
+test.use({ exchangeRate: 1.25 })
+
+const PARTICIPANTS = ['Alice', 'Bob']
+
+/** Creates a group where Bob owes Alice 50, and opens "Mark as paid". */
+async function openRepaymentForm(page: Page, name: string): Promise<string> {
+  const groupId = await createGroup(page, {
+    name: `${name} ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+  await addExpense(page, groupId, {
+    title: 'Hotel',
+    amount: '100',
+    paidBy: 'Alice',
+  })
+
+  await openTab(page, 'Balances')
+  await reimbursementRow(page, 'Bob', 'Alice')
+    .getByRole('link', { name: 'Mark as paid' })
+    .click()
+  await page.waitForURL(/\/expenses\/create\?.*reimbursement=yes/, {
+    timeout: 30_000,
+  })
+  return groupId
+}
+
+const originalAmount = (page: Page) =>
+  page.locator('input[name="originalAmount"]')
+
+type Page = import('@playwright/test').Page
+
+test('derives the transfer amount from the balance being settled', async ({
+  page,
+}) => {
+  await openRepaymentForm(page, 'E2E Repayment')
+
+  // The balance is the authoritative figure and stays in the group currency.
+  await expect(page.locator('input[name="amount"]')).toHaveValue(/^50/)
+
+  await selectRadixOption(
+    page,
+    fieldByLabel(page, 'Currency of expense').getByRole('combobox'),
+    /Euro \(EUR\)/,
+  )
+
+  // 50 USD at 1 EUR = 1.25 USD is 40 EUR, filled in without the user typing.
+  // This is the reverse of the regular-expense direction, where the foreign
+  // amount is what drives the group-currency one.
+  await expect(originalAmount(page)).toHaveValue('40.00')
+  await expect(page.getByText('Amount to transfer')).toBeVisible()
+  // Derived, so it must not be editable.
+  await expect(originalAmount(page)).toHaveAttribute('readonly', '')
+})
+
+test('settles the balance exactly and keeps the transferred amount', async ({
+  page,
+}) => {
+  await openRepaymentForm(page, 'E2E Repayment Settle')
+
+  await selectRadixOption(
+    page,
+    fieldByLabel(page, 'Currency of expense').getByRole('combobox'),
+    /Euro \(EUR\)/,
+  )
+  await expect(originalAmount(page)).toHaveValue('40.00')
+
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await page.waitForURL(EXPENSES_URL, { timeout: 30_000 })
+
+  // The card carries both figures: what settles the balance and what moved.
+  const card = expenseCard(page, 'Reimbursement')
+  await expect(card).toContainText(money(50))
+  await expect(card).toContainText(money(40, 'EUR'))
+
+  // The point of keeping the group amount authoritative: the balance is zero,
+  // not "zero apart from a rounding remainder".
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 0)
+  await expectBalance(page, 'Bob', 0)
+
+  // Reopening must not rewrite the stored amount at today's rate.
+  await openTab(page, 'Expenses')
+  await openExpense(page, 'Reimbursement')
+  await expect(originalAmount(page)).toHaveValue(/^40/)
+})
+
+test('refreshing the exchange rate does not submit the form', async ({
+  page,
+}) => {
+  const groupId = await openRepaymentForm(page, 'E2E Repayment Refresh')
+
+  await selectRadixOption(
+    page,
+    fieldByLabel(page, 'Currency of expense').getByRole('combobox'),
+    /Euro \(EUR\)/,
+  )
+  await expect(originalAmount(page)).toHaveValue('40.00')
+
+  await page.getByRole('button', { name: 'Refresh' }).click()
+
+  // Asserting that nothing happens, so it needs a settling period rather than
+  // an immediate check: a submit navigates a second or two later, and
+  // toHaveURL would match the create URL before that lands.
+  await expect(
+    page.waitForURL(EXPENSES_URL, { timeout: 5_000 }),
+  ).rejects.toThrow()
+
+  await expect(page).toHaveURL(new RegExp(`/groups/${groupId}/expenses/create`))
+  await expect(originalAmount(page)).toHaveValue('40.00')
+})

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -216,7 +216,9 @@
     },
     "conversionUnavailable": "To set a different currency per expense and convert amounts, select a non-custom currency for the group.",
     "originalAmountField": {
-      "label": "Amount to convert"
+      "label": "Amount to convert",
+      "repaymentLabel": "Amount to transfer",
+      "repaymentDescription": "Converted from the amount above, which is what settles the balance."
     },
     "conversionRateField": {
       "useApi": "Use rates from Frankfurter",

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -3,8 +3,9 @@ import { ActiveUserBalance } from '@/app/groups/[groupId]/expenses/active-user-b
 import { CategoryIcon } from '@/app/groups/[groupId]/expenses/category-icon'
 import { DocumentsCount } from '@/app/groups/[groupId]/expenses/documents-count'
 import { Button } from '@/components/ui/button'
+import { Locale } from '@/i18n/request'
 import { getGroupExpenses } from '@/lib/api'
-import { Currency } from '@/lib/currency'
+import { Currency, getCurrency } from '@/lib/currency'
 import { cn, formatCurrency, formatDateOnly } from '@/lib/utils'
 import { ChevronRight } from 'lucide-react'
 import { useLocale, useTranslations } from 'next-intl'
@@ -58,7 +59,18 @@ export function ExpenseCard({
   participantCount,
 }: Props) {
   const router = useRouter()
-  const locale = useLocale()
+  const locale = useLocale() as Locale
+
+  const originalAmount =
+    expense.originalAmount != null &&
+    expense.originalCurrency &&
+    expense.originalCurrency !== currency.code
+      ? formatCurrency(
+          getCurrency(expense.originalCurrency, locale),
+          expense.originalAmount,
+          locale,
+        )
+      : null
 
   return (
     <div
@@ -97,6 +109,11 @@ export function ExpenseCard({
         >
           {formatCurrency(currency, expense.amount, locale)}
         </div>
+        {originalAmount && (
+          <div className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+            {originalAmount}
+          </div>
+        )}
         <div className="text-xs text-muted-foreground">
           <DocumentsCount count={expense._count.documents} />
         </div>

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -606,6 +606,9 @@ export function ExpenseForm({
                           {!exchangeRate.isLoading && (
                             <Button
                               className="h-auto py-0"
+                              // Without this the button inherits type="submit"
+                              // and refreshing the rate submits the form.
+                              type="button"
                               variant="link"
                               onClick={() => exchangeRate.refresh()}
                             >

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -37,6 +37,10 @@ import { Locale } from '@/i18n/request'
 import { useAnalytics } from '@/lib/analytics/context'
 import { randomId } from '@/lib/api'
 import { defaultCurrencyList, getCurrency } from '@/lib/currency'
+import {
+  convertToGroupCurrency,
+  convertToOriginalCurrency,
+} from '@/lib/currency-conversion'
 import { RuntimeFeatureFlags } from '@/lib/featureFlags'
 import { useActiveUser, useCurrencyRate } from '@/lib/hooks'
 import {
@@ -171,6 +175,9 @@ export function ExpenseForm({
   const isCreate = expense === undefined
   const searchParams = useSearchParams()
 
+  /** Whether the form was opened from a suggested reimbursement ("Mark as paid"). */
+  const isRepayment = isCreate && !!searchParams.get('reimbursement')
+
   const getSelectedPayer = (field?: { value: string }) => {
     if (isCreate && typeof window !== 'undefined') {
       const activeUser = localStorage.getItem(`${group.id}-activeUser`)
@@ -220,7 +227,7 @@ export function ExpenseForm({
           notes: expense.notes ?? '',
           recurrenceRule: expense.recurrenceRule ?? undefined,
         }
-      : searchParams.get('reimbursement')
+      : isRepayment
         ? {
             title: t('reimbursement'),
             expenseDate: new Date(),
@@ -229,7 +236,9 @@ export function ExpenseForm({
               groupCurrency,
             ),
             originalCurrency: group.currencyCode,
-            originalAmount: undefined,
+            // Empty rather than undefined: the field is filled in by the conversion, and
+            // switching an input from uncontrolled to controlled warns in React.
+            originalAmount: '' as any,
             conversionRate: undefined,
             category: 1, // category with Id 1 is Payment
             paidBy: searchParams.get('from') ?? undefined,
@@ -302,15 +311,18 @@ export function ExpenseForm({
           : shares,
     }))
 
-    // Currency should be blank if same as group currency
-    if (!conversionRequired) {
-      delete values.originalAmount
-      delete values.originalCurrency
-    } else if (values.originalAmount !== undefined) {
+    // Currency should be blank if same as group currency, or if no conversion took place
+    if (conversionRequired && values.originalAmount !== undefined) {
       values.originalAmount = amountAsMinorUnits(
         values.originalAmount,
         originalCurrency,
       )
+    } else {
+      delete values.originalAmount
+      delete values.originalCurrency
+      // Without this a repayment whose converted amount rounded to zero would
+      // still be saved with a rate but no amount to apply it to.
+      delete values.conversionRate
     }
     return onSubmit(values, activeUserId ?? undefined)
   }
@@ -338,6 +350,16 @@ export function ExpenseForm({
     group.currencyCode.length &&
     originalCurrency.code.length &&
     originalCurrency.code !== group.currencyCode
+
+  /**
+   * Which of the two amount fields drives the other.
+   *
+   * For a regular expense the user enters what they spent in the original currency and the
+   * group-currency amount follows. For a repayment it is the other way around: the
+   * group-currency amount is the balance being settled, and the original amount is the
+   * amount to actually transfer, derived from it.
+   */
+  const convertFromGroupCurrency = !!form.watch('isReimbursement')
 
   useEffect(() => {
     setManuallyEditedParticipants(new Set())
@@ -413,18 +435,21 @@ export function ExpenseForm({
     }
   }, [exchangeRate.data, usingCustomConversionRate])
 
+  // Original currency -> group currency, for regular expenses.
   useEffect(() => {
+    if (convertFromGroupCurrency || !conversionRequired) return
     if (!form.getFieldState('originalAmount').isTouched) return
     const originalAmount = form.getValues('originalAmount') ?? 0
     const conversionRate = form.getValues('conversionRate')
 
     if (conversionRate && originalAmount) {
-      const rate = Number(conversionRate)
-      const convertedAmount = originalAmount * rate
-      if (!Number.isNaN(convertedAmount)) {
-        const v = enforceCurrencyPattern(
-          convertedAmount.toFixed(groupCurrency.decimal_digits),
-        )
+      const converted = convertToGroupCurrency(
+        Number(originalAmount),
+        Number(conversionRate),
+        groupCurrency,
+      )
+      if (converted !== null) {
+        const v = enforceCurrencyPattern(converted)
         const income = Number(v) < 0
         setIsIncome(income)
         if (income) form.setValue('isReimbursement', false)
@@ -435,6 +460,48 @@ export function ExpenseForm({
     form.watch('originalAmount'),
     form.watch('conversionRate'),
     form.getFieldState('originalAmount').isTouched,
+    convertFromGroupCurrency,
+    conversionRequired,
+  ])
+
+  // Group currency -> original currency, for repayments: the group-currency amount settles
+  // the balance, and the original amount is what the user actually transfers.
+  useEffect(() => {
+    if (!convertFromGroupCurrency || !conversionRequired) return
+    // When editing an existing expense, leave the stored amount alone until the user
+    // changes something that the conversion depends on.
+    if (
+      !isCreate &&
+      !form.getFieldState('amount').isDirty &&
+      !form.getFieldState('originalCurrency').isDirty &&
+      !form.getFieldState('conversionRate').isDirty
+    )
+      return
+
+    const converted = convertToOriginalCurrency(
+      Number(form.getValues('amount')),
+      Number(form.getValues('conversionRate')),
+      originalCurrency,
+    )
+    if (converted !== null) {
+      // A tiny balance can round down to zero in the original currency, which the schema
+      // rejects. Leave the field empty rather than block a form the user cannot correct.
+      form.setValue(
+        'originalAmount',
+        // String for consistent form handling, so trailing zeros survive; the schema
+        // coerces it, and it maps '' back to undefined.
+        (Number(converted) === 0
+          ? ''
+          : enforceCurrencyPattern(converted)) as any,
+      )
+    }
+  }, [
+    form.watch('amount'),
+    form.watch('conversionRate'),
+    convertFromGroupCurrency,
+    conversionRequired,
+    originalCurrency.code,
+    isCreate,
   ])
 
   let conversionRateMessage = ''
@@ -566,24 +633,39 @@ export function ExpenseForm({
             />
 
             <div
-              className={`sm:order-4 ${
-                !conversionRequired ? 'max-sm:hidden sm:invisible' : ''
-              } col-span-2 md:col-span-1 space-y-2`}
+              className={cn(
+                convertFromGroupCurrency ? 'sm:order-5' : 'sm:order-4',
+                !conversionRequired && 'max-sm:hidden sm:invisible',
+                'col-span-2 md:col-span-1 space-y-2',
+              )}
             >
               <FormField
                 control={form.control}
                 name="originalAmount"
                 render={({ field: { onChange, ...field } }) => (
                   <FormItem>
-                    <FormLabel>{t('originalAmountField.label')}</FormLabel>
+                    <FormLabel>
+                      {t(
+                        convertFromGroupCurrency
+                          ? 'originalAmountField.repaymentLabel'
+                          : 'originalAmountField.label',
+                      )}
+                    </FormLabel>
                     <div className="flex items-baseline gap-2">
                       <span>{originalCurrency.symbol}</span>
                       <FormControl>
                         <Input
-                          className="text-base max-w-[120px]"
+                          className={cn(
+                            'text-base max-w-[120px]',
+                            // Derived from the amount being settled: still selectable so it
+                            // can be copied, but not meant to be edited directly.
+                            convertFromGroupCurrency &&
+                              'bg-muted text-muted-foreground',
+                          )}
                           type="text"
                           inputMode="decimal"
                           placeholder="0.00"
+                          readOnly={convertFromGroupCurrency}
                           onChange={(event) => {
                             const v = enforceCurrencyPattern(event.target.value)
                             onChange(v)
@@ -596,6 +678,11 @@ export function ExpenseForm({
                         />
                       </FormControl>
                     </div>
+                    {convertFromGroupCurrency && (
+                      <FormDescription>
+                        {t('originalAmountField.repaymentDescription')}
+                      </FormDescription>
+                    )}
                     <FormDescription>
                       {isNaN(form.getValues('expenseDate').getTime()) ? (
                         t('conversionRateState.noDate')
@@ -705,7 +792,11 @@ export function ExpenseForm({
               control={form.control}
               name="amount"
               render={({ field: { onChange, ...field } }) => (
-                <FormItem className="sm:order-5">
+                <FormItem
+                  className={
+                    convertFromGroupCurrency ? 'sm:order-4' : 'sm:order-5'
+                  }
+                >
                   <FormLabel>{t('amountField.label')}</FormLabel>
                   <div className="flex items-baseline gap-2">
                     <span>{group.currency}</span>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -351,6 +351,8 @@ export async function getGroupExpenses(
       expenseDate: true,
       id: true,
       isReimbursement: true,
+      originalAmount: true,
+      originalCurrency: true,
       paidBy: { select: { id: true, name: true } },
       paidFor: {
         select: {

--- a/src/lib/currency-conversion.test.ts
+++ b/src/lib/currency-conversion.test.ts
@@ -1,0 +1,76 @@
+import { getCurrency } from './currency'
+import {
+  convertToGroupCurrency,
+  convertToOriginalCurrency,
+} from './currency-conversion'
+
+const EUR = getCurrency('EUR')
+const THB = getCurrency('THB')
+/** Has no minor units in practice */
+const JPY = getCurrency('JPY')
+
+describe('convertToGroupCurrency', () => {
+  it('converts using the rate and rounds to the group currency', () => {
+    // 1 EUR = 38.4 THB
+    expect(convertToGroupCurrency(130.21, 38.4, THB)).toBe('5000.06')
+  })
+
+  it('rounds to the group currency decimal digits', () => {
+    expect(convertToGroupCurrency(10, 163.456, JPY)).toBe('1635')
+  })
+
+  it('supports negative amounts (income)', () => {
+    expect(convertToGroupCurrency(-10, 38.4, THB)).toBe('-384.00')
+  })
+
+  it.each([0, -1, NaN, Infinity])('rejects the rate %p', (rate) => {
+    expect(convertToGroupCurrency(100, rate, THB)).toBeNull()
+  })
+
+  it('rejects a non-numeric amount', () => {
+    expect(convertToGroupCurrency(NaN, 38.4, THB)).toBeNull()
+  })
+})
+
+describe('convertToOriginalCurrency', () => {
+  it('converts back and rounds to the original currency', () => {
+    // Settling ฿5,000 at 1 EUR = 38.4 THB
+    expect(convertToOriginalCurrency(5000, 38.4, EUR)).toBe('130.21')
+  })
+
+  it('rounds to the original currency decimal digits', () => {
+    // 1 JPY = 0.0064 EUR
+    expect(convertToOriginalCurrency(100, 0.0064, JPY)).toBe('15625')
+  })
+
+  it.each([0, -1, NaN, Infinity])('rejects the rate %p', (rate) => {
+    expect(convertToOriginalCurrency(100, rate, EUR)).toBeNull()
+  })
+
+  it('rejects a non-numeric amount', () => {
+    expect(convertToOriginalCurrency(NaN, 38.4, EUR)).toBeNull()
+  })
+})
+
+describe('round trip', () => {
+  /**
+   * The original amount is rounded to its own currency, so converting it back does not
+   * always yield the exact group amount. The drift must stay below one minor unit of the
+   * original currency expressed in the group currency.
+   */
+  it.each([
+    [5000, 38.4],
+    [1234.56, 0.87],
+    [99.99, 1.0921],
+    [1, 145.3],
+  ])('stays within one minor unit for %p at rate %p', (groupAmount, rate) => {
+    const original = convertToOriginalCurrency(groupAmount, rate, EUR)
+    expect(original).not.toBeNull()
+    const roundTripped = convertToGroupCurrency(Number(original), rate, THB)
+    expect(roundTripped).not.toBeNull()
+    const drift = Math.abs(Number(roundTripped) - groupAmount)
+    expect(drift).toBeLessThanOrEqual(
+      (rate / 10 ** EUR.decimal_digits / 2) * 1.000001,
+    )
+  })
+})

--- a/src/lib/currency-conversion.ts
+++ b/src/lib/currency-conversion.ts
@@ -1,0 +1,52 @@
+import { Currency } from './currency'
+
+/**
+ * Conversion rates are always expressed as "1 original currency = `rate` group currency",
+ * matching how `useCurrencyRate` queries the API (the original currency is the base).
+ */
+function isUsableRate(rate: number) {
+  return Number.isFinite(rate) && rate > 0
+}
+
+/**
+ * Converts an amount given in the expense's original currency into the group currency.
+ * This is the direction used for regular expenses: the user enters what they actually
+ * spent abroad, and the group-currency amount follows.
+ *
+ * @returns the converted amount as a string with the group currency's decimal digits,
+ * or `null` if the inputs cannot produce a meaningful result.
+ */
+export function convertToGroupCurrency(
+  originalAmount: number,
+  rate: number,
+  groupCurrency: Currency,
+): string | null {
+  if (!Number.isFinite(originalAmount) || !isUsableRate(rate)) return null
+  const converted = originalAmount * rate
+  if (!Number.isFinite(converted)) return null
+  return converted.toFixed(groupCurrency.decimal_digits)
+}
+
+/**
+ * Converts an amount given in the group currency into the expense's original currency.
+ * This is the direction used for repayments: the group-currency amount is fixed by the
+ * balance being settled, and the amount to actually transfer follows.
+ *
+ * The result is rounded to the original currency's decimal digits, so converting it back
+ * will not always yield the exact group-currency amount. That is intentional: the
+ * group-currency amount stays the authoritative figure, and the original amount is only
+ * recorded for reference.
+ *
+ * @returns the converted amount as a string with the original currency's decimal digits,
+ * or `null` if the inputs cannot produce a meaningful result.
+ */
+export function convertToOriginalCurrency(
+  groupAmount: number,
+  rate: number,
+  originalCurrency: Currency,
+): string | null {
+  if (!Number.isFinite(groupAmount) || !isUsableRate(rate)) return null
+  const converted = groupAmount / rate
+  if (!Number.isFinite(converted)) return null
+  return converted.toFixed(originalCurrency.decimal_digits)
+}


### PR DESCRIPTION
# feat: settle up in a currency other than the group's

Part of the series in #553, and the last feature PR in it. Five commits,
7 files.

## The problem

A group created for a trip uses the local currency, so its balances are
denominated in it — but the repayment happens in the participants' own
currency. The expense form could already convert in one direction: you enter
the foreign amount, the group-currency amount follows. A repayment is the
mirror case, and it had no support at all, so settling up meant working the
transfer amount out by hand.

## What lands

"Mark as paid" now derives it. Picking a currency fills a read-only **Amount to
transfer** field with the converted value, using the existing Frankfurter rate
or a custom one. The two amount fields also swap visual order, so whichever one
drives the other comes first.

**The group-currency amount stays authoritative**, which is the property that
matters. It is what settles the balance, so a repayment still brings it to
exactly zero no matter how the transfer amount rounds — nothing ever recomputes
a balance from the original amount.

The direction is driven by the `isReimbursement` flag rather than by the URL
parameter, so editing an existing repayment behaves like creating one. When
editing, the stored amount is left alone until the user changes something the
conversion depends on; otherwise merely opening an old repayment would rewrite
it at today's rate.

## A pre-existing bug, fixed in commit 2

The shadcn `Button` renders a plain `<button>` and sets no `type`, so inside a
`<form>` it defaults to `type="submit"`. **Clicking "Refresh" next to the
conversion rate submits the expense** instead of refetching the rate.

I reproduced this rather than reasoning about it — against a build without the
fix, five seconds after the click the URL is `/groups/<id>/expenses` and the
expense list contains the reimbursement that was never meant to be saved. It is
independent of the rest of this PR; cherry-pick it out if you would rather ship
it separately. It is in here because it lives in the region this PR rewrites,
and stacking two PRs on the same block of `expense-form.tsx` costs a rebase.

## Five commits, in review order

1. **`currency-conversion.ts` + tests** — both directions as pure functions.
   **Stands alone: `check-types` clean, 19 tests green with no caller in the
   tree.**
2. **The `type="button"` fix** — one line.
3. **The feature** — `expense-form.tsx` and `en-US` strings only.
4. **The expense card** showing the original amount, so the list tells you what
   actually moved. Droppable on its own.
5. **E2E coverage.** Also droppable.

Each conversion rounds to its *target* currency, so a round trip does not
return the exact starting amount. That is deliberate, and the round-trip tests
pin the drift to below half a minor unit rather than leaving it as a comment.

## Two smaller corrections that fall out

- A converted amount that rounds down to zero in the original currency was
  rejected by the schema — on a read-only field the user has no way to correct.
  It now clears the field instead.
- Submitting a form with no conversion deleted the amount and currency but left
  `conversionRate` set, so a rate could be stored with nothing to apply it to.
  All three are now dropped together.

## Verification

Against `50c606c`, Node 24 / npm 11: `npm ci --ignore-scripts`,
`npx prisma generate`, `check-types`, `check-formatting`, `npm test` — 9 suites,
**148 tests** (129 before) — and a full `npm run build`.

**Your E2E suite: 41/41**, including `multi-currency.spec.ts` and
`reimbursements.spec.ts`, the two this PR could most plausibly have broken since
it rewrites the conversion effects and the repayment defaults they both exercise.

The three new specs were mutation-checked:

```
expect(locator).toHaveValue(expected)
Expected: "41.00"
Received: "40.00"

expect(locator).toContainText(expected)
Received string: "ReimbursementPaid by Bob for Alice$50.00€40.00Aug 16, 2026"
```

The second is the one worth reading: the card really does carry both figures —
`$50.00` settles the balance, `€40.00` is what was transferred.

**One of the three specs was initially vacuous, and mutation-checking did not
catch it.** The "Refresh does not submit" test asserts that *nothing* happens,
and my first version checked the URL immediately after the click — which
matched the create URL before the submit's navigation landed, so it passed
against the unfixed code. Flipping an expected value proves nothing for an
assertion like that; the only thing that works is running it against the
unfixed build, which is what turned it up. It now waits out a settling period
and is verified to fail without commit 2.

`npm run lint` reports **19 warnings / 0 errors**, up from 16. All three new
ones are `react-hooks/exhaustive-deps` on the effect this PR adds — the same
`form.watch(...)`-in-deps shape as the ten already in that file. I kept the
surrounding file's style rather than hoisting the watches in one effect and not
the others, but happy to change it if you would rather the count stayed put.

E2E ran against a real Postgres 16 and the built app rather than the compose
stack — no Docker daemon where I work — driven through `E2E_BASE_URL`. Same app,
same specs; it does not exercise the image build or `scripts/e2e.sh`.

## Not in this PR

The `originalAmount` data migration my fork carried alongside this feature.
#550 already landed a better one — mine assumed every row predated the cutover
and would have double-converted anything written after #425. Nothing of it goes
upstream.
