### PR TITLE
feat: configurable OpenAI endpoint, models, and structured outputs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ POSTGRES_URL_NON_POOLING=postgresql://postgres:1234@localhost
 
 NEXT_PUBLIC_DEFAULT_CURRENCY_CODE=""
 
+# OpenAI options for the receipt and category features (see the README).
+# OPENAI_BASE_URL=          # OpenAI-compatible endpoint; defaults to OpenAI
+# OPENAI_MODEL_RECEIPT_EXTRACT=gpt-5-nano
+# OPENAI_MODEL_CATEGORY_EXTRACT=gpt-5-nano
+
 # Analytics is disabled unless a provider is selected. See the README.
 # ANALYTICS_PROVIDER=console
 # ANALYTICS_PROVIDER=plausible

--- a/README.md
+++ b/README.md
@@ -192,18 +192,20 @@ S3_UPLOAD_ENDPOINT=http://localhost:9000
 
 ### Create expense from receipt
 
-You can offer users to create expense by uploading a receipt. This feature relies on [OpenAI GPT-4 with Vision](https://platform.openai.com/docs/guides/vision) and a public S3 storage endpoint.
+You can offer users to create expense by uploading a receipt. This feature relies on a [vision-capable OpenAI model](https://platform.openai.com/docs/guides/vision) and a public S3 storage endpoint.
 
 To enable the feature:
 
 - You must enable expense documents feature as well (see section above). That might change in the future, but for now we need to store images to make receipt scanning work.
-- Subscribe to OpenAI API and get access to GPT 4 with Vision (you might need to buy credits in advance).
+- Subscribe to OpenAI API and get access to a vision-capable model (you might need to buy credits in advance).
 - Update your environment variables with appropriate values:
 
 ```.env
 NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT=true
 OPENAI_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
+
+The model defaults to `gpt-5-nano` and can be changed with the optional `OPENAI_MODEL_RECEIPT_EXTRACT` variable — a larger model reads poor-quality photos more reliably, at a higher price per scan.
 
 ### Deduce category from title
 
@@ -213,6 +215,22 @@ You can offer users to automatically deduce the expense category from the title.
 NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT=true
 OPENAI_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
+
+The model defaults to `gpt-5-nano` and can be changed with the optional `OPENAI_MODEL_CATEGORY_EXTRACT` variable.
+
+### Using another OpenAI-compatible provider
+
+Both AI features above talk to the official OpenAI API by default. Set the optional `OPENAI_BASE_URL` variable to point them at a self-hosted or alternative provider instead:
+
+```.env
+OPENAI_BASE_URL=http://localhost:11434/v1
+OPENAI_MODEL_RECEIPT_EXTRACT=name-of-a-vision-model
+OPENAI_MODEL_CATEGORY_EXTRACT=name-of-a-text-model
+```
+
+Whichever provider you choose has to support the `json_schema` response format ([structured outputs](https://platform.openai.com/docs/guides/structured-outputs)), and the receipt feature additionally needs image input. If a response does not match the expected schema, the app reports that nothing could be extracted rather than filling the form with guesses.
+
+If your environment file was created on Windows, make sure it uses **LF line endings**. A trailing carriage return makes `OPENAI_API_KEY` fail authentication and silently switches feature flags off.
 
 ### Analytics
 

--- a/container.env.example
+++ b/container.env.example
@@ -5,6 +5,11 @@ POSTGRES_PASSWORD=1234
 POSTGRES_PRISMA_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db
 POSTGRES_URL_NON_POOLING=postgresql://postgres:${POSTGRES_PASSWORD}@db
 
+# OpenAI options for the receipt and category features (see the README).
+# OPENAI_BASE_URL=          # OpenAI-compatible endpoint; defaults to OpenAI
+# OPENAI_MODEL_RECEIPT_EXTRACT=gpt-5-nano
+# OPENAI_MODEL_CATEGORY_EXTRACT=gpt-5-nano
+
 # analytics
 # Disabled unless a provider is selected. See the README.
 # ANALYTICS_PROVIDER=plausible

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.test.ts
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.test.ts
@@ -1,0 +1,133 @@
+// See the note in src/components/expense-form-actions.test.ts on why this is a
+// `var` reached through an arrow.
+var mockCreate = jest.fn()
+
+jest.mock('openai', () => ({
+  __esModule: true,
+  default: class {
+    chat = {
+      completions: { create: (...args: unknown[]) => mockCreate(...args) },
+    }
+  },
+}))
+jest.mock('../../../../lib/env', () => ({
+  env: {
+    OPENAI_API_KEY: 'sk-test',
+    OPENAI_BASE_URL: undefined,
+    OPENAI_MODEL_RECEIPT_EXTRACT: 'test-vision-model',
+  },
+}))
+jest.mock('../../../../lib/featureFlags', () => ({
+  getRuntimeFeatureFlags: async () => ({ enableReceiptExtract: true }),
+}))
+jest.mock('../../../../lib/api', () => ({
+  getCategories: async () => [
+    { id: 0, grouping: 'General', name: 'General' },
+    { id: 4, grouping: 'Transport', name: 'Taxi' },
+  ],
+}))
+jest.mock('../../../../lib/uploaded-image-url', () => ({
+  isAllowedUploadUrl: (url: string) => url.startsWith('https://uploads.test/'),
+}))
+
+import { extractExpenseInformationFromImage } from './create-from-receipt-button-actions'
+
+const IMAGE = 'https://uploads.test/receipt.jpg'
+
+function respondWith(content: string | null) {
+  mockCreate.mockResolvedValue({ choices: [{ message: { content } }] })
+}
+
+const NOTHING_EXTRACTED = {
+  amount: null,
+  categoryId: null,
+  date: null,
+  title: null,
+}
+
+describe('extractExpenseInformationFromImage', () => {
+  beforeEach(() => mockCreate.mockReset())
+
+  it('returns every field the model read off the receipt', async () => {
+    respondWith(
+      JSON.stringify({
+        amount: 42.5,
+        categoryId: '4',
+        date: '2026-03-01',
+        title: 'Dinner',
+      }),
+    )
+    expect(await extractExpenseInformationFromImage(IMAGE)).toEqual({
+      amount: 42.5,
+      categoryId: '4',
+      date: '2026-03-01',
+      title: 'Dinner',
+    })
+  })
+
+  it('keeps a title containing a comma intact', async () => {
+    respondWith(
+      JSON.stringify({
+        amount: 42.5,
+        categoryId: '4',
+        date: '2026-03-01',
+        title: 'Dinner, drinks and tip',
+      }),
+    )
+    const info = await extractExpenseInformationFromImage(IMAGE)
+    expect(info.title).toBe('Dinner, drinks and tip')
+    expect(info.amount).toBe(42.5)
+  })
+
+  it('asks for a strict JSON schema, and for the configured model', async () => {
+    respondWith(
+      JSON.stringify({
+        amount: 1,
+        categoryId: '0',
+        date: '2026-03-01',
+        title: 'x',
+      }),
+    )
+    await extractExpenseInformationFromImage(IMAGE)
+
+    const request = mockCreate.mock.calls[0][0]
+    expect(request.model).toBe('test-vision-model')
+    expect(request.response_format.type).toBe('json_schema')
+    expect(request.response_format.json_schema.strict).toBe(true)
+  })
+
+  it.each([
+    [
+      'a field of the wrong type',
+      JSON.stringify({
+        amount: '42.5',
+        categoryId: '4',
+        date: '2026-03-01',
+        title: 'x',
+      }),
+    ],
+    ['a missing field', JSON.stringify({ amount: 42.5, categoryId: '4' })],
+    ['a response that is not JSON', '42.5,4,2026-03-01,Dinner'],
+    ['an empty response', ''],
+  ])('reports nothing extracted for %s', async (_name, content) => {
+    respondWith(content)
+    expect(await extractExpenseInformationFromImage(IMAGE)).toEqual(
+      NOTHING_EXTRACTED,
+    )
+  })
+
+  it('reports nothing extracted when there is no content at all', async () => {
+    respondWith(null)
+    expect(await extractExpenseInformationFromImage(IMAGE)).toEqual(
+      NOTHING_EXTRACTED,
+    )
+  })
+
+  it('refuses an image URL the app did not upload', async () => {
+    respondWith(JSON.stringify({ amount: 1 }))
+    await expect(
+      extractExpenseInformationFromImage('https://evil.example/receipt.jpg'),
+    ).rejects.toThrow('Invalid image URL.')
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
@@ -7,7 +7,10 @@ import { formatCategoryForAIPrompt } from '@/lib/utils'
 import OpenAI from 'openai'
 import { z } from 'zod'
 
-const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY })
+const openai = new OpenAI({
+  apiKey: env.OPENAI_API_KEY,
+  baseURL: env.OPENAI_BASE_URL,
+})
 
 // The model is contractually bound to this shape by `strict: true` below, but
 // the response is still parsed rather than trusted: a self-hosted or older
@@ -39,7 +42,7 @@ export async function extractExpenseInformationFromImage(imageUrl: string) {
   const categories = await getCategories()
 
   const completion = await openai.chat.completions.create({
-    model: 'gpt-5-nano',
+    model: env.OPENAI_MODEL_RECEIPT_EXTRACT,
     response_format: {
       type: 'json_schema',
       json_schema: {

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
@@ -5,9 +5,19 @@ import { getRuntimeFeatureFlags } from '@/lib/featureFlags'
 import { isAllowedUploadUrl } from '@/lib/uploaded-image-url'
 import { formatCategoryForAIPrompt } from '@/lib/utils'
 import OpenAI from 'openai'
-import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/index.mjs'
+import { z } from 'zod'
 
 const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY })
+
+// The model is contractually bound to this shape by `strict: true` below, but
+// the response is still parsed rather than trusted: a self-hosted or older
+// endpoint may ignore the schema.
+const receiptResponseSchema = z.object({
+  amount: z.number(),
+  categoryId: z.string(),
+  date: z.string(),
+  title: z.string(),
+})
 
 export async function extractExpenseInformationFromImage(imageUrl: string) {
   'use server'
@@ -28,8 +38,26 @@ export async function extractExpenseInformationFromImage(imageUrl: string) {
 
   const categories = await getCategories()
 
-  const body: ChatCompletionCreateParamsNonStreaming = {
+  const completion = await openai.chat.completions.create({
     model: 'gpt-5-nano',
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: 'receipt_response',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: {
+            amount: { type: 'number' },
+            categoryId: { type: 'string' },
+            date: { type: 'string' },
+            title: { type: 'string' },
+          },
+          required: ['amount', 'categoryId', 'date', 'title'],
+          additionalProperties: false,
+        },
+      },
+    },
     messages: [
       {
         role: 'user',
@@ -43,8 +71,7 @@ export async function extractExpenseInformationFromImage(imageUrl: string) {
                 (category) => formatCategoryForAIPrompt(category),
               )}.
               Guess the expense’s date and store it as yyyy-mm-dd.
-              Guess a title for the expense.
-              Return the amount, the category, the date and the title with just a comma between them, without anything else.`,
+              Guess a title for the expense.`,
           },
         ],
       },
@@ -53,20 +80,26 @@ export async function extractExpenseInformationFromImage(imageUrl: string) {
         content: [{ type: 'image_url', image_url: { url: imageUrl } }],
       },
     ],
-  }
-  const completion = await openai.chat.completions.create(body)
+  })
 
-  const [amountString, categoryId, date, title] = completion.choices
-    .at(0)
-    ?.message.content?.split(',') ?? [null, null, null, null]
-  // The model is asked for a plain number, but nothing guarantees it obliges.
-  // Report "not extracted" rather than passing NaN on to the expense form.
-  const amount = Number(amountString)
+  const messageContent = completion.choices.at(0)?.message.content
+  const parsed = (() => {
+    if (!messageContent) return null
+    try {
+      return receiptResponseSchema.parse(JSON.parse(messageContent))
+    } catch {
+      // Malformed or schema-violating output: report "nothing extracted"
+      // rather than passing junk on to the expense form.
+      return null
+    }
+  })()
+
+  const amount = Number(parsed?.amount)
   return {
     amount: Number.isFinite(amount) ? amount : null,
-    categoryId,
-    date,
-    title,
+    categoryId: parsed?.categoryId ?? null,
+    date: parsed?.date ?? null,
+    title: parsed?.title ?? null,
   }
 }
 

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -559,7 +559,12 @@ export function ExpenseForm({
                       {...field}
                       onBlur={async () => {
                         field.onBlur() // avoid skipping other blur event listeners since we overwrite `field`
-                        if (runtimeFeatureFlags.enableCategoryExtract) {
+                        // Skip empty titles: tabbing through the field would
+                        // otherwise spend an API call to categorise "".
+                        if (
+                          runtimeFeatureFlags.enableCategoryExtract &&
+                          field.value.trim()
+                        ) {
                           setCategoryLoading(true)
                           const { categoryId } = await extractCategoryFromTitle(
                             field.value,

--- a/src/components/expense-form-actions.test.ts
+++ b/src/components/expense-form-actions.test.ts
@@ -1,0 +1,90 @@
+// `var` and the indirection through an arrow are both deliberate: the module
+// under test constructs its OpenAI client at import time, which jest hoists
+// above this file's own initialisation.
+var mockCreate = jest.fn()
+
+jest.mock('openai', () => ({
+  __esModule: true,
+  default: class {
+    chat = {
+      completions: { create: (...args: unknown[]) => mockCreate(...args) },
+    }
+  },
+}))
+jest.mock('../lib/env', () => ({
+  env: {
+    OPENAI_API_KEY: 'sk-test',
+    OPENAI_BASE_URL: undefined,
+    OPENAI_MODEL_CATEGORY_EXTRACT: 'test-model',
+  },
+}))
+jest.mock('../lib/featureFlags', () => ({
+  getRuntimeFeatureFlags: async () => ({ enableCategoryExtract: true }),
+}))
+jest.mock('../lib/api', () => ({
+  getCategories: async () => [
+    { id: 0, grouping: 'General', name: 'General' },
+    { id: 4, grouping: 'Transport', name: 'Taxi' },
+  ],
+}))
+
+import { extractCategoryFromTitle } from './expense-form-actions'
+
+function respondWith(content: string | null) {
+  mockCreate.mockResolvedValue({ choices: [{ message: { content } }] })
+}
+
+describe('extractCategoryFromTitle', () => {
+  beforeEach(() => mockCreate.mockReset())
+
+  it('returns the category the model picked', async () => {
+    respondWith(JSON.stringify({ categoryId: 4 }))
+    expect(await extractCategoryFromTitle('Taxi to the airport')).toEqual({
+      categoryId: 4,
+    })
+  })
+
+  it('asks for a strict JSON schema, and for the configured model', async () => {
+    respondWith(JSON.stringify({ categoryId: 4 }))
+    await extractCategoryFromTitle('Taxi to the airport')
+
+    const request = mockCreate.mock.calls[0][0]
+    expect(request.model).toBe('test-model')
+    expect(request.response_format.type).toBe('json_schema')
+    expect(request.response_format.json_schema.strict).toBe(true)
+    // Both were tuned for a free-text answer and are rejected by the models
+    // that support structured outputs.
+    expect(request.max_tokens).toBeUndefined()
+    expect(request.temperature).toBeUndefined()
+  })
+
+  it('truncates the title before sending it', async () => {
+    respondWith(JSON.stringify({ categoryId: 4 }))
+    await extractCategoryFromTitle('T'.repeat(100))
+
+    const userMessage = mockCreate.mock.calls[0][0].messages.at(-1)
+    expect(userMessage.content).toHaveLength(40)
+  })
+
+  // Everything below must degrade to the "General" fallback rather than throw:
+  // a self-hosted endpoint may ignore the schema entirely.
+  it.each([
+    ['an id that does not exist', JSON.stringify({ categoryId: 9999 })],
+    ['a value of the wrong type', JSON.stringify({ categoryId: 'four' })],
+    ['a missing field', JSON.stringify({})],
+    ['a response that is not JSON', 'Transport'],
+    ['an empty response', ''],
+  ])('falls back to the first category for %s', async (_name, content) => {
+    respondWith(content)
+    expect(await extractCategoryFromTitle('Taxi to the airport')).toEqual({
+      categoryId: 0,
+    })
+  })
+
+  it('falls back to the first category when there is no content at all', async () => {
+    respondWith(null)
+    expect(await extractCategoryFromTitle('Taxi to the airport')).toEqual({
+      categoryId: 0,
+    })
+  })
+})

--- a/src/components/expense-form-actions.tsx
+++ b/src/components/expense-form-actions.tsx
@@ -6,7 +6,10 @@ import { formatCategoryForAIPrompt } from '@/lib/utils'
 import OpenAI from 'openai'
 import { z } from 'zod'
 
-const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY })
+const openai = new OpenAI({
+  apiKey: env.OPENAI_API_KEY,
+  baseURL: env.OPENAI_BASE_URL,
+})
 
 /** Limit of characters to be evaluated. May help avoiding abuse when using AI. */
 const limit = 40 // ~10 tokens
@@ -32,7 +35,7 @@ export async function extractCategoryFromTitle(description: string) {
   const categories = await getCategories()
 
   const completion = await openai.chat.completions.create({
-    model: 'gpt-5-nano',
+    model: env.OPENAI_MODEL_CATEGORY_EXTRACT,
     response_format: {
       type: 'json_schema',
       json_schema: {

--- a/src/components/expense-form-actions.tsx
+++ b/src/components/expense-form-actions.tsx
@@ -4,12 +4,16 @@ import { env } from '@/lib/env'
 import { getRuntimeFeatureFlags } from '@/lib/featureFlags'
 import { formatCategoryForAIPrompt } from '@/lib/utils'
 import OpenAI from 'openai'
-import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/index.mjs'
+import { z } from 'zod'
 
 const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY })
 
 /** Limit of characters to be evaluated. May help avoiding abuse when using AI. */
 const limit = 40 // ~10 tokens
+
+// See the note in create-from-receipt-button-actions.ts: `strict: true` binds
+// the model to this shape, but the response is parsed rather than trusted.
+const categoryResponseSchema = z.object({ categoryId: z.number() })
 
 /**
  * Attempt extraction of category from expense title
@@ -27,15 +31,26 @@ export async function extractCategoryFromTitle(description: string) {
 
   const categories = await getCategories()
 
-  const body: ChatCompletionCreateParamsNonStreaming = {
-    model: 'gpt-3.5-turbo',
-    temperature: 0.1, // try to be highly deterministic so that each distinct title may lead to the same category every time
-    max_tokens: 1, // category ids are unlikely to go beyond ~4 digits so limit possible abuse
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-5-nano',
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: 'category_response',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: { categoryId: { type: 'integer' } },
+          required: ['categoryId'],
+          additionalProperties: false,
+        },
+      },
+    },
     messages: [
       {
         role: 'system',
         content: `
-        Task: Receive expense titles. Respond with the most relevant category ID from the list below. Respond with the ID only.
+        Task: Receive expense titles. Respond with the most relevant category ID from the list below.
         Categories: ${categories.map((category) =>
           formatCategoryForAIPrompt(category),
         )}
@@ -50,12 +65,19 @@ export async function extractCategoryFromTitle(description: string) {
         content: description.substring(0, limit),
       },
     ],
-  }
-  const completion = await openai.chat.completions.create(body)
+  })
   const messageContent = completion.choices.at(0)?.message.content
+  const parsed = (() => {
+    if (!messageContent) return null
+    try {
+      return categoryResponseSchema.parse(JSON.parse(messageContent))
+    } catch {
+      return null
+    }
+  })()
   // ensure the returned id actually exists
   const category = categories.find((category) => {
-    return category.id === Number(messageContent)
+    return category.id === parsed?.categoryId
   })
   // fall back to first category (should be "General") if no category matches the output
   return { categoryId: category?.id || 0 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -3,7 +3,9 @@ import { ANALYTICS_PROVIDER_IDS } from './analytics/provider-ids'
 
 const interpretEnvVarAsBool = (val: unknown): boolean => {
   if (typeof val !== 'string') return false
-  return ['true', 'yes', '1', 'on'].includes(val.toLowerCase())
+  // .trim() guards against trailing whitespace such as the CR from a CRLF
+  // (Windows) .env file, which would otherwise make "true\r" !== "true".
+  return ['true', 'yes', '1', 'on'].includes(val.trim().toLowerCase())
 }
 
 /**
@@ -44,7 +46,9 @@ const envSchema = z
       interpretEnvVarAsBool,
       z.boolean().default(false),
     ),
-    OPENAI_API_KEY: z.string().optional(),
+    // .trim() guards against a trailing CR from a CRLF (Windows) .env file: a
+    // key ending in "\r" would otherwise fail authentication with a 401.
+    OPENAI_API_KEY: z.string().trim().optional(),
     // Analytics is disabled unless a provider is selected. These are read on
     // the server and passed to the client as props, so they are deliberately
     // not `NEXT_PUBLIC_`: a single image stays configurable at container start.

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -49,6 +49,23 @@ const envSchema = z
     // .trim() guards against a trailing CR from a CRLF (Windows) .env file: a
     // key ending in "\r" would otherwise fail authentication with a 401.
     OPENAI_API_KEY: z.string().trim().optional(),
+    // Optional OpenAI-compatible endpoint (a self-hosted or alternative
+    // provider). When unset the SDK's default — the official API — is used.
+    OPENAI_BASE_URL: z.preprocess(
+      interpretBlankEnvVarAsUndefined,
+      z.string().trim().url().optional(),
+    ),
+    // The models each feature uses. Both default to what the code used before
+    // they were configurable; a provider set through OPENAI_BASE_URL will
+    // almost certainly need different names.
+    OPENAI_MODEL_RECEIPT_EXTRACT: z.preprocess(
+      interpretBlankEnvVarAsUndefined,
+      z.string().trim().default('gpt-5-nano'),
+    ),
+    OPENAI_MODEL_CATEGORY_EXTRACT: z.preprocess(
+      interpretBlankEnvVarAsUndefined,
+      z.string().trim().default('gpt-5-nano'),
+    ),
     // Analytics is disabled unless a provider is selected. These are read on
     // the server and passed to the client as props, so they are deliberately
     // not `NEXT_PUBLIC_`: a single image stays configurable at container start.


### PR DESCRIPTION
# feat: configurable OpenAI endpoint, models, and structured outputs

Part of the series in #553. Four commits, 8 files, no dependency changes.

Both AI features asked the model for prose and then took the answer apart by
hand. This replaces that with `json_schema` structured outputs, makes the model
names configurable, and — since neither path had a single test — adds 18.

## What was actually wrong, measured rather than assumed

I stood up a stub OpenAI-compatible endpoint and pointed the current `main` at
it, which turned up one thing I had wrong and two worth stating precisely.

**`OPENAI_BASE_URL` already works today.** The SDK falls back to
`process.env.OPENAI_BASE_URL` when no `baseURL` is passed, so requests from
current `main` do reach an alternative provider — I watched them arrive. I had
planned this PR as "add a base URL option"; that framing was wrong. What
actually blocks a self-hosted provider is the *model*: the redirected request
asks it for `gpt-3.5-turbo`, a name it has never heard of. So this PR adds the
two model variables and merely *declares* `OPENAI_BASE_URL` in the env schema,
so behaviour that already exists becomes documented, validated as a URL, and
trimmed.

**The receipt parser mangles any title containing a comma.** It splits the
response on `,`, so a receipt the model titles `Dinner, drinks and tip` shifts
every field after it by one position. There is a test for exactly this case now.

**The category parser cannot distinguish "no category fits" from garbage.** It
caps the reply at one token and compares the raw string to a number, so any
stray character falls through to General with no way to tell that apart from a
genuine fallback.

## Four commits

1. **`fix: ignore trailing whitespace in environment variables`** — standalone
   bug fix, unrelated to the AI work except that it bites hardest there.
2. **`feat: ask the AI for JSON instead of parsing free text`** — the parsing
   change.
3. **`feat: make the OpenAI models configurable, and validate the endpoint`**.
4. **`test: cover both AI extraction paths`** — droppable on its own, though I'd
   rather it wasn't.

Each was checked to type-check and pass the suite on its own.

## The CRLF bug is live on `main` today

An `.env` saved with Windows line endings gives every value a trailing carriage
return. Reproduced both ways against `src/lib/env.ts`, with
`NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT="true\r"` and `OPENAI_API_KEY="sk-test\r"`:

| | flag | key |
|---|---|---|
| current `main` | `false` | `"sk-test\r"` |
| with commit 1 | `true` | `"sk-test"` |

So today a Windows-authored `.env` silently disables the feature — no error, no
log line — and if you get past that, the key fails authentication with a 401
that points at the key rather than at the file. One `.trim()` each.

## Structured outputs

`response_format: { type: 'json_schema', strict: true }` on both calls. The
response is still parsed with zod rather than trusted: `strict` is a contract
with OpenAI, not with whatever a self-hoster points `OPENAI_BASE_URL` at, and a
provider that ignores the schema should degrade to "nothing extracted" rather
than write junk into the form.

Two consequences I'd rather flag than bury:

- **The category model moves from `gpt-3.5-turbo` to `gpt-5-nano`.** This is
  forced: `json_schema` is unsupported before `gpt-4o-2024-08-06`. I picked
  `gpt-5-nano` because it is the model the receipt path already uses, rather
  than introducing a name this repo has never run. The receipt model is
  unchanged.
- **`temperature: 0.1` and `max_tokens: 1` are gone.** The gpt-5 family accepts
  neither, and both existed to constrain a free-text answer that no longer
  exists — the schema does that job now, and better: `max_tokens: 1` contradicted
  its own comment ("category ids are unlikely to go beyond ~4 digits") by
  capping the reply at a single token.

Also: the category call is now skipped when the title is blank, so tabbing
through an empty field no longer spends a request categorising `""`.

## Configuration

Three optional variables, all defaulting to today's behaviour, so an existing
deployment sees no change:

| | default |
|---|---|
| `OPENAI_MODEL_RECEIPT_EXTRACT` | `gpt-5-nano` |
| `OPENAI_MODEL_CATEGORY_EXTRACT` | `gpt-5-nano` |
| `OPENAI_BASE_URL` | unset → the official API |

Blank values are treated as unset, matching how the analytics variables already
behave, so listing a variable without a value does not resolve to an empty model
name. Verified: `OPENAI_MODEL_RECEIPT_EXTRACT=` yields `gpt-5-nano`, and
`OPENAI_MODEL_CATEGORY_EXTRACT="  llama3.2-vision  "` yields `llama3.2-vision`.

Passing `baseURL` explicitly does not change the unset case — the SDK applies its
own env fallback for an `undefined` option, so the two mechanisms agree.

**These stay `NEXT_PUBLIC_ENABLE_*`-gated as they are today.** Moving the feature
flags themselves to runtime variables is the next PR in the series and is
deliberately not mixed in here.

## Verification

Against `6135983`, Node 24 / npm 11: `check-types`, `check-formatting`,
`npm test` (**11 suites / 166 tests**, up from 9 / 148), `npm run lint`
(**19 warnings / 0 errors — unchanged from `main`**), and a full `npm run build`.

**E2E: 41/41.** Real Postgres 16, migrations applied from empty, the built app
under `next start`.

Beyond that, both actions were driven against a stub OpenAI-compatible endpoint
on a real socket — which is what produced the finding at the top of this
description. That exercise confirmed the request carries the configured model
and the strict schema, that `max_tokens` and `temperature` are gone, that a
title containing a comma survives, that all five malformed-response shapes
degrade rather than throw, and that the receipt path still refuses a URL the app
did not upload without reaching the model at all.

The new tests were mutation-checked, not just run: removing the `try`/`catch`
fails 3 of the 9 category tests, and simulating the old comma-splitting behaviour
fails the comma test and nothing else.

Two lint warnings appeared and were chased rather than accepted — an
`eslint-disable no-var` I had added was inert, since the rule is not enabled
here. Removed; back to 19.

## What I have not verified

The real OpenAI API. Every run above is against a stub, so this confirms what
Spliit sends and how it handles what comes back, but not that `gpt-5-nano`
answers a receipt well. Someone with a key and a real receipt should try both
features before this merges — particularly the category one, since its model
changes.
