### PR TITLE
feat: runtime-configurable feature flags and BASE_URL for prebuilt images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,29 @@
 POSTGRES_PRISMA_URL=postgresql://postgres:1234@localhost
 POSTGRES_URL_NON_POOLING=postgresql://postgres:1234@localhost
 
-NEXT_PUBLIC_DEFAULT_CURRENCY_CODE=""
+# Public URL this instance is reachable at. Defaults to http://localhost:3000.
+# BASE_URL=http://localhost:3000
+
+# Default currency pre-selected when creating a new group. Defaults to USD.
+# DEFAULT_CURRENCY_CODE=EUR
+
+# Opt-in features — uncomment to enable. See the README for what each needs.
+
+# Attach images to expenses (requires S3 storage):
+# ENABLE_EXPENSE_DOCUMENTS=true
+# S3_UPLOAD_KEY=
+# S3_UPLOAD_SECRET=
+# S3_UPLOAD_BUCKET=
+# S3_UPLOAD_REGION=
+# S3_UPLOAD_ENDPOINT=       # only needed for non-AWS S3 providers
+
+# Create expenses by scanning receipts (requires OpenAI and expense documents):
+# ENABLE_RECEIPT_EXTRACT=true
+# OPENAI_API_KEY=
+
+# Auto-suggest the expense category from its title (requires OpenAI):
+# ENABLE_CATEGORY_EXTRACT=true
+# OPENAI_API_KEY=
 
 # OpenAI options for the receipt and category features (see the README).
 # OPENAI_BASE_URL=          # OpenAI-compatible endpoint; defaults to OpenAI

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Force LF line endings on environment files. A CRLF .env makes every value end
+# in a stray carriage return, which used to disable feature flags silently and
+# break credentials. The parser now trims, but keeping these files LF-only stops
+# the problem at the source — including for any variable read directly from
+# process.env rather than through the schema.
+*.env text eol=lf
+.env text eol=lf
+.env.* text eol=lf

--- a/README.md
+++ b/README.md
@@ -167,6 +167,56 @@ The application has a health check endpoint that can be used to check if the app
 - `GET /api/health/readiness` or `GET /api/health` - Check if the application is ready to serve requests, including database connectivity.
 - `GET /api/health/liveness` - Check if the application is running, but not necessarily ready to serve requests.
 
+## Configuration
+
+Every variable below is read at runtime. For a container deployment, set them in
+`container.env` or pass them with `docker run -e`; no rebuild is required, which
+means the published image can be configured by whoever runs it.
+
+### Application URL
+
+Set `BASE_URL` to the public URL your instance is reachable at. It is used for
+metadata, the sitemap, `robots.txt`, and to accept server actions sent to that
+host.
+
+```.env
+BASE_URL=https://spliit.example.com
+```
+
+Defaults to `http://localhost:3000`.
+
+### Default currency
+
+Set `DEFAULT_CURRENCY_CODE` to pre-select a currency on the new-group form.
+
+```.env
+DEFAULT_CURRENCY_CODE=EUR
+```
+
+Defaults to `USD`.
+
+### Migrating from the `NEXT_PUBLIC_*` variables
+
+Earlier versions used `NEXT_PUBLIC_`-prefixed variables for the settings above
+and for the opt-in feature flags below. Next.js **inlines those into the app at
+build time**, so in a prebuilt image — like the published one — they are frozen
+at whatever the release build used and setting them at runtime does nothing. The
+runtime variables replace them:
+
+| Old (build-time)                       | New (runtime)              |
+| -------------------------------------- | -------------------------- |
+| `NEXT_PUBLIC_BASE_URL`                 | `BASE_URL`                 |
+| `NEXT_PUBLIC_DEFAULT_CURRENCY_CODE`    | `DEFAULT_CURRENCY_CODE`    |
+| `NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS` | `ENABLE_EXPENSE_DOCUMENTS` |
+| `NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT`   | `ENABLE_RECEIPT_EXTRACT`   |
+| `NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT`  | `ENABLE_CATEGORY_EXTRACT`  |
+
+**The old variables still work** — the runtime variant simply takes precedence
+when both are set, so there is nothing you have to change immediately. They
+remain the right choice if you build your own image and want a setting baked in.
+To migrate, drop the `NEXT_PUBLIC_` prefix and set the variable wherever your
+container gets its environment.
+
 ## Opt-in features
 
 ### Expense documents

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Spliit offers users to upload images (to an AWS S3 bucket) and attach them to ex
 - Update your environments variables with appropriate values:
 
 ```.env
-NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS=true
+ENABLE_EXPENSE_DOCUMENTS=true
 S3_UPLOAD_KEY=AAAAAAAAAAAAAAAAAAAA
 S3_UPLOAD_SECRET=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 S3_UPLOAD_BUCKET=name-of-s3-bucket
@@ -201,7 +201,7 @@ To enable the feature:
 - Update your environment variables with appropriate values:
 
 ```.env
-NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT=true
+ENABLE_RECEIPT_EXTRACT=true
 OPENAI_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
@@ -212,7 +212,7 @@ The model defaults to `gpt-5-nano` and can be changed with the optional `OPENAI_
 You can offer users to automatically deduce the expense category from the title. Since this feature relies on a OpenAI subscription, follow the signup instructions above and configure the following environment variables:
 
 ```.env
-NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT=true
+ENABLE_CATEGORY_EXTRACT=true
 OPENAI_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 

--- a/container.env.example
+++ b/container.env.example
@@ -5,6 +5,30 @@ POSTGRES_PASSWORD=1234
 POSTGRES_PRISMA_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db
 POSTGRES_URL_NON_POOLING=postgresql://postgres:${POSTGRES_PASSWORD}@db
 
+# Public URL this instance is reachable at. Defaults to http://localhost:3000.
+# BASE_URL=http://localhost:3000
+
+# Default currency pre-selected when creating a new group. Defaults to USD.
+# DEFAULT_CURRENCY_CODE=EUR
+
+# Opt-in features — uncomment to enable. See the README for what each needs.
+
+# Attach images to expenses (requires S3 storage):
+# ENABLE_EXPENSE_DOCUMENTS=true
+# S3_UPLOAD_KEY=
+# S3_UPLOAD_SECRET=
+# S3_UPLOAD_BUCKET=
+# S3_UPLOAD_REGION=
+# S3_UPLOAD_ENDPOINT=       # only needed for non-AWS S3 providers
+
+# Create expenses by scanning receipts (requires OpenAI and expense documents):
+# ENABLE_RECEIPT_EXTRACT=true
+# OPENAI_API_KEY=
+
+# Auto-suggest the expense category from its title (requires OpenAI):
+# ENABLE_CATEGORY_EXTRACT=true
+# OPENAI_API_KEY=
+
 # OpenAI options for the receipt and category features (see the README).
 # OPENAI_BASE_URL=          # OpenAI-compatible endpoint; defaults to OpenAI
 # OPENAI_MODEL_RECEIPT_EXTRACT=gpt-5-nano

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -31,7 +31,20 @@ const nextConfig = {
   // Required to run in a codespace (see https://github.com/vercel/next.js/issues/58019)
   experimental: {
     serverActions: {
-      allowedOrigins: ['localhost:3000'],
+      // localhost:3000 covers local dev and same-host container access; the
+      // configured base URL covers a deployment reached under its own domain,
+      // whose server actions would otherwise be rejected as cross-origin.
+      // An unparseable value is ignored here rather than thrown: this file is
+      // evaluated before the env schema runs, and its `Invalid URL` is far less
+      // useful than the validation error the schema is about to produce.
+      allowedOrigins: (() => {
+        const base = process.env.BASE_URL || process.env.NEXT_PUBLIC_BASE_URL
+        try {
+          return ['localhost:3000', ...(base ? [new URL(base).host] : [])]
+        } catch {
+          return ['localhost:3000']
+        }
+      })(),
     },
   },
 }

--- a/scripts/build.env
+++ b/scripts/build.env
@@ -9,6 +9,9 @@ POSTGRES_PRISMA_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db
 POSTGRES_URL_NON_POOLING=postgresql://postgres:${POSTGRES_PASSWORD}@db
 
 # app-minio
+# NEXT_PUBLIC_* flags are inlined at build time, so they stay false here. To
+# enable a feature in the prebuilt image, set the non-public counterpart
+# (ENABLE_*) in the container environment instead — no rebuild needed.
 NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS=false
 S3_UPLOAD_KEY=AAAAAAAAAAAAAAAAAAAA
 S3_UPLOAD_SECRET=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA

--- a/src/app/groups/[groupId]/expenses/page.tsx
+++ b/src/app/groups/[groupId]/expenses/page.tsx
@@ -2,7 +2,9 @@ import GroupExpensesPageClient from '@/app/groups/[groupId]/expenses/page.client
 import { env } from '@/lib/env'
 import { Metadata } from 'next'
 
-export const revalidate = 3600
+// Render at request time rather than caching for an hour, so the flag below
+// reflects the environment the container was started with.
+export const dynamic = 'force-dynamic'
 
 export const metadata: Metadata = {
   title: 'Expenses',
@@ -11,7 +13,9 @@ export const metadata: Metadata = {
 export default async function GroupExpensesPage() {
   return (
     <GroupExpensesPageClient
-      enableReceiptExtract={env.NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT}
+      enableReceiptExtract={
+        env.ENABLE_RECEIPT_EXTRACT || env.NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT
+      }
     />
   )
 }

--- a/src/app/groups/create/create-group.tsx
+++ b/src/app/groups/create/create-group.tsx
@@ -4,13 +4,18 @@ import { GroupForm } from '@/components/group-form'
 import { trpc } from '@/trpc/client'
 import { useRouter } from 'next/navigation'
 
-export const CreateGroup = () => {
+export const CreateGroup = ({
+  defaultCurrencyCode,
+}: {
+  defaultCurrencyCode: string
+}) => {
   const { mutateAsync } = trpc.groups.create.useMutation()
   const utils = trpc.useUtils()
   const router = useRouter()
 
   return (
     <GroupForm
+      defaultCurrencyCode={defaultCurrencyCode}
       onSubmit={async (groupFormValues) => {
         const { groupId } = await mutateAsync({ groupFormValues })
         await utils.groups.invalidate()

--- a/src/app/groups/create/page.tsx
+++ b/src/app/groups/create/page.tsx
@@ -1,4 +1,5 @@
 import { CreateGroup } from '@/app/groups/create/create-group'
+import { env } from '@/lib/env'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -6,5 +7,7 @@ export const metadata: Metadata = {
 }
 
 export default function CreateGroupPage() {
-  return <CreateGroup />
+  const defaultCurrencyCode =
+    env.DEFAULT_CURRENCY_CODE ?? env.NEXT_PUBLIC_DEFAULT_CURRENCY_CODE ?? 'USD'
+  return <CreateGroup defaultCurrencyCode={defaultCurrencyCode} />
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Toaster } from '@/components/ui/toaster'
 import { Analytics } from '@/lib/analytics/analytics'
 import { getAnalyticsConfig } from '@/lib/analytics/config'
-import { env } from '@/lib/env'
+import { effectiveBaseUrl } from '@/lib/env'
 import { TRPCProvider } from '@/trpc/client'
 import type { Metadata, Viewport } from 'next'
 import { NextIntlClientProvider, useTranslations } from 'next-intl'
@@ -19,7 +19,7 @@ import { Suspense } from 'react'
 import './globals.css'
 
 export const metadata: Metadata = {
-  metadataBase: new URL(env.NEXT_PUBLIC_BASE_URL),
+  metadataBase: new URL(effectiveBaseUrl),
   title: {
     default: 'Spliit · Share Expenses with Friends & Family',
     template: '%s · Spliit',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,9 @@
-import { env } from '@/lib/env'
+import { effectiveBaseUrl } from '@/lib/env'
 import { MetadataRoute } from 'next'
+
+// Rendered per request: a statically prerendered robots.txt would bake in the
+// build-time base URL, which is exactly what BASE_URL exists to override.
+export const dynamic = 'force-dynamic'
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -8,6 +12,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: '/',
       disallow: '/groups/',
     },
-    sitemap: `${env.NEXT_PUBLIC_BASE_URL}/sitemap.xml`,
+    sitemap: `${effectiveBaseUrl}/sitemap.xml`,
   }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,10 +1,13 @@
-import { env } from '@/lib/env'
+import { effectiveBaseUrl } from '@/lib/env'
 import { MetadataRoute } from 'next'
+
+// Rendered per request, for the same reason as robots.ts.
+export const dynamic = 'force-dynamic'
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: env.NEXT_PUBLIC_BASE_URL,
+      url: effectiveBaseUrl,
       lastModified: new Date(),
       changeFrequency: 'yearly',
       priority: 1,

--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -51,12 +51,15 @@ export type Props = {
     participantId?: string,
   ) => Promise<void>
   protectedParticipantIds?: string[]
+  /** Resolved on the server, since the runtime variable is not public. */
+  defaultCurrencyCode?: string
 }
 
 export function GroupForm({
   group,
   onSubmit,
   protectedParticipantIds = [],
+  defaultCurrencyCode = 'USD',
 }: Props) {
   const locale = useLocale()
   const t = useTranslations('GroupForm')
@@ -74,7 +77,7 @@ export function GroupForm({
           name: '',
           information: '',
           currency: '',
-          currencyCode: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY_CODE || 'USD', // TODO: If NEXT_PUBLIC_DEFAULT_CURRENCY_CODE, is not set, determine the default currency code based on locale
+          currencyCode: defaultCurrencyCode, // TODO: derive from the locale when not configured
           participants: [
             { name: t('Participants.John') },
             { name: t('Participants.Jane') },

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -32,6 +32,15 @@ const envSchema = z
       interpretEnvVarAsBool,
       z.boolean().default(false),
     ),
+    // Runtime (non-public) counterpart. Next.js inlines NEXT_PUBLIC_* vars into
+    // the bundle at build time, so they can never be changed in a prebuilt
+    // image; this one is read from the environment at runtime and can be
+    // toggled with `docker run -e ...`. Enabling either variable enables the
+    // feature, so existing NEXT_PUBLIC_* configuration keeps working.
+    ENABLE_EXPENSE_DOCUMENTS: z.preprocess(
+      interpretEnvVarAsBool,
+      z.boolean().default(false),
+    ),
     NEXT_PUBLIC_DEFAULT_CURRENCY_CODE: z.string().optional(),
     S3_UPLOAD_KEY: z.string().optional(),
     S3_UPLOAD_SECRET: z.string().optional(),
@@ -42,7 +51,17 @@ const envSchema = z
       interpretEnvVarAsBool,
       z.boolean().default(false),
     ),
+    // Runtime (non-public) counterpart, see ENABLE_EXPENSE_DOCUMENTS above.
+    ENABLE_RECEIPT_EXTRACT: z.preprocess(
+      interpretEnvVarAsBool,
+      z.boolean().default(false),
+    ),
     NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT: z.preprocess(
+      interpretEnvVarAsBool,
+      z.boolean().default(false),
+    ),
+    // Runtime (non-public) counterpart, see ENABLE_EXPENSE_DOCUMENTS above.
+    ENABLE_CATEGORY_EXTRACT: z.preprocess(
       interpretEnvVarAsBool,
       z.boolean().default(false),
     ),
@@ -93,8 +112,16 @@ const envSchema = z
     ),
   })
   .superRefine((env, ctx) => {
+    // Either spelling enables the feature, so either has to satisfy the
+    // dependency checks below.
+    const enableExpenseDocuments =
+      env.ENABLE_EXPENSE_DOCUMENTS || env.NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS
+    const enableReceiptExtract =
+      env.ENABLE_RECEIPT_EXTRACT || env.NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT
+    const enableCategoryExtract =
+      env.ENABLE_CATEGORY_EXTRACT || env.NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT
     if (
-      env.NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS &&
+      enableExpenseDocuments &&
       // S3_UPLOAD_ENDPOINT is fully optional as it will only be used for providers other than AWS
       (!env.S3_UPLOAD_BUCKET ||
         !env.S3_UPLOAD_KEY ||
@@ -104,18 +131,17 @@ const envSchema = z
       ctx.addIssue({
         code: ZodIssueCode.custom,
         message:
-          'If NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS is specified, then S3_* must be specified too',
+          'If ENABLE_EXPENSE_DOCUMENTS is set, then S3_* must be set too',
       })
     }
     if (
-      (env.NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT ||
-        env.NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT) &&
+      (enableReceiptExtract || enableCategoryExtract) &&
       !env.OPENAI_API_KEY
     ) {
       ctx.addIssue({
         code: ZodIssueCode.custom,
         message:
-          'If NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT or NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT is specified, then OPENAI_API_KEY must be specified too',
+          'If ENABLE_RECEIPT_EXTRACT or ENABLE_CATEGORY_EXTRACT is set, then OPENAI_API_KEY must be set too',
       })
     }
     if (env.ANALYTICS_PROVIDER === 'plausible' && !env.PLAUSIBLE_DOMAIN) {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -48,6 +48,12 @@ const envSchema = z
       interpretEnvVarAsBool,
       z.boolean().default(false),
     ),
+    // Runtime override for the currency pre-selected on the new-group form.
+    // Takes precedence over NEXT_PUBLIC_DEFAULT_CURRENCY_CODE.
+    DEFAULT_CURRENCY_CODE: z.preprocess(
+      interpretBlankEnvVarAsUndefined,
+      z.string().trim().optional(),
+    ),
     NEXT_PUBLIC_DEFAULT_CURRENCY_CODE: z.string().optional(),
     S3_UPLOAD_KEY: z.string().optional(),
     S3_UPLOAD_SECRET: z.string().optional(),

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -20,6 +20,13 @@ const envSchema = z
   .object({
     POSTGRES_URL_NON_POOLING: z.string().url(),
     POSTGRES_PRISMA_URL: z.string().url(),
+    // Runtime override for the public base URL, so a prebuilt image can be
+    // told where it is reachable without a rebuild. Takes precedence over
+    // NEXT_PUBLIC_BASE_URL, which is baked in at build time.
+    BASE_URL: z.preprocess(
+      interpretBlankEnvVarAsUndefined,
+      z.string().trim().url().optional(),
+    ),
     NEXT_PUBLIC_BASE_URL: z
       .string()
       .optional()
@@ -154,3 +161,7 @@ const envSchema = z
   })
 
 export const env = envSchema.parse(process.env)
+
+// The base URL to use everywhere: the runtime override when set, otherwise the
+// value baked in at build time.
+export const effectiveBaseUrl = env.BASE_URL ?? env.NEXT_PUBLIC_BASE_URL

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -2,11 +2,28 @@
 
 import { env } from './env'
 
+const parseFlag = (val: string | undefined) =>
+  ['true', 'yes', '1', 'on'].includes((val ?? '').trim().toLowerCase())
+
 export async function getRuntimeFeatureFlags() {
+  // The ENABLE_* vars are read from process.env on every call rather than from
+  // the module-level `env` snapshot, which is parsed once at import. In a
+  // long-running server the two are the same; reading live keeps this correct
+  // if the module is ever imported before the environment is complete.
+  //
+  // env.NEXT_PUBLIC_* are read from the snapshot on purpose: Next.js inlines
+  // them at build time, so the snapshot *is* the build-time value, which is the
+  // right answer for a self-built image.
   return {
-    enableExpenseDocuments: env.NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS,
-    enableReceiptExtract: env.NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT,
-    enableCategoryExtract: env.NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT,
+    enableExpenseDocuments:
+      parseFlag(process.env.ENABLE_EXPENSE_DOCUMENTS) ||
+      env.NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS,
+    enableReceiptExtract:
+      parseFlag(process.env.ENABLE_RECEIPT_EXTRACT) ||
+      env.NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT,
+    enableCategoryExtract:
+      parseFlag(process.env.ENABLE_CATEGORY_EXTRACT) ||
+      env.NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT,
   }
 }
 


### PR DESCRIPTION
# feat: runtime-configurable feature flags and BASE_URL for prebuilt images

Part of the series in #553. Five commits, 15 files, no dependency changes.

**The problem in one sentence: the image published to ghcr.io cannot be
configured by the person running it.** Every user-facing setting is a
`NEXT_PUBLIC_` variable, and Next.js inlines those into the bundle at build
time, so they are frozen at whatever the release build used. An operator who
sets `NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT=true` in their `docker run` sees
nothing happen, with no error to explain why.

This is the same argument #548 makes for the analytics variables — *read on the
server so a single image stays configurable at container start* — applied to
the feature flags, the base URL and the default currency.

## What it looks like

| Old (build-time)                       | New (runtime)              |
| -------------------------------------- | -------------------------- |
| `NEXT_PUBLIC_BASE_URL`                 | `BASE_URL`                 |
| `NEXT_PUBLIC_DEFAULT_CURRENCY_CODE`    | `DEFAULT_CURRENCY_CODE`    |
| `NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS` | `ENABLE_EXPENSE_DOCUMENTS` |
| `NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT`   | `ENABLE_RECEIPT_EXTRACT`   |
| `NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT`  | `ENABLE_CATEGORY_EXTRACT`  |

The old names keep working — the runtime variant takes precedence when both are
set — so this is additive for every existing deployment, and the
`NEXT_PUBLIC_` spellings remain the right choice if you build your own image
and want a setting baked in.

## Five commits

1. **`.gitattributes`: force LF on env files.** Complements #590's trimming fix
   by stopping the problem at the source, since `next.config.mjs` and
   `featureFlags` read some variables straight from `process.env`.
2. **Runtime feature flags.**
3. **`BASE_URL`.**
4. **`DEFAULT_CURRENCY_CODE`.**
5. **Docs.**

Each was checked to type-check, pass the suite and pass `check-formatting` on
its own.

## The verification is the interesting part

The claim this PR makes is *"one build, configured at start"*, and that is not
something type-checking can confirm. So I built once with every
`NEXT_PUBLIC_*` off, then started **that same build** twice with different
environments:

| | A: no runtime vars | B: same build, runtime vars set |
|---|---|---|
| `robots.txt` sitemap URL | `http://localhost:3000/…` | `https://spliit.example.com/…` |
| `sitemap.xml` `<loc>` | `http://localhost:3000` | `https://spliit.example.com` |
| new-group currency | `USD` | `EUR` |
| receipt-scan button | absent | present |

Then a second build using only the **old** `NEXT_PUBLIC_*` spelling, to check
the compatibility claim rather than assert it:

| | C: legacy vars, no runtime vars | D: same build, runtime vars too |
|---|---|---|
| `robots.txt` sitemap URL | `https://old-style.example/…` | `https://runtime-wins.example/…` |
| new-group currency | `GBP` | `JPY` |
| receipt-scan button | present | — |

C is the existing-deployment case and it behaves exactly as it does today. D
confirms the documented precedence.

**That exercise found a real bug in my own first attempt.** `BASE_URL` had no
effect on `robots.txt` or `sitemap.xml`, and only on those two: they are the
only statically prerendered routes in the app, so they are generated during the
build and capture the build-time URL no matter what the container is started
with. Both now render per request. Every other route was already
server-rendered on demand, so nothing else needed changing — I checked the
build's route table rather than sprinkling `force-dynamic` around.

The cost is that two low-traffic routes stop being static. If you would rather
keep them prerendered, the alternative is to leave `BASE_URL` documented as
build-time-only for those two files, which seemed worse than the trade.

## Implementation notes

- **`getRuntimeFeatureFlags` reads `ENABLE_*` from `process.env` on each call**,
  not from the module-level `env` snapshot. In a long-running server the two
  agree; reading live keeps it correct regardless of import order. The
  `NEXT_PUBLIC_*` half deliberately keeps reading the snapshot, because for
  those the snapshot *is* the build-time value, which is the right answer.
- **The env schema's dependency checks accept either spelling**, so
  `ENABLE_EXPENSE_DOCUMENTS=true` without `S3_*` still fails at startup the way
  `NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS=true` does today.
- **The group expenses page traded `revalidate = 3600` for `force-dynamic`.** A
  page cached for an hour cannot reflect the environment it was started with.
- **`DEFAULT_CURRENCY_CODE` is resolved on the server and passed down as a
  prop.** It was read inside a client component, which is why the
  `NEXT_PUBLIC_` prefix was needed in the first place; `GroupForm` keeps `'USD'`
  as its own default so the component stays usable standalone.
- **`next.config.mjs` ignores an unparseable base URL rather than throwing.** It
  is evaluated before the env schema runs, and a bare `Invalid URL` from a
  config file is much less useful than the validation error the schema is about
  to produce for the same input.

## Verification

Against `b036c03`, Node 24 / npm 11: `check-types`, `check-formatting`,
`npm test` (11 suites / 166 tests), `npm run lint` (**19 warnings / 0 errors —
unchanged from `main`**), and `npm run build`.

**E2E: 41/41**, real Postgres 16, migrations applied from empty, with the
runtime variables unset so the run matches today's defaults. Plus the four
configurations in the tables above.

## What I have not verified

`docker build` — no Docker daemon where I work — so the tables above come from
`npm run start` against a production build rather than from the image itself.
The mechanism is the same one the container uses, but if you want a belt-and-
braces check before merging, `docker run -e ENABLE_RECEIPT_EXTRACT=true` on a
freshly built image is the one command that would close it.
