### PR TITLE
build: standalone runtime image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,6 +54,11 @@ jobs:
           platforms: ${{ matrix.platform }}
           provenance: false # Disable provenance to avoid unknown/unknown
           sbom: false       # Disable sbom to avoid unknown/unknown
+          # Reuse layers from previous runs, scoped per architecture so the two
+          # matrix jobs do not overwrite each other's cache. The dependency
+          # install is the slow layer and only changes when the lockfile does.
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.REPO }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,16 @@ COPY ./package.json \
 COPY ./scripts ./scripts
 COPY ./prisma ./prisma
 
+# The registry occasionally resets a connection mid-install, which fails the
+# whole image build for a reason that has nothing to do with the code. Retry a
+# few times before giving up.
 RUN apk add --no-cache openssl && \
-    npm ci --ignore-scripts
+    for i in 1 2 3 4 5; do \
+      npm ci --ignore-scripts --fetch-retries=5 --fetch-timeout=600000 && exit 0; \
+      echo "npm ci failed (attempt $i of 5), retrying in 10s..."; \
+      sleep 10; \
+    done; \
+    exit 1
 
 COPY ./src ./src
 COPY ./messages ./messages

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,30 +35,65 @@ ENV NEXT_TELEMETRY_DISABLED=1
 COPY scripts/build.env .env
 RUN npm run build
 
-RUN rm -r .next/cache
+# Next.js copies .env into the standalone output, which would ship the mocked
+# build values (a database URL pointing at `db`, placeholder S3 and OpenAI
+# credentials) inside the image. Real configuration comes from the container
+# environment and would win, but a variable the operator *forgot* to set would
+# silently resolve to a build placeholder instead of failing. Drop it.
+RUN rm -f .next/standalone/.env
 
-FROM node:24-alpine AS runtime-deps
+# The standalone output traces its own dependencies, so the runtime stage no
+# longer installs a production node_modules. What it does still need is the
+# Prisma CLI, to run `migrate deploy` at container start — and the CLI is not
+# part of the app's module graph, so nothing traces it.
+#
+# It gets its own isolated install rather than being copied out of the base
+# stage: that stage installs with --ignore-scripts (the repo's postinstall runs
+# migrate deploy, which cannot run at build time), so @prisma/engines never
+# downloads the schema engine that `migrate deploy` needs. Installing the same
+# version here, with scripts, produces a complete self-contained CLI.
+FROM node:24-alpine AS prisma-cli
 
-WORKDIR /usr/app
-COPY --from=base /usr/app/package.json /usr/app/package-lock.json /usr/app/next.config.mjs ./
-COPY --from=base /usr/app/prisma ./prisma
-
-# No `prisma generate` here: the generated client is bundled into .next by the
-# build, and regenerating would need the source tree this stage does not have.
-RUN npm ci --omit=dev --ignore-scripts
+WORKDIR /opt/prisma-cli
+ENV CHECKPOINT_DISABLE=1
+RUN apk add --no-cache openssl
+COPY --from=base /usr/app/node_modules/prisma/package.json ./_prisma.json
+RUN PRISMA_VERSION="$(node -p "require('./_prisma.json').version")" && \
+    rm -f ./_prisma.json && \
+    npm init -y > /dev/null && \
+    for i in 1 2 3 4 5; do \
+      npm install --no-audit --no-fund --fetch-retries=5 \
+        --fetch-timeout=600000 "prisma@${PRISMA_VERSION}" && exit 0; \
+      echo "prisma install failed (attempt $i of 5), retrying in 10s..."; \
+      sleep 10; \
+    done; \
+    exit 1
 
 FROM node:24-alpine AS runner
 
 EXPOSE 3000/tcp
 WORKDIR /usr/app
 
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+# The standalone server binds to localhost by default, which is unreachable
+# from outside the container.
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
+RUN apk add --no-cache openssl
+
+# The traced server, plus the two things tracing cannot know about: the static
+# assets it serves and the public/ directory.
+COPY --from=base /usr/app/.next/standalone ./
+COPY --from=base /usr/app/.next/static ./.next/static
+COPY ./public ./public
+
 # prisma.config.ts carries the connection URLs that used to live in
 # schema.prisma; `prisma migrate deploy` reads it at container start.
-COPY --from=base /usr/app/package.json /usr/app/package-lock.json /usr/app/next.config.mjs /usr/app/prisma.config.ts ./
-COPY --from=runtime-deps /usr/app/node_modules ./node_modules
-COPY ./public ./public
-COPY ./scripts ./scripts
 COPY --from=base /usr/app/prisma ./prisma
-COPY --from=base /usr/app/.next ./.next
+COPY --from=base /usr/app/prisma.config.ts ./
+COPY --from=prisma-cli /opt/prisma-cli/node_modules ./node_modules
+COPY ./scripts ./scripts
 
 ENTRYPOINT ["/bin/sh", "/usr/app/scripts/container-entrypoint.sh"]

--- a/compose.e2e.yaml
+++ b/compose.e2e.yaml
@@ -30,7 +30,7 @@ services:
     healthcheck:
       # 127.0.0.1 rather than localhost: busybox may resolve localhost to ::1.
       # /api/health/readiness runs `SELECT 1`, and scripts/container-entrypoint.sh
-      # runs `prisma migrate deploy` *before* `npm run start` -- so any 200 here
+      # runs `prisma migrate deploy` *before* starting the server -- so any 200 here
       # proves the schema is migrated and the app is serving.
       test:
         [

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,6 +24,10 @@ if (process.env.S3_UPLOAD_ENDPOINT) {
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Emit a self-contained server into .next/standalone, containing only the
+  // files Next.js traced as actually reachable at runtime. The Docker runtime
+  // stage copies that instead of a full production `node_modules`.
+  output: 'standalone',
   images: {
     remotePatterns
   },

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -2,5 +2,9 @@
 
 set -euxo pipefail
 
-npx prisma migrate deploy
-exec npm run start
+# Invoke the Prisma CLI by path: the standalone image has no package.json
+# scripts and no .bin on PATH, so `npx prisma` would try to fetch it.
+node node_modules/prisma/build/index.js migrate deploy
+
+# The standalone build's own server entry point, in place of `next start`.
+exec node server.js


### PR DESCRIPTION
# build: standalone runtime image

Last one in the series in #553. Three commits, 5 files, no dependency changes.

**The runtime image is about 2.4× larger than it needs to be.** It installs a
second, production-only `node_modules` and copies the whole `.next` directory
on top. Almost none of that second install is ever loaded: `npm ci --omit=dev`
resolves every production dependency, including the parts of packages the app
never imports and the transitive tail behind them.

Next.js can answer the "what is actually needed" question directly.
`output: 'standalone'` traces the module graph reachable from the server and
emits exactly those files, plus a `server.js` entry point.

## Measured, not estimated

Both images built with `docker build` from the same commit, same base image,
sizes read from `docker image inspect`:

| | uncompressed | compressed (what a `docker pull` transfers) |
|---|---|---|
| `main` today | 1.6 GB | 316.2 MB |
| this branch | 670 MB | 143.5 MB |
| | **−58%** | **−55%** |

Essentially the whole difference is one layer. From `docker history` on `main`:

```
1.05GB  COPY /usr/app/node_modules ./node_modules
41.5MB  COPY /usr/app/.next ./.next
```

and on this branch:

```
264MB   COPY /opt/prisma-cli/node_modules ./node_modules
74.8MB  COPY /usr/app/.next/standalone ./
3.43MB  COPY /usr/app/.next/static ./.next/static
```

The traced server that actually runs the app is **74.8 MB**, against 1.05 GB of
installed dependencies.

## Three consequences worth reviewing

- **The `runtime-deps` stage is gone.** It existed only to produce that
  `node_modules`. With it goes the class of bug #552 had to fix, where
  `--omit=optional` stripped sharp's platform binaries out of that install —
  tracing keeps a file because something reaches it, not because of which
  dependency bucket it was declared in.

- **The Prisma CLI needs its own stage.** `migrate deploy` runs at container
  start, but the CLI is not part of the app's module graph, so nothing traces
  it. It also cannot just be copied out of the base stage: that stage installs
  with `--ignore-scripts` (the repo's `postinstall` runs `migrate deploy`,
  which can't run at build time), so `@prisma/engines` never fetches the schema
  engine `migrate deploy` needs. A small isolated install of the same pinned
  version, with scripts, produces a complete CLI. It reads the version out of
  the base stage rather than hardcoding it, so it cannot drift from the
  lockfile.

- **The entrypoint invokes both by path.** A standalone image has no
  `package.json` scripts and no `node_modules/.bin` on `PATH`, so `npx prisma`
  would try to fetch the CLI over the network at container start, and
  `npm run start` has nothing to run.

## A bug this introduced, caught by running the image

**Next.js copies `.env` into the standalone output.** The build stage does
`COPY scripts/build.env .env` for its mocked values, so the first version of
this image shipped those mocks at `/usr/app/.env` — a database URL pointing at
`db`, `S3_UPLOAD_SECRET=AAAA…`, `OPENAI_API_KEY=XXXX…`. Today's image has no
such file, so this would have been a regression.

Real configuration from the container environment takes precedence, so it would
not have broken a correctly-configured deployment. The bad case is quieter: a
variable the operator *forgot* to set would resolve to a build placeholder
instead of failing, and `POSTGRES_PRISMA_URL` in particular would silently
point at a host called `db`.

The build now deletes it, and the deletion is folded into the commit that
causes the problem. Worth knowing about generally — it is a property of
`output: 'standalone'`, not of this repo.

## Verified by running the image

Against a real PostgreSQL 16 with an **empty** database:

- `prisma migrate deploy` applies the full migration history from scratch, and
  the server starts — so the isolated CLI stage really is complete.
- `/api/health/readiness` returns 200, which per `compose.e2e.yaml`'s own
  reasoning proves the schema is migrated and the app is serving.
- Pages, static assets and `public/` files all serve.
- **The full E2E suite passes 41/41 against the container itself**, rather than
  against `npm run start` as in the earlier PRs in this series.
- **#591's runtime configuration still works through the standalone build**,
  which was the thing I most expected to break. The same image, restarted with
  a different environment:

  | | no runtime vars | `BASE_URL` + `DEFAULT_CURRENCY_CODE` set |
  |---|---|---|
  | `robots.txt` sitemap URL | `http://localhost:3000/…` | `https://standalone.example.com/…` |
  | `sitemap.xml` `<loc>` | `http://localhost:3000` | `https://standalone.example.com` |
  | new-group currency | `USD` | `EUR` |

## An observation for later, not part of this PR

The Prisma CLI stage is now the largest layer at 264 MB, bigger than the app
itself. Measuring an `npm install prisma@7.9.1` in isolation:

```
43M  @prisma/studio-core      34M  effect          26M  @electric-sql
19M  @prisma/dev               7.7M elkjs           7.2M react-dom
```

Roughly 140 MB of the CLI is Prisma Studio and `prisma dev` — a graph-layout
library and a React renderer — reached through `prisma`'s regular
`dependencies`, so `--omit=optional` does not drop them. `migrate deploy` needs
`@prisma/engines` (23 MB) and `@prisma/config` (56 KB).

I have **not** tried to prune it here. A hand-maintained deny-list of package
directories is exactly the kind of thing that breaks silently on the next
Prisma upgrade, and this PR is already a large enough change to the runtime
image. Flagging it as the obvious next target if image size stays interesting.

## What I could not verify

- **`linux/arm64`.** Only amd64 here. The change is architecture-independent —
  no new binaries, and tracing produces the same file list — but the CD matrix
  builds arm64 natively and that leg has not been exercised.
- **The GHA layer cache.** `cache-from`/`cache-to` only do anything on a real
  Actions runner, so commit 3 gets its first real test when you cut a tag. It
  is a separate commit and drops cleanly if you would rather not take it.

I deliberately left out the action-version bumps that were on my list for this
PR: #564 added `github-actions` to Dependabot, so it will propose them itself
with release notes to check against, which beats me asserting a set of pins.
