### PR TITLE
fix: surface validation errors reported on a field array as a whole

### DIFF
--- a/src/components/ui/form.test.tsx
+++ b/src/components/ui/form.test.tsx
@@ -1,0 +1,85 @@
+import { Form, FormField, FormItem, FormMessage } from '@/components/ui/form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useForm } from 'react-hook-form'
+import * as z from 'zod'
+import messages from '../../../messages/en-US.json'
+
+// next-intl is ESM-only, which Jest does not transform inside node_modules.
+// FormMessage only reads the message catalogue, so stand that one hook up with
+// the real translations.
+jest.mock('next-intl', () => ({
+  useMessages: () => require('../../../messages/en-US.json'),
+}))
+
+// Mirrors the expense form: a `paidFor` array whose per-row inputs register
+// bracket-indexed names, plus a refinement that reports on the array itself.
+const schema = z
+  .object({
+    paidFor: z.array(z.object({ participant: z.string(), shares: z.string() })),
+  })
+  .superRefine((values, ctx) => {
+    const sum = values.paidFor.reduce(
+      (total, { shares }) => total + Number(shares),
+      0,
+    )
+    if (sum !== 100) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'percentageSum',
+        path: ['paidFor'],
+      })
+    }
+  })
+
+function TestForm() {
+  const form = useForm<z.input<typeof schema>>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      paidFor: [
+        { participant: 'alice', shares: '50' },
+        { participant: 'bob', shares: '30' },
+      ],
+    },
+  })
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(() => {})}>
+        <FormField
+          control={form.control}
+          name="paidFor"
+          render={({ field }) => (
+            <FormItem>
+              {field.value.map((_, index) => (
+                <FormField
+                  key={index}
+                  name={`paidFor[${index}].shares`}
+                  render={() => (
+                    <FormItem>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              ))}
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <button type="submit">Submit</button>
+      </form>
+    </Form>
+  )
+}
+
+it('renders an error reported on a field array as a whole', async () => {
+  render(<TestForm />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+  expect(
+    await screen.findByText(messages.SchemaErrors.percentageSum),
+  ).toBeVisible()
+  expect(screen.queryByText('undefined')).not.toBeInTheDocument()
+})

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -148,12 +148,13 @@ const FormMessage = React.forwardRef<
   const messages = useMessages()
   const { error, formMessageId } = useFormField()
   let body
-  if (error) {
-    body = String(error?.message)
-    const translation = (messages.SchemaErrors as any)[body]
-    if (translation) {
-      body = translation
-    }
+  // An error on a field array as a whole -- "sum of percentages must equal
+  // 100", say -- is nested under `root` by @hookform/resolvers rather than
+  // sitting on the field error itself.
+  const message = error?.message ?? error?.root?.message
+  if (message) {
+    const translation = (messages.SchemaErrors as any)[message]
+    body = translation ?? message
   } else {
     body = children
   }


### PR DESCRIPTION
The **E2E** workflow has been failing since the resolvers major bump in #589. On tag `1.23.0` (run [33257081185](https://github.com/spliit-app/spliit/actions/runs/33257081185)), `split-modes.spec.ts › rejects percentages that do not add up to 100` fails: the expected message never appears, and the captured page snapshot shows the app rendering the literal string `undefined` in its place.

## Cause

`@hookform/resolvers` v5 changed how `toNestErrors` detects a field array:

- v3: `names.some(name => name.startsWith(path + "."))`
- v5: normalises bracket indices first (`paidFor[0].shares` → `paidFor.0.shares`), then matches `^paidFor\.\d+`

The expense form registers its per-row inputs as `` `paidFor[${i}].shares` ``. Under v3 those names did not match, so an error reported on the array itself landed on `errors.paidFor`. Under v5 they do match, so it now lands on `errors.paidFor.root` instead.

`FormMessage` only read `error.message`. That became `undefined`, `String(undefined)` produced `"undefined"`, no translation matched it, and the literal string was rendered.

## Fix

Fall back to `error.root.message`, and fall through to `children` rather than `"undefined"` when there is no message at all.

`FormMessage` is the only place schema errors are rendered, so this covers every error reported on the array: `percentageSum`, `amountSum`, `paidForMin1` and `noZeroShares`.

## Verification

- Added `src/components/ui/form.test.tsx`, which reproduces the structure (array field with bracket-indexed children). Confirmed it fails without the fix — rendering `undefined`, matching the CI snapshot — and passes with it.
- Full Playwright suite against the Docker stack: **41 passed**, including the previously failing test.
- `npm run check-types`, `npm run lint` (0 errors), `npm run check-formatting`, `npm test` (167 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)