### PR TITLE
Add security headers and a baseline Content-Security-Policy

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -51,6 +51,27 @@ const nextConfig = {
       })(),
     },
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(self), microphone=(), geolocation=()',
+          },
+          {
+            key: 'Content-Security-Policy',
+            value:
+              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default withNextIntl(nextConfig)


### PR DESCRIPTION
## Summary
- Sends `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, and a baseline CSP on every route.
- `camera=(self)` so receipt scanning and the QR scanner keep working; `img-src`/`connect-src` allow `https:` for optional S3 and analytics.

Closes a class of clickjacking / MIME-sniffing issues without changing app behavior.

## Test plan
- [ ] Load the homepage and a group page; DevTools → Network shows the new response headers.
- [ ] If expense documents / receipt camera are enabled, confirm the camera prompt still appears.
- [ ] Confirm S3-hosted document thumbnails still load when that feature is on.
