### PR TITLE
Add error boundaries that do not leak exception messages

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -11,6 +11,12 @@
   "Header": {
     "groups": "Groups"
   },
+  "Errors": {
+    "title": "Something went wrong",
+    "groupTitle": "Couldn’t load this group",
+    "generic": "Please try again. If this keeps happening, reload the page.",
+    "retry": "Try again"
+  },
   "Footer": {
     "madeIn": "Made in Montréal, Québec 🇨🇦",
     "builtBy": "Built by <author>Sebastien Castiel</author> and <source>contributors</source>"

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -15,6 +15,7 @@
     "title": "Something went wrong",
     "groupTitle": "Couldn’t load this group",
     "generic": "Please try again. If this keeps happening, reload the page.",
+    "reference": "Reference: {digest}",
     "retry": "Try again"
   },
   "Footer": {

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { useTranslations } from 'next-intl'
+
+export default function Error({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const t = useTranslations('Errors')
+  return (
+    <div className="container max-w-lg py-16 text-center space-y-4">
+      <h2 className="text-xl font-semibold">{t('title')}</h2>
+      <p className="text-muted-foreground text-sm">{t('generic')}</p>
+      <Button type="button" onClick={() => reset()}>
+        {t('retry')}
+      </Button>
+    </div>
+  )
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,22 +1,23 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
+import { ErrorState } from '@/components/error-state'
 import { useTranslations } from 'next-intl'
 
 export default function Error({
-  reset,
+  error,
+  retry,
 }: {
-  error: Error & { digest?: string }
+  error: unknown
   reset: () => void
+  retry: () => void
 }) {
   const t = useTranslations('Errors')
   return (
-    <div className="container max-w-lg py-16 text-center space-y-4">
-      <h2 className="text-xl font-semibold">{t('title')}</h2>
-      <p className="text-muted-foreground text-sm">{t('generic')}</p>
-      <Button type="button" onClick={() => reset()}>
-        {t('retry')}
-      </Button>
-    </div>
+    <ErrorState
+      error={error}
+      retry={retry}
+      title={t('title')}
+      className="container max-w-lg py-16"
+    />
   )
 }

--- a/src/app/groups/[groupId]/error.tsx
+++ b/src/app/groups/[groupId]/error.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { useTranslations } from 'next-intl'
+
+export default function GroupError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const t = useTranslations('Errors')
+  return (
+    <div className="py-10 text-center space-y-4">
+      <h2 className="text-xl font-semibold">{t('groupTitle')}</h2>
+      <p className="text-muted-foreground text-sm">{t('generic')}</p>
+      <Button type="button" onClick={() => reset()}>
+        {t('retry')}
+      </Button>
+    </div>
+  )
+}

--- a/src/app/groups/[groupId]/error.tsx
+++ b/src/app/groups/[groupId]/error.tsx
@@ -1,22 +1,23 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
+import { ErrorState } from '@/components/error-state'
 import { useTranslations } from 'next-intl'
 
 export default function GroupError({
-  reset,
+  error,
+  retry,
 }: {
-  error: Error & { digest?: string }
+  error: unknown
   reset: () => void
+  retry: () => void
 }) {
   const t = useTranslations('Errors')
   return (
-    <div className="py-10 text-center space-y-4">
-      <h2 className="text-xl font-semibold">{t('groupTitle')}</h2>
-      <p className="text-muted-foreground text-sm">{t('generic')}</p>
-      <Button type="button" onClick={() => reset()}>
-        {t('retry')}
-      </Button>
-    </div>
+    <ErrorState
+      error={error}
+      retry={retry}
+      title={t('groupTitle')}
+      className="py-10"
+    />
   )
 }

--- a/src/components/error-state.tsx
+++ b/src/components/error-state.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { useTranslations } from 'next-intl'
+import { useEffect } from 'react'
+
+function getDigest(error: unknown) {
+  return typeof error === 'object' && error !== null && 'digest' in error
+    ? String((error as { digest?: unknown }).digest ?? '')
+    : ''
+}
+
+/**
+ * Fallback rendered by the `error.tsx` boundaries. The exception message is
+ * never displayed: only the opaque digest Next.js attaches to server errors is,
+ * so a user can quote it in a bug report while the message stays in the logs.
+ */
+export function ErrorState({
+  error,
+  // `retry` refreshes the router before resetting the boundary; `reset` alone
+  // re-renders the same failed payload, which would loop on server errors.
+  retry,
+  title,
+  className,
+}: {
+  error: unknown
+  retry: () => void
+  title: string
+  className?: string
+}) {
+  const t = useTranslations('Errors')
+  const digest = getDigest(error)
+
+  useEffect(() => {
+    // Browser console only, so the details stay available while debugging.
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className={cn('text-center space-y-4', className)}>
+      <h2 className="text-xl font-semibold">{title}</h2>
+      <p className="text-muted-foreground text-sm">{t('generic')}</p>
+      {digest && (
+        <p className="text-muted-foreground text-xs font-mono">
+          {t('reference', { digest })}
+        </p>
+      )}
+      <Button type="button" onClick={retry}>
+        {t('retry')}
+      </Button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `src/app/error.tsx` and `src/app/groups/[groupId]/error.tsx`.
- Copy is generic i18n (`Errors.*`); `error.message` is never rendered.

Stops unhandled exceptions from leaking internals to anyone who can open a group URL.

## Test plan
- [x] Temporarily throw in a group page; the boundary shows the generic message and Retry works.
- [x] Confirm the thrown message string does not appear in the HTML.
