### PR TITLE
Load expense participant IDs without fetching every expense

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -127,14 +127,24 @@ export async function deleteExpense(
 }
 
 export async function getGroupExpensesParticipants(groupId: string) {
-  const expenses = await getGroupExpenses(groupId)
+  const [payers, paidFor] = await Promise.all([
+    prisma.expense.findMany({
+      where: { groupId },
+      distinct: ['paidById'],
+      select: { paidById: true },
+    }),
+    prisma.expensePaidFor.findMany({
+      where: { expense: { groupId } },
+      distinct: ['participantId'],
+      select: { participantId: true },
+    }),
+  ])
+
   return Array.from(
-    new Set(
-      expenses.flatMap((e) => [
-        e.paidBy.id,
-        ...e.paidFor.map((pf) => pf.participant.id),
-      ]),
-    ),
+    new Set([
+      ...payers.map((expense) => expense.paidById),
+      ...paidFor.map((row) => row.participantId),
+    ]),
   )
 }
 


### PR DESCRIPTION
## Summary
- `getGroupExpensesParticipants` is used only to know which participants cannot be deleted on the group edit form.
- It previously called `getGroupExpenses()` with no page, which hydrates every expense (payers, paid-for, documents count) and also runs `createRecurringExpenses()` as a side effect.
- Replace that with two small `distinct` Prisma queries for `paidById` and `ExpensePaidFor.participantId`.

## Test plan
- [x] Open group settings on a group with expenses: participants who paid or were paid for still cannot be removed.
- [x] A participant with no expenses can still be removed.
- [x] Viewing group settings no longer depends on loading the full expense list (large groups should stay snappy).

Made with [Cursor](https://cursor.com)