### PR TITLE
Performance test suite

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,89 @@
+name: Performance
+
+# Path-filtered on pull requests so it stays off PRs that cannot affect query
+# cost, plus a weekly run and manual dispatch. The gate is deterministic
+# (query counts, response bytes, row counts) rather than wall-clock, so it is
+# safe to block a PR on: it does not flake with runner noise.
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays, 05:00 UTC.
+    - cron: '0 5 * * 1'
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'src/lib/api.ts'
+      - 'src/lib/balances.ts'
+      - 'src/lib/totals.ts'
+      - 'src/lib/prisma.ts'
+      - 'src/trpc/**'
+      - 'prisma/**'
+      - 'perf/**'
+      - 'compose.perf.yaml'
+      - 'scripts/perf.sh'
+      - '.github/workflows/perf.yml'
+
+concurrency:
+  group: perf-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  perf:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      # --ignore-scripts, as in ci.yml: postinstall runs `prisma migrate deploy`,
+      # which needs a database that does not exist yet at this point.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # The seeder runs on the host and talks to postgres directly, so it needs
+      # a generated client.
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Start the app stack
+        run: ./scripts/perf.sh up
+
+      - name: Seed the performance dataset
+        run: ./scripts/perf.sh seed
+
+      - name: Run benchmarks
+        run: npx ts-node -T perf/run.ts
+
+      - name: Collect container logs
+        if: failure()
+        run: ./scripts/perf.sh logs > compose-logs.txt
+
+      - name: Upload performance report
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: perf-report
+          path: perf-report.json
+          retention-days: 90
+
+      - name: Upload container logs
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: perf-container-logs
+          path: compose-logs.txt
+          retention-days: 14
+
+      - name: Stop the app stack
+        if: always()
+        run: ./scripts/perf.sh down

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -6,6 +6,10 @@ name: Performance
 # safe to block a PR on: it does not flake with runner noise.
 on:
   workflow_dispatch:
+  # Release tags, matching cd.yml and e2e.yml -- every release build becomes a
+  # point on the trend chart published to GitHub Pages.
+  push:
+    tags: ['*']
   schedule:
     # Mondays, 05:00 UTC.
     - cron: '0 5 * * 1'
@@ -27,6 +31,8 @@ concurrency:
   group: perf-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default; only the publish job below widens this, and only
+# on tag builds.
 permissions:
   contents: read
 
@@ -64,6 +70,24 @@ jobs:
       - name: Run benchmarks
         run: npx ts-node -T perf/run.ts
 
+      # Converted here rather than in the publish job so that job needs no
+      # node toolchain -- it only downloads two JSON files and hands them over.
+      - name: Convert report for the trend dashboard
+        if: startsWith(github.ref, 'refs/tags/')
+        run: >
+          npx ts-node -T perf/to-benchmark-json.ts
+          perf-report.json bench-deterministic.json bench-timing.json
+
+      - name: Upload trend data
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-data
+          path: |
+            bench-deterministic.json
+            bench-timing.json
+          retention-days: 7
+
       - name: Collect container logs
         if: failure()
         run: ./scripts/perf.sh logs > compose-logs.txt
@@ -87,3 +111,57 @@ jobs:
       - name: Stop the app stack
         if: always()
         run: ./scripts/perf.sh down
+
+  # Separate job purely so `contents: write` is scoped to tag builds instead of
+  # being granted on every pull request run.
+  #
+  # Publishes to a `gh-pages` branch, which GitHub Pages then serves as an
+  # interactive chart at /dev/bench/deterministic and /dev/bench/timing. Both
+  # the branch and Pages have to be enabled in repository settings; until they
+  # are, this job is the only thing that fails and the benchmarks above still
+  # run and still gate.
+  publish-trend:
+    needs: perf
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Download trend data
+        uses: actions/download-artifact@v7
+        with:
+          name: bench-data
+
+      # Exactly reproducible against a fixed dataset, so a tight threshold here
+      # is a real signal rather than noise.
+      - name: Publish deterministic trend
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Spliit performance (deterministic)
+          tool: customSmallerIsBetter
+          output-file-path: bench-deterministic.json
+          benchmark-data-dir-path: dev/bench/deterministic
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: '110%'
+          comment-on-alert: true
+          fail-on-alert: true
+
+      # Charted for the eye, never gated: runner-to-runner variance would make
+      # any useful threshold fire on noise. See perf/README.md.
+      - name: Publish timing trend
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Spliit performance (timing)
+          tool: customSmallerIsBetter
+          output-file-path: bench-timing.json
+          benchmark-data-dir-path: dev/bench/timing
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          fail-on-alert: false
+          comment-on-alert: false
+          alert-threshold: '300%'

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ postgres-data
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# performance suite output (perf/run.ts)
+/perf-report.json

--- a/compose.perf.yaml
+++ b/compose.perf.yaml
@@ -1,0 +1,78 @@
+# Ephemeral stack for the performance suite.
+#
+# A near-copy of compose.e2e.yaml -- same throwaway database, same readiness
+# healthcheck -- with two deliberate differences, both load-bearing:
+#
+#   1. The db port is PUBLISHED. perf/seed.ts runs on the host and writes
+#      directly to postgres; the e2e stack keeps it unpublished because nothing
+#      outside the compose network ever needs it.
+#   2. The app defaults to host port 3100, so a perf run does not collide with a
+#      dev server or an e2e stack on 3000. Only /api/trpc is exercised -- never a
+#      server action -- so next.config.mjs pinning serverActions.allowedOrigins
+#      to localhost:3000 does not apply.
+#
+# Always invoke through scripts/perf.sh, which adds the flags that guarantee a
+# clean database.
+name: spliit-perf
+
+services:
+  app:
+    build:
+      context: .
+    image: spliit-perf:latest
+    ports:
+      - '${PERF_HOST_PORT:-3100}:3000'
+    environment:
+      POSTGRES_PRISMA_URL: postgresql://postgres:perf@db:5432/spliit_perf
+      POSTGRES_URL_NON_POOLING: postgresql://postgres:perf@db:5432/spliit_perf
+      NEXT_TELEMETRY_DISABLED: '1'
+    restart: 'no'
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      # 127.0.0.1 rather than localhost: busybox may resolve localhost to ::1.
+      # /api/health/readiness runs `SELECT 1`, and scripts/container-entrypoint.sh
+      # runs `prisma migrate deploy` *before* starting the server -- so any 200 here
+      # proves the schema is migrated and the app is serving.
+      test:
+        [
+          'CMD-SHELL',
+          'wget -q -O /dev/null http://127.0.0.1:3000/api/health/readiness || exit 1',
+        ]
+      interval: 3s
+      timeout: 5s
+      retries: 40
+      start_period: 20s
+
+  db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: perf
+      POSTGRES_DB: spliit_perf
+    ports:
+      # Published so the host-side seeder can reach it. Defaults well away from
+      # 5432 to avoid colliding with a local postgres.
+      - '${PERF_DB_PORT:-55432}:5432'
+    # As in compose.e2e.yaml: the postgres image declares its own VOLUME, so
+    # freshness comes from `up --renew-anon-volumes` and `down --volumes` in
+    # scripts/perf.sh, not from the absence of a volume here.
+    #
+    # fsync is off because this database is thrown away every run. It makes the
+    # suite fast, and it is also why the timings are only good for comparing
+    # runs against each other -- never for estimating production capacity.
+    command:
+      - postgres
+      - -c
+      - fsync=off
+      - -c
+      - synchronous_commit=off
+      - -c
+      - full_page_writes=off
+    restart: 'no'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres -d spliit_perf']
+      interval: 2s
+      timeout: 5s
+      retries: 30

--- a/compose.perf.yaml
+++ b/compose.perf.yaml
@@ -1,12 +1,14 @@
 # Ephemeral stack for the performance suite.
 #
 # A near-copy of compose.e2e.yaml -- same throwaway database, same readiness
-# healthcheck -- with two deliberate differences, both load-bearing:
+# healthcheck -- with three deliberate differences, all of them load-bearing:
 #
 #   1. The db port is PUBLISHED. perf/seed.ts runs on the host and writes
 #      directly to postgres; the e2e stack keeps it unpublished because nothing
 #      outside the compose network ever needs it.
-#   2. The app defaults to host port 3100, so a perf run does not collide with a
+#   2. PERF_INSTRUMENTATION is on, which makes /api/trpc report how many Prisma
+#      operations each request ran. It is inert everywhere else.
+#   3. The app defaults to host port 3100, so a perf run does not collide with a
 #      dev server or an e2e stack on 3000. Only /api/trpc is exercised -- never a
 #      server action -- so next.config.mjs pinning serverActions.allowedOrigins
 #      to localhost:3000 does not apply.
@@ -26,6 +28,10 @@ services:
       POSTGRES_PRISMA_URL: postgresql://postgres:perf@db:5432/spliit_perf
       POSTGRES_URL_NON_POOLING: postgresql://postgres:perf@db:5432/spliit_perf
       NEXT_TELEMETRY_DISABLED: '1'
+      # Turns on the query counter in src/lib/perf-instrumentation.ts. Nothing
+      # else in the repository sets this. Read at runtime, not baked into the
+      # image, so the Dockerfile needs no build argument for it.
+      PERF_INSTRUMENTATION: '1'
     restart: 'no'
     depends_on:
       db:

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "start": "next start",
     "lint": "eslint .",
     "check-types": "tsc --noEmit",
-    "check-formatting": "prettier -c src e2e playwright.config.ts",
-    "prettier": "prettier -w src e2e playwright.config.ts",
+    "check-formatting": "prettier -c src e2e perf playwright.config.ts",
+    "prettier": "prettier -w src e2e perf playwright.config.ts",
     "postinstall": "prisma migrate deploy && prisma generate",
     "build-image": "./scripts/build-image.sh",
     "start-container": "docker compose --env-file container.env up",
@@ -24,6 +24,12 @@
     "e2e:logs": "./scripts/e2e.sh logs",
     "e2e:test": "./scripts/e2e.sh test",
     "e2e:report": "playwright show-report",
+    "perf": "./scripts/perf.sh",
+    "perf:up": "./scripts/perf.sh up",
+    "perf:seed": "./scripts/perf.sh seed",
+    "perf:bench": "./scripts/perf.sh bench",
+    "perf:down": "./scripts/perf.sh down",
+    "perf:logs": "./scripts/perf.sh logs",
     "generate-currency-data": "ts-node -T ./src/scripts/generateCurrencyData.ts"
   },
   "dependencies": {

--- a/perf/README.md
+++ b/perf/README.md
@@ -94,6 +94,23 @@ noticing that a procedure now runs N queries where it used to run a constant
 number. It is what makes the fan-out in `groups.balances.forUser` a catchable
 regression, since that one does not change the response by a single byte.
 
+## Trend over releases
+
+Every release tag runs the suite and publishes two series to a `gh-pages`
+branch, which GitHub Pages serves as an interactive chart:
+
+- `/dev/bench/deterministic` — query counts and response bytes. A regression
+  beyond 110% alerts and fails the workflow.
+- `/dev/bench/timing` — p50 and p95. Charted only; never alerts.
+
+Both need a `gh-pages` branch and Pages enabled in repository settings. Until
+they are, only the publishing job fails — the benchmarks still run and still
+gate pull requests.
+
+Read the timing chart as a trend across many releases. Two adjacent points come
+from two different runners and are not meaningfully comparable; see the caveat
+below.
+
 ## Caveats
 
 The benchmark Postgres runs with `fsync=off`, `synchronous_commit=off` and

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,119 @@
+# Performance suite
+
+Benchmarks the three most-used flows in the app over HTTP, against a real
+Postgres with a realistic amount of data in it.
+
+The point is to make performance work measurable: to tell whether a change to a
+query, an index, or a procedure actually helped, and to catch it when something
+gets quietly worse.
+
+## Running it
+
+```sh
+npm run perf
+```
+
+That builds an image from the checkout, starts it with a throwaway Postgres,
+seeds the dataset, benchmarks, prints a report, and tears everything down.
+
+While iterating, keep the stack up between runs:
+
+```sh
+npm run perf:up      # build and start
+npm run perf:seed    # (re)seed
+npm run perf:bench   # benchmark; repeat as often as you like
+npm run perf:bench -- --filter view-group
+npm run perf:down
+```
+
+Sizing and sampling come from environment variables — see `config.ts` for the
+full list and defaults:
+
+```sh
+PERF_LARGE_GROUP_EXPENSES=10000 PERF_ITERATIONS=50 npm run perf
+```
+
+## What it measures
+
+| Scenario                 | Screen                            | Procedures                                               |
+| ------------------------ | --------------------------------- | -------------------------------------------------------- |
+| `list-groups:home`       | `/groups`                         | `groups.list` + `groups.balances.forUser`                |
+| `view-group:first-page`  | `/groups/[id]/expenses`           | `groups.get` + `groups.expenses.list`                    |
+| `view-group:deep-page`   | scrolled halfway down that list   | `groups.expenses.list` at a deep offset                  |
+| `view-group:search`      | the search box on that list       | `groups.expenses.list` with a filter                     |
+| `view-group:balances`    | the Balances tab                  | `groups.balances.list`                                   |
+| `view-expense:edit-form` | `/groups/[id]/expenses/[id]/edit` | `groups.get` + `categories.list` + `groups.expenses.get` |
+
+Each mirrors what the client genuinely issues — same procedures, same page size,
+same batching — so a number here corresponds to a real screen rather than to a
+query someone thought the screen ran.
+
+## Reading the report
+
+```
+step                          p50        p95       cold     db ms   queries      bytes    rows
+list-groups:home           241.3ms    268.9ms    502.1ms   198.4ms     61/61  31204/24000     40
+```
+
+- **p50 / p95 / cold** — wall-clock, client-side. Informational only.
+- **db ms** — server-side database time, from `Server-Timing`. Informational.
+- **queries / bytes** — actual against budget.
+- **rows** — how many rows came back.
+
+## What can fail the build
+
+Only the deterministic columns: request count, response bytes, row count and
+server-side query count. Against a fixed dataset these are exactly reproducible,
+so they can gate a pull request without flaking.
+
+Wall-clock timings are **never** asserted. On a shared CI runner they vary
+enough between jobs that any threshold tight enough to catch a real regression
+would also fire on noise. They are recorded, printed, and charted over releases,
+and they are for humans to look at.
+
+When a budget fails, the run prints what exceeded what. If the change was
+intentional, update `budgets.ts` with the figures from the report.
+
+Budgets are written as formulas over `config` rather than as bare numbers, so a
+resized dataset keeps working — and so the cost model is stated out loud.
+`1 + config.groups * 3` says the home screen does three queries per recent
+group, and a diff that turns it into `1 + config.groups` is a visible
+improvement rather than a number that silently moved.
+
+## Query counting
+
+`queries` comes from an optional `X-Perf-Db-Queries` response header. When the
+app under test does not send it the column reads `-` and any query budget is
+skipped rather than failed, so the suite works against any deployment.
+
+It counts **Prisma operations**, not raw SQL statements: one `findMany` with an
+`include` may issue several statements but counts once. That is still exactly
+reproducible, and it is the right granularity for what the counter is for —
+noticing that a procedure now runs N queries where it used to run a constant
+number.
+
+## Caveats
+
+The benchmark Postgres runs with `fsync=off`, `synchronous_commit=off` and
+`full_page_writes=off`, and CI runners vary. **These timings are for comparing
+runs against each other, not for estimating production capacity.** The timing
+series is meaningful as a trend across many releases; two adjacent points are
+not meaningfully comparable.
+
+## Determinism
+
+The seeder is the reason any of this works. It uses a fixed PRNG seed and fixed
+timestamps, and two properties matter enough to call out:
+
+- Every expense has a unique `createdAt`, so the list's
+  `[{expenseDate: desc}, {createdAt: desc}]` sort is a total order. Without
+  that, tied rows could come back in either order and the byte counts would
+  flap.
+- Nothing recurs. `getGroupExpenses` calls `createRecurringExpenses()` on every
+  read, which _writes_ when a frame is due — during a benchmark that would move
+  both row and query counts between iterations. Every seeded expense is
+  `RecurrenceRule.NONE`, so that pass stays a single constant-cost query.
+
+The harness also checks this at runtime: if a supposedly deterministic value
+changes between iterations of the same step, the run fails rather than averaging
+it away.

--- a/perf/README.md
+++ b/perf/README.md
@@ -82,15 +82,17 @@ improvement rather than a number that silently moved.
 
 ## Query counting
 
-`queries` comes from an optional `X-Perf-Db-Queries` response header. When the
-app under test does not send it the column reads `-` and any query budget is
-skipped rather than failed, so the suite works against any deployment.
+`queries` comes from the `X-Perf-Db-Queries` response header, which the app only
+emits when `PERF_INSTRUMENTATION=1` — set by `compose.perf.yaml` and nowhere
+else. Against any other deployment the column reads `-` and those budgets are
+skipped rather than failed.
 
 It counts **Prisma operations**, not raw SQL statements: one `findMany` with an
 `include` may issue several statements but counts once. That is still exactly
 reproducible, and it is the right granularity for what the counter is for —
 noticing that a procedure now runs N queries where it used to run a constant
-number.
+number. It is what makes the fan-out in `groups.balances.forUser` a catchable
+regression, since that one does not change the response by a single byte.
 
 ## Caveats
 

--- a/perf/budgets.ts
+++ b/perf/budgets.ts
@@ -1,0 +1,138 @@
+/**
+ * Deterministic budgets. These, and only these, can fail the build.
+ *
+ * Wall-clock timings are recorded and printed but never asserted: on a shared
+ * CI runner they vary enough between jobs that any threshold tight enough to
+ * catch a real regression would also fire on noise. Request count, response
+ * bytes, row count and server-side query count, measured against the fixed
+ * dataset in `seed.ts`, do not vary at all -- so they can gate.
+ *
+ * Budgets are ceilings, not expectations: going under one is an improvement and
+ * passes. They are written as formulas over `config` rather than as bare
+ * numbers, for two reasons. A resized dataset keeps working. And the formula
+ * states the cost model out loud -- `1 + 3 * config.groups` is a readable claim
+ * that the home screen runs three queries per recent group, and a diff turning
+ * it into `1 + config.groups` is a visible, reviewable improvement rather than a
+ * number that quietly moved.
+ *
+ * The byte constants were fitted from real runs at the default dataset size
+ * (and, for the group-scaled term, at 5/10/20 groups) and then given ~8-10%
+ * headroom, so an incidental change like a longer participant name does not
+ * fail the build but a structural change does. To re-baseline after an
+ * intentional change, run `npm run perf` and take the figures the report prints.
+ */
+import {
+  LARGE_GROUP,
+  config,
+  paidForCountFor,
+  participantCountFor,
+  searchMatchCount,
+  targetExpenseIndex,
+} from './config'
+
+export type Budget = {
+  /** Max HTTP requests. Rises if batching breaks. */
+  requests: number
+  /** Max total response bytes. Rises when the server over-fetches to the client. */
+  bytes: number
+  /**
+   * Exact expected row count -- compared for equality, since fetching fewer
+   * rows than expected means the step stopped exercising what it was written
+   * to exercise. Omitted where the count is emergent rather than predictable.
+   */
+  rows?: number
+  /**
+   * Max Prisma operations on the server. Skipped entirely when the app runs
+   * without PERF_INSTRUMENTATION.
+   */
+  dbQueries?: number
+}
+
+/**
+ * Every `getGroupExpenses` call pays for an unscoped `createRecurringExpenses()`
+ * pass before its own query -- see src/lib/api.ts. Two operations, not one.
+ */
+const EXPENSE_READ_QUERIES = 2
+
+/** `getGroup` is a single findUnique with an include. */
+const GROUP_READ_QUERIES = 1
+
+const largeGroupParticipants = participantCountFor(LARGE_GROUP)
+
+export const budgets: Record<string, Budget> = {
+  /**
+   * `groups.list` is one query for all N groups. `groups.balances.forUser` then
+   * runs `getGroup` + a full unpaged `getGroupExpenses` per group -- hence the
+   * `* config.groups`. Bringing that to a constant is the single biggest win
+   * available on this screen: at the default dataset it is 61 queries and by
+   * far the slowest step in the suite.
+   */
+  'list-groups:home': {
+    requests: 1,
+    bytes: 120 + config.groups * 360,
+    rows: config.groups * 2,
+    dbQueries: 1 + config.groups * (GROUP_READ_QUERIES + EXPENSE_READ_QUERIES),
+  },
+
+  'view-group:first-page': {
+    requests: 1,
+    bytes: 1_500 + config.pageSize * 1_340,
+    rows: largeGroupParticipants + config.pageSize,
+    dbQueries: GROUP_READ_QUERIES + EXPENSE_READ_QUERIES,
+  },
+
+  /**
+   * Same shape and same row count as `first-page` -- only the offset differs.
+   * That is the point: if these two ever diverge in bytes or queries, something
+   * about pagination changed. The interesting difference between them is
+   * timing, which lives in the report rather than here.
+   */
+  'view-group:deep-page': {
+    requests: 1,
+    bytes: config.pageSize * 1_340,
+    rows: config.pageSize,
+    dbQueries: EXPENSE_READ_QUERIES,
+  },
+
+  'view-group:search': {
+    requests: 1,
+    bytes: config.pageSize * 1_340,
+    // A full page, unless the dataset is small enough that fewer expenses match.
+    rows: Math.min(config.pageSize, searchMatchCount),
+    dbQueries: EXPENSE_READ_QUERIES,
+  },
+
+  /**
+   * Loads every expense in the group to compute balances in JS. The response is
+   * tiny -- balances only -- so `bytes` cannot catch a regression here;
+   * `dbQueries` and the timing trend are what matter for this step.
+   *
+   * No `rows` budget: `getPublicBalances` only lists participants that appear
+   * in a suggested reimbursement, so the count falls out of the balance
+   * arithmetic rather than from the dataset size. Pinning it would assert on an
+   * emergent property that a legitimate change to the reimbursement algorithm
+   * would move.
+   */
+  'view-group:balances': {
+    requests: 1,
+    bytes: largeGroupParticipants * 140,
+    dbQueries: EXPENSE_READ_QUERIES,
+  },
+
+  /**
+   * Three procedures, one batched request: `groups.get`, `categories.list` and
+   * `groups.expenses.get`. One query each. Most of the payload is the static
+   * category table rather than the expense itself, which is why the fixed term
+   * dominates.
+   */
+  'view-expense:edit-form': {
+    requests: 1,
+    bytes:
+      4_600 +
+      largeGroupParticipants * 60 +
+      paidForCountFor(LARGE_GROUP, targetExpenseIndex) * 40,
+    rows:
+      largeGroupParticipants + paidForCountFor(LARGE_GROUP, targetExpenseIndex),
+    dbQueries: GROUP_READ_QUERIES + 1 + 1,
+  },
+}

--- a/perf/client.ts
+++ b/perf/client.ts
@@ -1,0 +1,133 @@
+/**
+ * tRPC clients for the suite, plus the per-step recording of everything
+ * deterministic.
+ *
+ * These are built with the real `@trpc/client` links and the same superjson +
+ * Decimal serializer the app registers in src/trpc/client.tsx. Hand-rolling the
+ * `/api/trpc` URL and input encoding would work today and drift tomorrow; going
+ * through the actual client means the request on the wire is the request the
+ * browser makes.
+ *
+ * `batched` mirrors the app, which uses `httpBatchLink`: several procedures
+ * fired together arrive as one HTTP request. `single` is for steps that measure
+ * one procedure on its own.
+ */
+import type { AppRouter } from '@/trpc/routers/_app'
+import { createTRPCClient, httpBatchLink, httpLink } from '@trpc/client'
+import superjson from 'superjson'
+import { baseUrl } from './config'
+
+/**
+ * The server tags `Prisma.Decimal` values as `decimal.js` (src/trpc/init.ts),
+ * and superjson throws on an unregistered custom type. The app's client rebuilds
+ * a real Decimal; this one keeps the string, because the suite only ever counts
+ * rows and bytes and never does arithmetic on a payload.
+ *
+ * A pass-through rather than an import of `@/generated/prisma/client`: the
+ * generated Prisma 7 client is ESM-only and cannot be required from the
+ * CommonJS context ts-node gives these scripts.
+ */
+superjson.registerCustom<string, string>(
+  {
+    // The benchmark client never sends a Decimal, only receives one.
+    isApplicable: (value): value is string => false,
+    serialize: (value) => value,
+    deserialize: (value) => value,
+  },
+  'decimal.js',
+)
+
+/** What one step's HTTP traffic cost, independent of how fast it was. */
+export type Recording = {
+  /** HTTP requests issued. Batching means this is usually 1 even for 3 procedures. */
+  requests: number
+  /** Total response bytes. Catches over-fetching to the client. */
+  bytes: number
+  /**
+   * Prisma operations the server ran, summed from the `X-Perf-Db-Queries`
+   * header. Null when the app is running without PERF_INSTRUMENTATION, which is
+   * the normal case outside this suite -- the report renders it as "-" and the
+   * budget is skipped rather than failed.
+   */
+  dbQueries: number | null
+  /** Server-side database time in ms, from `Server-Timing: db`. Null as above. */
+  dbMs: number | null
+}
+
+let current: Recording | null = null
+
+const recordingFetch: typeof fetch = async (input, init) => {
+  const response = await fetch(input as RequestInfo, init as RequestInit)
+  if (!current) return response
+
+  // Read a clone so the body stays consumable by tRPC itself.
+  const body = await response.clone().arrayBuffer()
+  current.requests += 1
+  current.bytes += body.byteLength
+
+  const queries = response.headers.get('x-perf-db-queries')
+  if (queries !== null && queries !== '') {
+    current.dbQueries = (current.dbQueries ?? 0) + Number(queries)
+  }
+
+  // `Server-Timing: db;dur=12.3`
+  const timing = response.headers.get('server-timing')
+  const dur = timing?.match(/(?:^|,)\s*db;dur=([0-9.]+)/)?.[1]
+  if (dur !== undefined) {
+    current.dbMs = (current.dbMs ?? 0) + Number(dur)
+  }
+
+  return response
+}
+
+const url = `${baseUrl}/api/trpc`
+
+export const batched = createTRPCClient<AppRouter>({
+  links: [
+    httpBatchLink({ transformer: superjson, url, fetch: recordingFetch }),
+  ],
+})
+
+export const single = createTRPCClient<AppRouter>({
+  links: [httpLink({ transformer: superjson, url, fetch: recordingFetch })],
+})
+
+/** Runs `fn` while recording its HTTP traffic. Not re-entrant; steps run serially. */
+export async function withRecording<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; recording: Recording }> {
+  if (current) throw new Error('withRecording is not re-entrant')
+
+  const recording: Recording = {
+    requests: 0,
+    bytes: 0,
+    dbQueries: null,
+    dbMs: null,
+  }
+  current = recording
+  try {
+    const result = await fn()
+    return { result, recording }
+  } finally {
+    current = null
+  }
+}
+
+/** Polls the app's readiness endpoint until it serves, or throws. */
+export async function waitForApp(timeoutMs = 120_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  let lastError = 'no attempt made'
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/api/health/readiness`)
+      if (response.ok) return
+      lastError = `HTTP ${response.status}`
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  }
+
+  throw new Error(`App at ${baseUrl} never became ready (${lastError})`)
+}

--- a/perf/config.ts
+++ b/perf/config.ts
@@ -1,0 +1,110 @@
+/**
+ * Sizing and run knobs for the performance suite.
+ *
+ * Everything the seeder writes and everything `budgets.ts` asserts is derived
+ * from this one object, so a resized dataset stays internally consistent: raise
+ * PERF_GROUPS and the expected query count for the home screen follows along.
+ * That is why budgets are written as formulas over `config` rather than as bare
+ * numbers -- a hardcoded 61 would silently become wrong the first time someone
+ * ran the suite with a different dataset.
+ */
+
+function intFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined || raw.trim() === '') return fallback
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(
+      `${name} must be a positive integer, got ${JSON.stringify(raw)}`,
+    )
+  }
+  return parsed
+}
+
+export const config = {
+  /**
+   * How many groups the seeder creates, and therefore how many ids the home
+   * screen sends to `groups.list` / `groups.balances.forUser`. 20 is a busy but
+   * realistic `recentGroups` local-storage list.
+   */
+  groups: intFromEnv('PERF_GROUPS', 20),
+
+  /** Group 1 is the large one -- everything about scrolling and unpaged loads is measured against it. */
+  largeGroupExpenses: intFromEnv('PERF_LARGE_GROUP_EXPENSES', 2000),
+  largeGroupParticipants: intFromEnv('PERF_LARGE_GROUP_PARTICIPANTS', 20),
+
+  /** Groups 2..N. Small, but they still each cost a full expense load in `balances.forUser`. */
+  smallGroupExpenses: intFromEnv('PERF_SMALL_GROUP_EXPENSES', 30),
+  smallGroupParticipants: intFromEnv('PERF_SMALL_GROUP_PARTICIPANTS', 5),
+
+  /** Timed iterations per step, after `warmup` untimed ones. */
+  iterations: intFromEnv('PERF_ITERATIONS', 30),
+  warmup: intFromEnv('PERF_WARMUP', 5),
+
+  /**
+   * Must match PAGE_SIZE in src/app/groups/[groupId]/expenses/expense-list.tsx.
+   * If that changes, this should change with it -- the point is to measure the
+   * page the app actually requests.
+   */
+  pageSize: 20,
+} as const
+
+/** Base URL of the app under test. `scripts/perf.sh` sets PERF_HOST_PORT. */
+export const baseUrl =
+  process.env['PERF_BASE_URL'] ??
+  `http://localhost:${process.env['PERF_HOST_PORT'] ?? '3100'}`
+
+/**
+ * Connection string for the seeder. This is deliberately NOT the app's
+ * POSTGRES_PRISMA_URL: the app reaches postgres as `db:5432` inside the compose
+ * network, while the seeder runs on the host and reaches the published port.
+ */
+export const seedDatabaseUrl =
+  process.env['PERF_DATABASE_URL'] ??
+  `postgresql://postgres:perf@localhost:${process.env['PERF_DB_PORT'] ?? '55432'}/spliit_perf`
+
+export const groupId = (index: number) =>
+  `perf-group-${String(index).padStart(2, '0')}`
+
+export const participantId = (group: number, participant: number) =>
+  `perf-p-${String(group).padStart(2, '0')}-${String(participant).padStart(3, '0')}`
+
+export const expenseId = (group: number, expense: number) =>
+  `perf-e-${String(group).padStart(2, '0')}-${String(expense).padStart(6, '0')}`
+
+/** The large group, addressed by every `view-group` and `view-expense` step. */
+export const LARGE_GROUP = 1
+
+export const expenseCountFor = (group: number) =>
+  group === LARGE_GROUP ? config.largeGroupExpenses : config.smallGroupExpenses
+
+export const participantCountFor = (group: number) =>
+  group === LARGE_GROUP
+    ? config.largeGroupParticipants
+    : config.smallGroupParticipants
+
+/**
+ * Offset used by the `deep-page` step. Halfway through the large group, so it
+ * scales with the dataset and always lands on a full page of results.
+ */
+export const deepPageOffset =
+  Math.floor(config.largeGroupExpenses / 2 / config.pageSize) * config.pageSize
+
+/**
+ * Every 10th expense in the large group gets this token in its title, so the
+ * search step matches an exactly known number of rows. See `seed.ts`.
+ */
+export const SEARCH_TOKEN = 'Zzyzx'
+
+export const searchMatchCount = Math.floor(config.largeGroupExpenses / 10)
+
+/**
+ * How many participants an expense is split between. Shared by the seeder and
+ * the budgets so the expected row count is never a copy of the formula that
+ * produced it.
+ */
+export const paidForCountFor = (group: number, expenseIndex: number) =>
+  2 + (expenseIndex % Math.max(1, participantCountFor(group) - 1))
+
+/** The expense addressed by the `view-expense` scenario. */
+export const targetExpenseIndex = Math.floor(config.largeGroupExpenses / 2)

--- a/perf/harness.ts
+++ b/perf/harness.ts
@@ -1,0 +1,141 @@
+/**
+ * Runs one step many times and reduces it to a result row.
+ *
+ * Deliberately not a benchmark library: each iteration here is a 10-100 ms HTTP
+ * round trip to a real database, not a microbenchmark, so the sampling
+ * machinery a bench library exists to provide (nanosecond timers, adaptive
+ * iteration counts, outlier trimming) has nothing to bite on. Warmup plus
+ * percentiles is the whole of it.
+ */
+import { performance } from 'node:perf_hooks'
+import { type Recording, withRecording } from './client'
+import { config } from './config'
+
+/**
+ * A step returns the number of rows it received, which is the third
+ * deterministic signal alongside request count and byte size. What counts as a
+ * "row" is scenario-specific and documented at each call site.
+ */
+export type Step = {
+  name: string
+  run: () => Promise<number>
+}
+
+export type Timings = {
+  min: number
+  p50: number
+  p95: number
+  p99: number
+  max: number
+}
+
+export type StepResult = {
+  name: string
+  iterations: number
+  /** First call against a freshly started app: cold caches, cold connection pool. */
+  cold: number
+  timings: Timings
+  rows: number
+  recording: Recording
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return Number.NaN
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((p / 100) * sorted.length) - 1),
+  )
+  return sorted[index]!
+}
+
+/**
+ * Fails when a supposedly deterministic value moves between iterations of the
+ * same step. If this trips, the gate is not trustworthy -- the dataset or the
+ * scenario has hidden state in it -- and that is worth stopping for rather than
+ * quietly averaging away.
+ */
+function assertStable(
+  step: string,
+  field: string,
+  first: number | null,
+  seen: number | null,
+) {
+  if (first !== seen) {
+    throw new Error(
+      `Non-deterministic ${field} in step "${step}": got ${seen} after ${first}. ` +
+        `The suite cannot gate on a value that changes between identical calls.`,
+    )
+  }
+}
+
+export async function runStep(step: Step): Promise<StepResult> {
+  // The very first call also pays for the connection pool opening and Next.js
+  // compiling the route, so it is reported separately rather than folded into
+  // the percentiles.
+  const coldStart = performance.now()
+  await withRecording(step.run)
+  const cold = performance.now() - coldStart
+
+  for (let i = 1; i < config.warmup; i++) {
+    await withRecording(step.run)
+  }
+
+  const samples: number[] = []
+  let reference: { rows: number; recording: Recording } | null = null
+
+  for (let i = 0; i < config.iterations; i++) {
+    const start = performance.now()
+    const { result: rows, recording } = await withRecording(step.run)
+    samples.push(performance.now() - start)
+
+    if (reference === null) {
+      reference = { rows, recording }
+    } else {
+      assertStable(step.name, 'row count', reference.rows, rows)
+      assertStable(
+        step.name,
+        'request count',
+        reference.recording.requests,
+        recording.requests,
+      )
+      assertStable(
+        step.name,
+        'response bytes',
+        reference.recording.bytes,
+        recording.bytes,
+      )
+      assertStable(
+        step.name,
+        'query count',
+        reference.recording.dbQueries,
+        recording.dbQueries,
+      )
+      // dbMs is a duration, not a deterministic value -- keep the fastest seen
+      // as a representative figure.
+      if (
+        recording.dbMs !== null &&
+        (reference.recording.dbMs === null ||
+          recording.dbMs < reference.recording.dbMs)
+      ) {
+        reference.recording.dbMs = recording.dbMs
+      }
+    }
+  }
+
+  const sorted = [...samples].sort((a, b) => a - b)
+
+  return {
+    name: step.name,
+    iterations: config.iterations,
+    cold,
+    timings: {
+      min: sorted[0]!,
+      p50: percentile(sorted, 50),
+      p95: percentile(sorted, 95),
+      p99: percentile(sorted, 99),
+      max: sorted[sorted.length - 1]!,
+    },
+    rows: reference!.rows,
+    recording: reference!.recording,
+  }
+}

--- a/perf/random.ts
+++ b/perf/random.ts
@@ -1,0 +1,29 @@
+/**
+ * Seeded PRNG, so every run of `perf/seed.ts` produces byte-identical data.
+ *
+ * This is load-bearing rather than a nicety: the deterministic budgets in
+ * `budgets.ts` assert on response sizes and row counts, which are only stable
+ * if the rows themselves are. `Math.random()` would make the whole gate flap.
+ *
+ * mulberry32 -- 32 bits of state, no dependency, and more than good enough for
+ * generating plausible expense titles and amounts.
+ */
+export function makeRandom(seed: number) {
+  let state = seed >>> 0
+
+  const next = (): number => {
+    state = (state + 0x6d2b79f5) | 0
+    let t = Math.imul(state ^ (state >>> 15), 1 | state)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  return {
+    next,
+    /** Integer in [min, max]. */
+    int: (min: number, max: number) =>
+      min + Math.floor(next() * (max - min + 1)),
+    pick: <T>(items: readonly T[]): T =>
+      items[Math.floor(next() * items.length)]!,
+  }
+}

--- a/perf/run.ts
+++ b/perf/run.ts
@@ -1,0 +1,201 @@
+/**
+ * Entry point: runs every scenario against a seeded, running app, prints a
+ * report, writes it as JSON, and fails when a deterministic budget is exceeded.
+ *
+ * Usage (normally via `npm run perf`, which brings the stack up first):
+ *   ts-node -T perf/run.ts [--filter <substring>] [--json <path>]
+ */
+import { writeFileSync } from 'node:fs'
+import { type Budget, budgets } from './budgets'
+import { waitForApp } from './client'
+import { baseUrl, config } from './config'
+import { type StepResult, runStep } from './harness'
+import { listGroups } from './scenarios/list-groups'
+import { viewExpense } from './scenarios/view-expense'
+import { viewGroup } from './scenarios/view-group'
+
+const steps = [...listGroups, ...viewGroup, ...viewExpense]
+
+type Violation = {
+  step: string
+  metric: string
+  actual: number
+  budget: number
+}
+
+function checkBudget(result: StepResult, budget: Budget): Violation[] {
+  const violations: Violation[] = []
+  const { recording } = result
+
+  if (recording.requests > budget.requests) {
+    violations.push({
+      step: result.name,
+      metric: 'requests',
+      actual: recording.requests,
+      budget: budget.requests,
+    })
+  }
+
+  if (recording.bytes > budget.bytes) {
+    violations.push({
+      step: result.name,
+      metric: 'bytes',
+      actual: recording.bytes,
+      budget: budget.bytes,
+    })
+  }
+
+  // Rows is an equality check, not a ceiling: fetching fewer rows than expected
+  // means the scenario stopped exercising what it was written to exercise.
+  if (budget.rows !== undefined && result.rows !== budget.rows) {
+    violations.push({
+      step: result.name,
+      metric: 'rows (exact)',
+      actual: result.rows,
+      budget: budget.rows,
+    })
+  }
+
+  // Skipped entirely when the app runs without PERF_INSTRUMENTATION.
+  if (budget.dbQueries !== undefined && recording.dbQueries !== null) {
+    if (recording.dbQueries > budget.dbQueries) {
+      violations.push({
+        step: result.name,
+        metric: 'dbQueries',
+        actual: recording.dbQueries,
+        budget: budget.dbQueries,
+      })
+    }
+  }
+
+  return violations
+}
+
+const ms = (value: number) => `${value.toFixed(1)}ms`
+const pad = (value: string, width: number) => value.padEnd(width)
+const padStart = (value: string, width: number) => value.padStart(width)
+
+function report(results: StepResult[]) {
+  const nameWidth = Math.max(...results.map((r) => r.name.length), 4)
+
+  console.log('')
+  console.log(
+    `${pad('step', nameWidth)}  ${padStart('p50', 9)}  ${padStart('p95', 9)}  ` +
+      `${padStart('cold', 9)}  ${padStart('db ms', 8)}  ${padStart('queries', 8)}  ` +
+      `${padStart('bytes', 9)}  ${padStart('rows', 6)}`,
+  )
+  console.log('-'.repeat(nameWidth + 68))
+
+  for (const result of results) {
+    const budget = budgets[result.name]
+    const queries =
+      result.recording.dbQueries === null
+        ? '-'
+        : budget?.dbQueries !== undefined
+          ? `${result.recording.dbQueries}/${budget.dbQueries}`
+          : String(result.recording.dbQueries)
+    const bytes =
+      budget !== undefined
+        ? `${result.recording.bytes}/${budget.bytes}`
+        : String(result.recording.bytes)
+
+    console.log(
+      `${pad(result.name, nameWidth)}  ${padStart(ms(result.timings.p50), 9)}  ` +
+        `${padStart(ms(result.timings.p95), 9)}  ${padStart(ms(result.cold), 9)}  ` +
+        `${padStart(result.recording.dbMs === null ? '-' : ms(result.recording.dbMs), 8)}  ` +
+        `${padStart(queries, 8)}  ${padStart(bytes, 9)}  ` +
+        `${padStart(String(result.rows), 6)}`,
+    )
+  }
+  console.log('')
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const filterIndex = args.indexOf('--filter')
+  const filter = filterIndex === -1 ? null : args[filterIndex + 1]
+  const jsonIndex = args.indexOf('--json')
+  const jsonPath = jsonIndex === -1 ? 'perf-report.json' : args[jsonIndex + 1]!
+
+  const selected = filter
+    ? steps.filter((step) => step.name.includes(filter))
+    : steps
+
+  if (selected.length === 0) {
+    throw new Error(`No steps matched --filter ${filter}`)
+  }
+
+  console.log(`Target:  ${baseUrl}`)
+  console.log(
+    `Dataset: ${config.groups} groups, large group ${config.largeGroupExpenses} expenses / ` +
+      `${config.largeGroupParticipants} participants`,
+  )
+  console.log(
+    `Sampling: ${config.warmup} warmup + ${config.iterations} timed iterations per step`,
+  )
+
+  await waitForApp()
+
+  const results: StepResult[] = []
+  for (const step of selected) {
+    process.stdout.write(`  running ${step.name} ... `)
+    const result = await runStep(step)
+    console.log(`${ms(result.timings.p50)} p50`)
+    results.push(result)
+  }
+
+  report(results)
+
+  const instrumented = results.some((r) => r.recording.dbQueries !== null)
+  if (!instrumented) {
+    console.log(
+      'Note: the app is running without PERF_INSTRUMENTATION, so server-side ' +
+        'query counts are unavailable and their budgets were skipped.',
+    )
+  }
+
+  writeFileSync(
+    jsonPath,
+    `${JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        baseUrl,
+        config,
+        instrumented,
+        results,
+      },
+      null,
+      2,
+    )}\n`,
+  )
+  console.log(`Report written to ${jsonPath}`)
+
+  const violations = results.flatMap((result) => {
+    const budget = budgets[result.name]
+    if (!budget) {
+      console.warn(`No budget defined for step "${result.name}"`)
+      return []
+    }
+    return checkBudget(result, budget)
+  })
+
+  if (violations.length > 0) {
+    console.error('\nBudget exceeded:')
+    for (const violation of violations) {
+      console.error(
+        `  ${violation.step}  ${violation.metric}: ${violation.actual} (budget ${violation.budget})`,
+      )
+    }
+    console.error(
+      '\nIf this change is intentional, update perf/budgets.ts with the new figures.',
+    )
+    process.exit(1)
+  }
+
+  console.log('All deterministic budgets met.')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/perf/scenarios/list-groups.ts
+++ b/perf/scenarios/list-groups.ts
@@ -1,0 +1,37 @@
+/**
+ * The `/groups` home screen.
+ *
+ * Two client queries fire on mount and `httpBatchLink` combines them into one
+ * request: `groups.list` with the ids from local storage
+ * (src/app/groups/recent-group-list.tsx) and `groups.balances.forUser` with the
+ * active participant per group (src/app/groups/global-balance-card.tsx).
+ *
+ * This is the step that puts a number on the fan-out in
+ * src/trpc/routers/groups/balances/forUser.procedure.ts, which runs `getGroup`
+ * plus a full unpaged `getGroupExpenses` for every single recent group.
+ */
+import { batched } from '../client'
+import { config, groupId, participantId } from '../config'
+import type { Step } from '../harness'
+
+const groupIds = Array.from({ length: config.groups }, (_, i) => groupId(i + 1))
+
+const forUser = groupIds.map((id, i) => ({
+  groupId: id,
+  // Participant 0 of each group is the "active user" the home screen tracks.
+  participantId: participantId(i + 1, 0),
+}))
+
+export const listGroups: Step[] = [
+  {
+    name: 'list-groups:home',
+    /** Rows: one per group listed, plus one balance per group. */
+    run: async () => {
+      const [groups, balances] = await Promise.all([
+        batched.groups.list.query({ groupIds }),
+        batched.groups.balances.forUser.query({ groups: forUser }),
+      ])
+      return groups.groups.length + balances.balances.length
+    },
+  },
+]

--- a/perf/scenarios/view-expense.ts
+++ b/perf/scenarios/view-expense.ts
@@ -1,0 +1,45 @@
+/**
+ * `/groups/[groupId]/expenses/[expenseId]/edit` -- which is what "viewing a
+ * spending" means here, since expense cards navigate straight to the edit route
+ * and there is no read-only expense page.
+ *
+ * `EditExpenseForm` fires three queries in parallel and renders nothing until
+ * all three resolve, so the batch below is the whole critical path of that
+ * screen.
+ */
+import { batched } from '../client'
+import { LARGE_GROUP, expenseId, groupId, targetExpenseIndex } from '../config'
+import type { Step } from '../harness'
+
+const id = groupId(LARGE_GROUP)
+// An expense in the middle of the group: addressed by primary key, so its
+// position should not matter -- which is itself worth being able to see.
+const target = expenseId(LARGE_GROUP, targetExpenseIndex)
+
+export const viewExpense: Step[] = [
+  {
+    name: 'view-expense:edit-form',
+    /**
+     * Rows: the group's participants plus who the expense was paid for.
+     * Categories are deliberately excluded -- that table is static reference
+     * data seeded by migrations, so pinning its size here would turn "someone
+     * added a category" into a performance failure. The bytes budget still
+     * covers the category payload, which is the part that actually costs.
+     */
+    run: async () => {
+      const [group, categories, expense] = await Promise.all([
+        batched.groups.get.query({ groupId: id }),
+        batched.categories.list.query(),
+        batched.groups.expenses.get.query({ groupId: id, expenseId: target }),
+      ])
+      if (categories.categories.length === 0) {
+        throw new Error(
+          'categories.list returned nothing; is the database migrated?',
+        )
+      }
+      return (
+        (group.group?.participants.length ?? 0) + expense.expense.paidFor.length
+      )
+    },
+  },
+]

--- a/perf/scenarios/view-group.ts
+++ b/perf/scenarios/view-group.ts
@@ -1,0 +1,79 @@
+/**
+ * `/groups/[groupId]/expenses` and the Balances tab, against the large group.
+ *
+ * `first-page` mirrors what the page actually issues on mount: the layout's
+ * `groups.get` and the list's `groups.expenses.list` at PAGE_SIZE, batched
+ * together (src/app/groups/[groupId]/expenses/expense-list.tsx).
+ *
+ * The other three steps each target a query shape that is cheap on a small
+ * group and progressively less so on a large one:
+ *
+ * - `deep-page`  offset pagination (`nextCursor = cursor + limit`) against an
+ *   `orderBy` that has no matching index.
+ * - `search`     `title: { contains, mode: 'insensitive' }`, i.e. an unindexed
+ *   scan of the group's expenses.
+ * - `balances`   `getGroupExpenses(groupId)` with no `take` at all -- the whole
+ *   group is loaded to compute balances in JS.
+ */
+import { batched, single } from '../client'
+import {
+  LARGE_GROUP,
+  SEARCH_TOKEN,
+  config,
+  deepPageOffset,
+  groupId,
+} from '../config'
+import type { Step } from '../harness'
+
+const id = groupId(LARGE_GROUP)
+
+export const viewGroup: Step[] = [
+  {
+    name: 'view-group:first-page',
+    /** Rows: the group's participants plus the first page of expenses. */
+    run: async () => {
+      const [group, expenses] = await Promise.all([
+        batched.groups.get.query({ groupId: id }),
+        batched.groups.expenses.list.query({
+          groupId: id,
+          cursor: 0,
+          limit: config.pageSize,
+        }),
+      ])
+      return (group.group?.participants.length ?? 0) + expenses.expenses.length
+    },
+  },
+  {
+    name: 'view-group:deep-page',
+    /** Rows: one page of expenses, fetched from halfway down the list. */
+    run: async () => {
+      const expenses = await single.groups.expenses.list.query({
+        groupId: id,
+        cursor: deepPageOffset,
+        limit: config.pageSize,
+      })
+      return expenses.expenses.length
+    },
+  },
+  {
+    name: 'view-group:search',
+    /** Rows: one page of matches for a token seeded into every 10th expense. */
+    run: async () => {
+      const expenses = await single.groups.expenses.list.query({
+        groupId: id,
+        cursor: 0,
+        limit: config.pageSize,
+        filter: SEARCH_TOKEN,
+      })
+      return expenses.expenses.length
+    },
+  },
+  {
+    name: 'view-group:balances',
+    /** Rows: balances plus suggested reimbursements. */
+    run: async () => {
+      const result = await single.groups.balances.list.query({ groupId: id })
+      return Object.keys(result.balances).length + result.reimbursements.length
+    },
+  },
+]

--- a/perf/seed.ts
+++ b/perf/seed.ts
@@ -1,0 +1,289 @@
+/**
+ * Seeds the performance database with a deterministic dataset.
+ *
+ * Talks to postgres through `pg` rather than through Prisma, for two reasons.
+ * The generated Prisma 7 client is ESM-only and cannot be required from the
+ * CommonJS context ts-node gives these scripts; and multi-row INSERTs are far
+ * faster than `createMany` for the tens of thousands of rows this writes.
+ * Going through `src/lib/api.ts` would be slower still -- that path writes one
+ * expense per call and logs an activity for each.
+ *
+ * Three properties of this data are load-bearing for the budgets:
+ *
+ * 1. **Fixed seed, fixed timestamps.** `budgets.ts` asserts on response byte
+ *    sizes, which are only stable if the rows are identical every run.
+ *
+ * 2. **Total ordering is unambiguous.** The expense list sorts by
+ *    `[{expenseDate: desc}, {createdAt: desc}]`. If two rows tied on both,
+ *    postgres could return them in either order and the byte counts would flap.
+ *    Every expense therefore gets a unique `createdAt`.
+ *
+ * 3. **Nothing recurs.** `getGroupExpenses` calls `createRecurringExpenses()`
+ *    on every read (src/lib/api.ts), which *writes* when a frame is due -- during
+ *    a benchmark that would move both row and query counts between iterations.
+ *    Every expense is `NONE` with no `RecurringExpenseLink`, so that pass finds
+ *    nothing to do and stays a single constant-cost query.
+ */
+import { Client } from 'pg'
+import {
+  SEARCH_TOKEN,
+  config,
+  expenseCountFor,
+  expenseId,
+  groupId,
+  paidForCountFor,
+  participantCountFor,
+  participantId,
+  seedDatabaseUrl,
+} from './config'
+import { makeRandom } from './random'
+
+const TITLES = [
+  'Groceries',
+  'Dinner',
+  'Taxi',
+  'Train tickets',
+  'Hotel',
+  'Museum',
+  'Coffee',
+  'Brunch',
+  'Petrol',
+  'Parking',
+  'Snacks',
+  'Drinks',
+  'Cinema',
+  'Supermarket',
+  'Pharmacy',
+  'Bakery',
+  'Lunch',
+  'Ferry',
+]
+
+const NAMES = [
+  'Ada',
+  'Bruno',
+  'Chiara',
+  'Dmitri',
+  'Elena',
+  'Farid',
+  'Greta',
+  'Hugo',
+  'Ines',
+  'Jonas',
+  'Kira',
+  'Lars',
+  'Mira',
+  'Noor',
+  'Otto',
+  'Pia',
+  'Quentin',
+  'Rosa',
+  'Sven',
+  'Tuva',
+]
+
+/**
+ * Fixed epoch for every generated timestamp. `new Date()` would change the
+ * payload on each run and defeat the byte budgets.
+ */
+const EPOCH = Date.UTC(2025, 0, 1, 12, 0, 0)
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** Rows per INSERT. 500 x 15 columns stays well inside the 65535 parameter cap. */
+const CHUNK = 500
+
+const pad = (value: number, width: number) => String(value).padStart(width, '0')
+
+/** `expenseDate` is a DATE column: format explicitly so no timezone shifts it. */
+function toDateOnly(ms: number): string {
+  const d = new Date(ms)
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1, 2)}-${pad(d.getUTCDate(), 2)}`
+}
+
+/** `createdAt` is TIMESTAMP WITHOUT TIME ZONE: same reasoning. */
+function toTimestamp(ms: number): string {
+  const d = new Date(ms)
+  return (
+    `${toDateOnly(ms)} ${pad(d.getUTCHours(), 2)}:${pad(d.getUTCMinutes(), 2)}:` +
+    `${pad(d.getUTCSeconds(), 2)}.${pad(d.getUTCMilliseconds(), 3)}`
+  )
+}
+
+/**
+ * Builds `INSERT INTO t (cols) VALUES ($1,$2,...),($3,$4,...)` and runs it in
+ * chunks. `casts` maps a column index to a postgres type, needed for the enum
+ * columns where an untyped parameter cannot be inferred.
+ */
+async function insertRows(
+  client: Client,
+  table: string,
+  columns: string[],
+  rows: unknown[][],
+  casts: Record<number, string> = {},
+) {
+  const columnList = columns.map((c) => `"${c}"`).join(', ')
+
+  for (let start = 0; start < rows.length; start += CHUNK) {
+    const batch = rows.slice(start, start + CHUNK)
+    const values: unknown[] = []
+    const tuples = batch.map((row) => {
+      const placeholders = row.map((value, column) => {
+        values.push(value)
+        const cast = casts[column]
+        return cast ? `$${values.length}::${cast}` : `$${values.length}`
+      })
+      return `(${placeholders.join(', ')})`
+    })
+
+    await client.query(
+      `INSERT INTO "${table}" (${columnList}) VALUES ${tuples.join(', ')}`,
+      values,
+    )
+  }
+}
+
+async function main() {
+  const client = new Client({ connectionString: seedDatabaseUrl })
+  await client.connect()
+
+  try {
+    // RESTART IDENTITY CASCADE, but never on Category (populated by migration
+    // 20240108194443_add_categories -- expenses reference it) or on
+    // _prisma_migrations.
+    await client.query(`
+      TRUNCATE TABLE
+        "ExpensePaidFor", "ExpenseDocument", "RecurringExpenseLink",
+        "Activity", "Expense", "Participant", "Group"
+      RESTART IDENTITY CASCADE
+    `)
+
+    const { rows: categories } = await client.query<{ id: number }>(
+      'SELECT id FROM "Category" ORDER BY id ASC',
+    )
+    if (categories.length === 0) {
+      throw new Error(
+        'No categories found. The database is missing its migrations -- run `prisma migrate deploy` first.',
+      )
+    }
+
+    let totalExpenses = 0
+
+    for (let g = 1; g <= config.groups; g++) {
+      // Seeded per group, so raising PERF_GROUPS does not reshuffle the data of
+      // the groups that were already there.
+      const random = makeRandom(0x5eed + g)
+      const participants = participantCountFor(g)
+      const expenses = expenseCountFor(g)
+
+      await insertRows(
+        client,
+        'Group',
+        ['id', 'name', 'currency', 'currencyCode', 'createdAt'],
+        [
+          [
+            groupId(g),
+            `Perf Group ${pad(g, 2)}`,
+            '$',
+            'USD',
+            toTimestamp(EPOCH),
+          ],
+        ],
+      )
+
+      await insertRows(
+        client,
+        'Participant',
+        ['id', 'name', 'groupId'],
+        Array.from({ length: participants }, (_, p) => [
+          participantId(g, p),
+          `${NAMES[p % NAMES.length]} ${p}`,
+          groupId(g),
+        ]),
+      )
+
+      const expenseRows = Array.from({ length: expenses }, (_, i) => {
+        // Every 10th expense carries SEARCH_TOKEN, so the search step matches an
+        // exactly known number of rows (config.searchMatchCount).
+        const title =
+          i % 10 === 0
+            ? `${SEARCH_TOKEN} ${random.pick(TITLES)}`
+            : `${random.pick(TITLES)} ${i}`
+
+        return {
+          id: expenseId(g, i),
+          title,
+          amount: random.int(250, 25000),
+          // Three expenses per day, and a strictly decreasing createdAt, so
+          // (expenseDate desc, createdAt desc) is a total order equal to `i`.
+          expenseDate: toDateOnly(EPOCH - Math.floor(i / 3) * DAY_MS),
+          createdAt: toTimestamp(EPOCH - i * 1000),
+          categoryId: categories[i % categories.length]!.id,
+          paidById: participantId(g, i % participants),
+          // A minority of reimbursements, as in a real group.
+          isReimbursement: i % 17 === 0,
+          splitMode: i % 7 === 0 ? 'BY_SHARES' : 'EVENLY',
+        }
+      })
+
+      await insertRows(
+        client,
+        'Expense',
+        [
+          'id',
+          'title',
+          'amount',
+          'expenseDate',
+          'createdAt',
+          'categoryId',
+          'paidById',
+          'groupId',
+          'isReimbursement',
+          'splitMode',
+          'recurrenceRule',
+        ],
+        expenseRows.map((e) => [
+          e.id,
+          e.title,
+          e.amount,
+          e.expenseDate,
+          e.createdAt,
+          e.categoryId,
+          e.paidById,
+          groupId(g),
+          e.isReimbursement,
+          e.splitMode,
+          'NONE',
+        ]),
+        { 9: '"SplitMode"', 10: '"RecurrenceRule"' },
+      )
+
+      await insertRows(
+        client,
+        'ExpensePaidFor',
+        ['expenseId', 'participantId', 'shares'],
+        expenseRows.flatMap((expense, i) =>
+          Array.from({ length: paidForCountFor(g, i) }, (_, s) => [
+            expense.id,
+            participantId(g, (i + s) % participants),
+            expense.splitMode === 'BY_SHARES' ? 1 + (s % 3) : 1,
+          ]),
+        ),
+      )
+
+      totalExpenses += expenses
+    }
+
+    console.log(
+      `Seeded ${config.groups} groups / ${totalExpenses} expenses ` +
+        `(large group ${groupId(1)}: ${config.largeGroupExpenses} expenses, ` +
+        `${config.largeGroupParticipants} participants).`,
+    )
+  } finally {
+    await client.end()
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/perf/to-benchmark-json.ts
+++ b/perf/to-benchmark-json.ts
@@ -1,0 +1,80 @@
+/**
+ * Converts `perf-report.json` into the `customSmallerIsBetter` shape that
+ * benchmark-action/github-action-benchmark consumes, so release builds land as
+ * points on a trend chart.
+ *
+ * Emits two files, because the two kinds of metric need opposite treatment:
+ *
+ *   deterministic  query counts, response bytes, row counts. Exactly
+ *                  reproducible, so the workflow alerts on them tightly and
+ *                  fails on a regression.
+ *   timing         p50 / p95 wall clock. Charted for the eye only, never
+ *                  alerted -- see the note on runner noise in README.md.
+ *
+ * Usage: ts-node -T perf/to-benchmark-json.ts <report> <deterministic> <timing>
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import type { StepResult } from './harness'
+
+type Entry = { name: string; unit: string; value: number }
+
+type Report = {
+  instrumented: boolean
+  results: StepResult[]
+}
+
+function main() {
+  const [reportPath, deterministicPath, timingPath] = process.argv.slice(2)
+  if (!reportPath || !deterministicPath || !timingPath) {
+    throw new Error(
+      'usage: to-benchmark-json.ts <report> <deterministic-out> <timing-out>',
+    )
+  }
+
+  const report = JSON.parse(readFileSync(reportPath, 'utf8')) as Report
+
+  const deterministic: Entry[] = []
+  const timing: Entry[] = []
+
+  for (const result of report.results) {
+    deterministic.push({
+      name: `${result.name} bytes`,
+      unit: 'bytes',
+      value: result.recording.bytes,
+    })
+    if (result.recording.dbQueries !== null) {
+      deterministic.push({
+        name: `${result.name} queries`,
+        unit: 'queries',
+        value: result.recording.dbQueries,
+      })
+    }
+
+    timing.push({
+      name: `${result.name} p50`,
+      unit: 'ms',
+      value: Number(result.timings.p50.toFixed(2)),
+    })
+    timing.push({
+      name: `${result.name} p95`,
+      unit: 'ms',
+      value: Number(result.timings.p95.toFixed(2)),
+    })
+  }
+
+  if (deterministic.length === 0) {
+    throw new Error(`No results found in ${reportPath}`)
+  }
+
+  writeFileSync(
+    deterministicPath,
+    `${JSON.stringify(deterministic, null, 2)}\n`,
+  )
+  writeFileSync(timingPath, `${JSON.stringify(timing, null, 2)}\n`)
+
+  console.log(
+    `Wrote ${deterministic.length} deterministic and ${timing.length} timing entries.`,
+  )
+}
+
+main()

--- a/scripts/perf.sh
+++ b/scripts/perf.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Runs the performance suite against an isolated app + postgres stack built from
+# this checkout. CI calls the same subcommands, so local and CI runs are identical.
+#
+#   ./scripts/perf.sh                 build, start, seed, benchmark, tear down
+#   ./scripts/perf.sh up              start and leave running
+#   ./scripts/perf.sh seed            (re)seed the database of a running stack
+#   ./scripts/perf.sh bench           benchmark an already-running, already-seeded stack
+#   ./scripts/perf.sh logs            dump container logs
+#   ./scripts/perf.sh down            stop and delete the database
+#
+# Env:
+#   PERF_HOST_PORT   host port for the app (default 3100)
+#   PERF_DB_PORT     host port for postgres (default 55432)
+#   PERF_SKIP_BUILD  set to 1 when the image was already built (CI cache path)
+#   PERF_GROUPS, PERF_LARGE_GROUP_EXPENSES, ...  dataset sizing, see perf/config.ts
+#   PERF_ITERATIONS, PERF_WARMUP                 sampling, see perf/config.ts
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PERF_HOST_PORT="${PERF_HOST_PORT:-3100}"
+PERF_DB_PORT="${PERF_DB_PORT:-55432}"
+export PERF_HOST_PORT PERF_DB_PORT
+
+compose() { docker compose -f compose.perf.yaml "$@"; }
+
+up() {
+  # --force-recreate --renew-anon-volumes is what actually guarantees a clean
+  # database: the postgres image declares its own VOLUME, so a plain `up` would
+  # silently reattach the previous run's anonymous volume.
+  #
+  # Spelled out twice rather than built as an array: macOS still ships bash 3.2,
+  # where `set -u` treats an empty array expansion as an unbound variable.
+  if [ "${PERF_SKIP_BUILD:-}" = "1" ]; then
+    compose up --wait --wait-timeout 300 --force-recreate --renew-anon-volumes
+  else
+    compose up --wait --wait-timeout 300 --force-recreate --renew-anon-volumes --build
+  fi
+}
+
+down() { compose down --volumes --remove-orphans --timeout 10; }
+
+logs() { compose logs --no-color --timestamps; }
+
+seed() { npx ts-node -T perf/seed.ts; }
+
+bench() {
+  shift || true
+  npx ts-node -T perf/run.ts "$@"
+}
+
+case "${1:-all}" in
+up) up ;;
+down) down ;;
+logs) logs ;;
+seed) seed ;;
+bench) bench "$@" ;;
+all)
+  # Drop an explicit leading "all" so it is not forwarded as an argument.
+  # Spelled as an if, not `[ ... ] && shift`: under `set -e` a false test as the
+  # last command in the branch would abort the script.
+  if [ $# -gt 0 ]; then shift; fi
+  trap 'status=$?; if [ $status -ne 0 ]; then logs || true; fi; down || true; exit $status' EXIT
+  up
+  seed
+  npx ts-node -T perf/run.ts "$@"
+  ;;
+*)
+  echo "usage: $0 [all|up|seed|bench|down|logs]" >&2
+  exit 2
+  ;;
+esac

--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -1,13 +1,47 @@
+import {
+  PERF_INSTRUMENTATION_ENABLED,
+  type PerfCounters,
+  withPerfCounters,
+} from '@/lib/perf-instrumentation'
 import { createTRPCContext } from '@/trpc/init'
 import { appRouter } from '@/trpc/routers/_app'
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch'
 
-const handler = (req: Request) =>
+const handleRequest = (req: Request) =>
   fetchRequestHandler({
     endpoint: '/api/trpc',
     req,
     router: appRouter,
     createContext: createTRPCContext,
   })
+
+/**
+ * Reports how much database work the request did, for the `perf/` suite.
+ * Off unless PERF_INSTRUMENTATION=1, which only compose.perf.yaml sets.
+ */
+const handler = async (req: Request) => {
+  if (!PERF_INSTRUMENTATION_ENABLED) return handleRequest(req)
+
+  const counters: PerfCounters = { queries: 0, dbMs: 0 }
+  const response = await withPerfCounters(counters, () => handleRequest(req))
+
+  // tRPC builds this Response itself, so its headers are mutable -- but a
+  // response constructed from a fetch would not be, and this must never be the
+  // reason a request fails.
+  try {
+    response.headers.set('x-perf-db-queries', String(counters.queries))
+    response.headers.set('server-timing', `db;dur=${counters.dbMs.toFixed(1)}`)
+    return response
+  } catch {
+    const headers = new Headers(response.headers)
+    headers.set('x-perf-db-queries', String(counters.queries))
+    headers.set('server-timing', `db;dur=${counters.dbMs.toFixed(1)}`)
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  }
+}
 
 export { handler as GET, handler as POST }

--- a/src/lib/perf-instrumentation.ts
+++ b/src/lib/perf-instrumentation.ts
@@ -1,0 +1,43 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+/**
+ * Per-request counting of database work, for the benchmark suite in `perf/`.
+ *
+ * Everything here is inert unless `PERF_INSTRUMENTATION=1`, which only
+ * `compose.perf.yaml` sets. In every other deployment `enabled` is false, the
+ * Prisma client is returned unwrapped, and `/api/trpc` sets no extra headers.
+ *
+ * It exists because the costliest things the suite needs to watch are invisible
+ * from outside: `groups.balances.forUser` runs two queries per group, and
+ * `getGroupExpenses` runs an unscoped `createRecurringExpenses()` pass before
+ * its own query. Neither changes the response by a single byte, so response
+ * size alone cannot catch them regressing.
+ */
+export const PERF_INSTRUMENTATION_ENABLED =
+  process.env['PERF_INSTRUMENTATION'] === '1'
+
+export type PerfCounters = {
+  /** Prisma operations run. Not raw SQL statements: one `findMany` with an
+   * `include` may issue several but counts once. */
+  queries: number
+  /** Milliseconds spent inside those operations. */
+  dbMs: number
+}
+
+const store = new AsyncLocalStorage<PerfCounters>()
+
+/** Runs `fn` with a counter in scope. Anything it awaits counts into `counters`. */
+export function withPerfCounters<T>(
+  counters: PerfCounters,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return store.run(counters, fn)
+}
+
+/** Called by the Prisma extension for each operation. A no-op outside a scope. */
+export function recordQuery(durationMs: number): void {
+  const counters = store.getStore()
+  if (!counters) return
+  counters.queries += 1
+  counters.dbMs += durationMs
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,4 +1,8 @@
 import { PrismaClient } from '@/generated/prisma/client'
+import {
+  PERF_INSTRUMENTATION_ENABLED,
+  recordQuery,
+} from '@/lib/perf-instrumentation'
 import { PrismaPg } from '@prisma/adapter-pg'
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
@@ -9,10 +13,32 @@ function createPrismaClient() {
   const adapter = new PrismaPg({
     connectionString: process.env['POSTGRES_PRISMA_URL'],
   })
-  return new PrismaClient({
+  const client = new PrismaClient({
     adapter,
     // log: [{ emit: 'stdout', level: 'query' }],
   })
+
+  if (!PERF_INSTRUMENTATION_ENABLED) return client
+
+  // Counts operations into whatever `withPerfCounters` scope is active, so
+  // /api/trpc can report how much database work a request did. Only reached
+  // when PERF_INSTRUMENTATION=1, i.e. under compose.perf.yaml.
+  //
+  // `$extends` returns a structurally different (narrower) type than
+  // PrismaClient, so the cast is needed to keep one type for both branches.
+  // Nothing is removed by the extension -- it only wraps each operation.
+  return client.$extends({
+    query: {
+      async $allOperations({ args, query }) {
+        const start = performance.now()
+        try {
+          return await query(args)
+        } finally {
+          recordQuery(performance.now() - start)
+        }
+      },
+    },
+  }) as unknown as PrismaClient
 }
 
 export let p: PrismaClient = undefined as any as PrismaClient


### PR DESCRIPTION
## What this adds

A performance test suite for the three most-used flows, so future optimisation
work can be measured rather than guessed at, and so regressions get caught
automatically.

- **listing groups** — `/groups`
- **viewing one group** — `/groups/[id]/expenses`, plus deep paging, search and the balances tab
- **viewing a spending** — `/groups/[id]/expenses/[id]/edit`

Each scenario drives the same tRPC procedures the client does, through the real
`@trpc/client` links with the app's own batching and page size. A number here
corresponds to a screen, not to a query someone assumed the screen ran.

Nothing about the app's behaviour changes. No query, index or schema is touched
— the current numbers are deliberately the committed baseline, so the fixes they
justify will show up as a visible diff in `perf/budgets.ts`.

## What it measures today

Default dataset (20 groups, largest 2 000 expenses / 20 participants):

| step | p50 | queries | db time |
|---|---|---|---|
| `list-groups:home` | 174.6ms | 61 | 946ms |
| `view-group:first-page` | 12.2ms | 3 | 5.7ms |
| `view-group:deep-page` | 10.4ms | 2 | 4.8ms |
| `view-group:search` | 10.5ms | 2 | 4.8ms |
| `view-group:balances` | 134.6ms | 2 | 88.3ms |
| `view-expense:edit-form` | 6.5ms | 3 | 2.7ms |

The home screen is 61 queries — exactly `1 + 3 × groups`, from the fan-out in
`groups.balances.forUser`, which runs `getGroup` plus a full unpaged
`getGroupExpenses` per recent group. It is ~13× slower than any other step.

## Why the gate is deterministic and not time-based

Only request count, response bytes, row count and server-side query count can
fail the build. Against the fixed dataset in `perf/seed.ts` these are exactly
reproducible, so they can block a PR without flaking.

Wall-clock timings are recorded, printed and charted, but **never asserted**. On
a shared runner they vary enough between jobs that any threshold tight enough to
catch a real regression would also fire on noise.

Budgets are ceilings written as formulas over `perf/config.ts` rather than bare
numbers, so a resized dataset keeps working and the cost model is stated out
loud. `1 + 3 * config.groups` is a readable claim about the home screen, and a
diff turning it into `1 + config.groups` is a reviewable improvement rather than
a number that quietly moved.

## The three commits

They are separable on purpose.

1. **`add HTTP benchmark suite for the main group flows`** — entirely additive,
   nothing under `src/`. `perf/`, `compose.perf.yaml`, `scripts/perf.sh`, and a
   path-filtered workflow. Runs and gates on its own.

2. **`count server-side queries per request behind an env flag`** — the only
   production-code change, ~70 lines. A Prisma client extension records each
   operation into an `AsyncLocalStorage` scope; `/api/trpc` reports the total as
   `X-Perf-Db-Queries` plus a `Server-Timing` entry. Gated on
   `PERF_INSTRUMENTATION=1`, which only `compose.perf.yaml` sets — everywhere
   else the client is returned unwrapped and the route handler is unchanged.

   It exists because the costliest things here are invisible from outside: the
   `balances.forUser` fan-out and the unscoped `createRecurringExpenses()` pass
   that `getGroupExpenses` runs on every read don't change the response by a
   single byte, so response size alone cannot catch either regressing.

3. **`chart performance of release builds on GitHub Pages`** — runs on release
   tags (matching `cd.yml`/`e2e.yml`) and publishes via
   `benchmark-action/github-action-benchmark`. Two series: deterministic metrics
   alert at 110% and fail; timings are charted only. Publishing is a separate
   job so `contents: write` is scoped to tag builds and never granted on PR runs.

If the instrumentation isn't wanted, commit 1 stands alone: the query column
renders `—` and those budgets are skipped rather than failed.

## Infrastructure

Mirrors the existing e2e setup deliberately. `compose.perf.yaml` is a near-copy
of `compose.e2e.yaml` and `scripts/perf.sh` takes the same subcommands as
`scripts/e2e.sh`. Two differences, both load-bearing: the db port is published
(the seeder runs on the host), and the app defaults to port 3100 so a perf run
doesn't collide with a dev server or an e2e stack.

```sh
npm run perf          # build, start, seed, benchmark, tear down
npm run perf:up       # or keep the stack up while iterating
npm run perf:seed
npm run perf:bench -- --filter view-group
npm run perf:down