### PR TITLE
fix: by-amount split no longer resets to even when the total amount changes

### DIFF
--- a/e2e/split-modes.spec.ts
+++ b/e2e/split-modes.spec.ts
@@ -102,3 +102,44 @@ test('rejects percentages that do not add up to 100', async ({ page }) => {
   ).toBeVisible()
   await expect(page).toHaveURL(/\/expenses\/create/)
 })
+
+test('keeps manual by-amount splits when the total amount changes', async ({
+  page,
+}) => {
+  const groupId = await createGroup(page, {
+    name: `E2E AmountEdit ${uniqueSuffix()}`,
+    participants: PARTICIPANTS,
+  })
+
+  await page.goto(`/groups/${groupId}/expenses/create`)
+  const submit = page.getByRole('button', { name: 'Create', exact: true })
+  await expect(submit).toBeVisible({ timeout: 30_000 })
+
+  await fillStable(page.locator('input[name="title"]'), 'Dinner')
+  await fillStable(page.locator('input[name="amount"]'), '100')
+  await selectRadixOption(page, page.getByTestId('paid-by'), 'Alice')
+  await page.getByRole('button', { name: /Advanced splitting options/ }).click()
+  await selectRadixOption(page, page.getByTestId('split-mode'), /By amount/)
+
+  // Enter an uneven split; leave Carol to auto-fill the remainder.
+  await fillStable(paidForRow(page, 'Alice').getByRole('textbox'), '70')
+  await fillStable(paidForRow(page, 'Bob').getByRole('textbox'), '20')
+  await expect(paidForRow(page, 'Carol').getByRole('textbox')).toHaveValue('10')
+
+  // Bumping the total must NOT wipe the manually entered amounts back to an
+  // even split -- only the untouched participant (Carol) should re-balance.
+  // Before the fix this reset every share to an even 40 / 40 / 40.
+  await fillStable(page.locator('input[name="amount"]'), '120')
+
+  await expect(paidForRow(page, 'Alice').getByRole('textbox')).toHaveValue('70')
+  await expect(paidForRow(page, 'Bob').getByRole('textbox')).toHaveValue('20')
+  await expect(paidForRow(page, 'Carol').getByRole('textbox')).toHaveValue('30')
+
+  // And the uneven amounts survive the round-trip through save.
+  await submit.click()
+  await page.waitForURL(/\/groups\/[^/]+\/expenses(\?|$)/, { timeout: 30_000 })
+  await openTab(page, 'Balances')
+  await expectBalance(page, 'Alice', 50)
+  await expectBalance(page, 'Bob', -20)
+  await expectBalance(page, 'Carol', -30)
+})

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -365,8 +365,13 @@ export function ExpenseForm({
   const convertFromGroupCurrency = !!form.watch('isReimbursement')
 
   useEffect(() => {
+    // Reset only when the split mode changes. Keying this on 'amount' as well
+    // wiped every manually entered by-amount value back to an even split on any
+    // change to the total: clearing the set re-ran the auto-balance effect
+    // below with no participants marked as manually edited.
     setManuallyEditedParticipants(new Set())
-  }, [form.watch('splitMode'), form.watch('amount')])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form.watch('splitMode')])
 
   useEffect(() => {
     const splitMode = form.getValues().splitMode


### PR DESCRIPTION
### Summary

"Unevenly — split by amount" silently overwrites manually entered amounts with an **even** split whenever the total expense amount is edited afterwards.

### Root cause

In `src/app/groups/[groupId]/expenses/expense-form.tsx` two effects cooperate to auto-fill by-amount splits:

- a **reset effect** that clears `manuallyEditedParticipants`, and
- an **auto-balance effect** that keeps the manually edited participants and evenly distributes the remainder to the rest.

The reset effect was keyed on **both** `splitMode` **and** `amount`:

```ts
useEffect(() => {
  setManuallyEditedParticipants(new Set())
}, [form.watch('splitMode'), form.watch('amount')])
```

So any change to the total amount emptied the "manually edited" set. That state change re-ran the auto-balance effect with **no** participants marked as edited, which then redistributed the entire total **evenly** and discarded the amounts the user typed.

This has been present since the feature was introduced in commit c392c06 (#173, *"feat: add auto-balancing for the amount edit"*).

### Reproduction

1. Create a group with 3 participants and add an expense.
2. Total = `100`, split mode = **Unevenly — by amount**.
3. Enter `Alice = 70`, `Bob = 20` (Carol auto-fills to `10`).
4. Change the total from `100` to `120`.
5. **Before:** shares reset to an even `40 / 40 / 40`. **After:** stays `70 / 20`, and only the untouched Carol re-balances to `30`.

### Fix

Key the reset on `splitMode` only, so switching split modes still clears manual edits but editing the total no longer wipes them. The auto-balance effect already reacts to `amount` on its own, so the remainder still recalculates.

### Tests

Adds an e2e regression test in `e2e/split-modes.spec.ts` that enters an uneven by-amount split, bumps the total, and asserts the manual amounts are preserved (and persist through save into the balances).
