### PR TITLE
Lazily construct the OpenAI client to prevent throw

### DIFF
--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
@@ -2,15 +2,10 @@
 import { getCategories } from '@/lib/api'
 import { env } from '@/lib/env'
 import { getRuntimeFeatureFlags } from '@/lib/featureFlags'
+import { getOpenAIClient } from '@/lib/openai'
 import { isAllowedUploadUrl } from '@/lib/uploaded-image-url'
 import { formatCategoryForAIPrompt } from '@/lib/utils'
-import OpenAI from 'openai'
 import { z } from 'zod'
-
-const openai = new OpenAI({
-  apiKey: env.OPENAI_API_KEY,
-  baseURL: env.OPENAI_BASE_URL,
-})
 
 // The model is contractually bound to this shape by `strict: true` below, but
 // the response is still parsed rather than trusted: a self-hosted or older
@@ -40,6 +35,7 @@ export async function extractExpenseInformationFromImage(imageUrl: string) {
   }
 
   const categories = await getCategories()
+  const openai = getOpenAIClient()
 
   const completion = await openai.chat.completions.create({
     model: env.OPENAI_MODEL_RECEIPT_EXTRACT,

--- a/src/components/expense-form-actions.test.ts
+++ b/src/components/expense-form-actions.test.ts
@@ -1,6 +1,5 @@
-// `var` and the indirection through an arrow are both deliberate: the module
-// under test constructs its OpenAI client at import time, which jest hoists
-// above this file's own initialisation.
+// `var` and the indirection through an arrow keep the mock reachable if Jest
+// evaluation order changes. The OpenAI client is constructed lazily.
 var mockCreate = jest.fn()
 
 jest.mock('openai', () => ({

--- a/src/components/expense-form-actions.tsx
+++ b/src/components/expense-form-actions.tsx
@@ -2,14 +2,9 @@
 import { getCategories } from '@/lib/api'
 import { env } from '@/lib/env'
 import { getRuntimeFeatureFlags } from '@/lib/featureFlags'
+import { getOpenAIClient } from '@/lib/openai'
 import { formatCategoryForAIPrompt } from '@/lib/utils'
-import OpenAI from 'openai'
 import { z } from 'zod'
-
-const openai = new OpenAI({
-  apiKey: env.OPENAI_API_KEY,
-  baseURL: env.OPENAI_BASE_URL,
-})
 
 /** Limit of characters to be evaluated. May help avoiding abuse when using AI. */
 const limit = 40 // ~10 tokens
@@ -33,6 +28,7 @@ export async function extractCategoryFromTitle(description: string) {
   }
 
   const categories = await getCategories()
+  const openai = getOpenAIClient()
 
   const completion = await openai.chat.completions.create({
     model: env.OPENAI_MODEL_CATEGORY_EXTRACT,

--- a/src/lib/openai.test.ts
+++ b/src/lib/openai.test.ts
@@ -1,0 +1,50 @@
+jest.mock('openai', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock('./env', () => ({
+  env: {
+    OPENAI_API_KEY: undefined as string | undefined,
+    OPENAI_BASE_URL: undefined as string | undefined,
+  },
+}))
+
+import OpenAI from 'openai'
+import { env } from './env'
+import { getOpenAIClient } from './openai'
+
+const mockEnv = env as {
+  OPENAI_API_KEY?: string
+  OPENAI_BASE_URL?: string
+}
+
+describe('getOpenAIClient', () => {
+  afterEach(() => {
+    delete mockEnv.OPENAI_API_KEY
+    delete mockEnv.OPENAI_BASE_URL
+    jest.mocked(OpenAI).mockReset()
+  })
+
+  it('does not construct a client when the module is imported', () => {
+    expect(OpenAI).not.toHaveBeenCalled()
+  })
+
+  it('throws before talking to the SDK when no API key is set', () => {
+    expect(() => getOpenAIClient()).toThrow('OPENAI_API_KEY is not set.')
+    expect(OpenAI).not.toHaveBeenCalled()
+  })
+
+  it('constructs the client on first use when a key is set', () => {
+    mockEnv.OPENAI_API_KEY = 'sk-test'
+    mockEnv.OPENAI_BASE_URL = 'https://llm.example/v1'
+
+    getOpenAIClient()
+
+    expect(OpenAI).toHaveBeenCalledTimes(1)
+    expect(OpenAI).toHaveBeenCalledWith({
+      apiKey: 'sk-test',
+      baseURL: 'https://llm.example/v1',
+    })
+  })
+})

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,0 +1,17 @@
+import OpenAI from 'openai'
+
+import { env } from './env'
+
+/**
+ * Build an OpenAI client when needed.
+ */
+export function getOpenAIClient() {
+  const apiKey = env.OPENAI_API_KEY
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is not set.')
+  }
+  return new OpenAI({
+    apiKey,
+    baseURL: env.OPENAI_BASE_URL,
+  })
+}


### PR DESCRIPTION
This prevents the following error message coming up in logs, with `ENABLE_EXPENSE_DOCUMENTS` unset:

```
⨯ Error: Missing credentials. Please pass an `apiKey`, `workloadIdentity`, `adminAPIKey`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable.
    at <unknown> (.next/server/chunks/ssr/_1lg1p53._.js:1:222)
    at Context.asyncModule [as a] (.next/server/chunks/ssr/[turbopack]_runtime.js:668:5)
    at module evaluation (.next/server/chunks/ssr/_1lg1p53._.js:1:28)
    at instantiateModule (.next/server/chunks/ssr/[turbopack]_runtime.js:889:9)
    at getOrInstantiateModuleFromParent (.next/server/chunks/ssr/[turbopack]_runtime.js:913:12)
    at Context.esmImport [as i] (.next/server/chunks/ssr/[turbopack]_runtime.js:352:20)
    at <unknown> (.next/server/chunks/ssr/_1lg1p53._.js:6:615)
    at Context.asyncModule [as a] (.next/server/chunks/ssr/[turbopack]_runtime.js:668:5)
    at module evaluation (.next/server/chunks/ssr/_1lg1p53._.js:6:566) {
  digest: '3709727598'
}
```